### PR TITLE
#57 removing css/fundamental-ui.css from gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,3 @@ tmp
 
 # Files that are generated on project startup
 ghpages
-docs/css/fundamental-ui.css

--- a/docs/_data/sidebars/left-navigation-sidebar.yml
+++ b/docs/_data/sidebars/left-navigation-sidebar.yml
@@ -130,19 +130,19 @@ entries:
     output: web
 
     folderitems:
-    - title: Layouts
-      url: /layouts.html
-      output: web
+    # - title: Layouts
+    #   url: /layouts.html
+    #   output: web
 
     - title: Starter Pages
       url: /starter-pages.html
       output: web
 
   # Resources
-  - title: Resources
-    output: web
-
-    folderitems:
-    - title: UI Kit
-      url: /ui-kit.html
-      output: web
+  # - title: Resources
+  #   output: web
+  #
+  #   folderitems:
+  #   - title: UI Kit
+  #     url: /ui-kit.html
+  #     output: web

--- a/docs/css/fundamental-ui.css
+++ b/docs/css/fundamental-ui.css
@@ -1,0 +1,4127 @@
+@charset "UTF-8";
+@import url("//fonts.googleapis.com/css?family=Roboto:400,500,700");
+@import url("//fonts.googleapis.com/css?family=Open+Sans:400,400italic,600,700");
+/*!
+* @section Root Element
+* Default styles for root elements
+*/
+html {
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  min-height: 100%; }
+
+html,
+body {
+  font-size: 1rem;
+  font-family: 'Open Sans', sans-serif;
+  line-height: 1.5; }
+
+* {
+  -webkit-box-sizing: inherit;
+          box-sizing: inherit; }
+  *::before, *::after {
+    -webkit-box-sizing: inherit;
+            box-sizing: inherit; }
+
+body {
+  margin: 0;
+  background-color: #ffffff;
+  -webkit-font-smoothing: antialiased;
+  color: #21262c; }
+
+/**
+* @section Header Elements
+* Default styles for header elements
+*/
+h1, h2, h3, h4, h5, h6 {
+  text-rendering: optimizeLegibility;
+  margin-bottom: 20px;
+  margin-top: 0; }
+
+/*!
+* @section Block Elements
+* Default styles for block elements
+*/
+p, ul, ol, blockquote, table, figure {
+  margin-top: 0;
+  margin-bottom: 20px; }
+  p:last-child, ul:last-child, ol:last-child, blockquote:last-child, table:last-child, figure:last-child {
+    margin-bottom: 0; }
+
+/*!
+* @section List Elements
+* Default styles for lists
+*/
+ul, ol {
+  padding-left: 0; }
+
+/*!
+* @section Phrases Elements
+* Default styles for phrase elements
+*/
+img {
+  line-height: 0;
+  vertical-align: middle; }
+
+a {
+  color: #009cdf;
+  text-decoration: none; }
+  a:hover {
+    color: #008ac6; }
+  a:active, a:focus {
+    color: #008ac6;
+    outline: none; }
+  a[aria-disabled="true"], a.is-disabled {
+    color: #7f90a4;
+    cursor: not-allowed; }
+
+/*!
+* @section Button Elements
+* Default styles for button elements
+*/
+button::-moz-focus-inner,
+input[type="submit"]::-moz-focus-inner {
+  border: 0;
+  padding: 0; }
+
+input[type=radio], input[type=checkbox] {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #21262c;
+  font-size: 1rem;
+  line-height: 1.5;
+  font-family: 'Open Sans', sans-serif;
+  font-weight: 400;
+  appearance: none;
+  -webkit-appearance: textfield;
+  -moz-appearance: textfield;
+  font-size: inherit;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  outline: none;
+  border-style: solid;
+  border-width: 1px;
+  border-color: #ccdaeb;
+  border-radius: 0;
+  color: #21262c;
+  background-color: transparent;
+  -webkit-transition: border-color 0.125s;
+  transition: border-color 0.125s;
+  -webkit-transition: border-color 0.125s ease-in, background-color 0.125s ease-in, background-image 0.125s ease-in;
+  transition: border-color 0.125s ease-in, background-color 0.125s ease-in, background-image 0.125s ease-in; }
+  input[type=radio]:focus, input[type=checkbox]:focus, input[type=radio]:hover, input[type=checkbox]:hover {
+    border-color: #009cdf; }
+  input.is-invalid[type=radio], input.is-invalid[type=checkbox] {
+    border-color: #df1919; }
+  input.is-valid[type=radio], input.is-valid[type=checkbox] {
+    border-color: #61bf33; }
+  input.is-warning[type=radio], input.is-warning[type=checkbox] {
+    border-color: #e97326; }
+  input[type=radio]:disabled, input[type=checkbox]:disabled, input[aria-disabled="true"][type=radio], input[aria-disabled="true"][type=checkbox], input.is-disabled[type=radio], input.is-disabled[type=checkbox] {
+    cursor: not-allowed;
+    color: #63758b;
+    border-color: #e4e4e4;
+    background-color: #f9fbfc; }
+  input[readonly][type=radio], input[readonly][type=checkbox], input.is-readonly[type=radio], input.is-readonly[type=checkbox] {
+    color: #21262c;
+    border-color: #e4e4e4;
+    border-width: 0 0 1px; }
+  input[type=radio]::after, input[type=checkbox]::after {
+    -webkit-transition: border-color 0.125s ease-in;
+    transition: border-color 0.125s ease-in; }
+  input[type=radio]::-webkit-input-placeholder, input[type=checkbox]::-webkit-input-placeholder {
+    color: #63758b; }
+  input[type=radio]:-ms-input-placeholder, input[type=checkbox]:-ms-input-placeholder {
+    color: #63758b; }
+  input[type=radio]::placeholder, input[type=checkbox]::placeholder {
+    color: #63758b; }
+
+fieldset {
+  border: 0;
+  padding: 0;
+  margin: 0; }
+
+input[type=text], input[type=password], input[type=email], input[type=url], input[type=search], input[type=tel], input[type=number], input[type=date],
+textarea {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #21262c;
+  font-size: 1rem;
+  line-height: 1.5;
+  font-family: 'Open Sans', sans-serif;
+  font-weight: 400;
+  appearance: none;
+  -webkit-appearance: textfield;
+  -moz-appearance: textfield;
+  font-size: inherit;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  outline: none;
+  border-style: solid;
+  border-width: 1px;
+  border-color: #ccdaeb;
+  border-radius: 0;
+  color: #21262c;
+  background-color: transparent;
+  -webkit-transition: border-color 0.125s;
+  transition: border-color 0.125s;
+  height: 52px;
+  padding-left: 16px;
+  padding-right: 16px;
+  width: 100%; }
+  input[type=text]:focus, input[type=text]:hover, input[type=password]:focus, input[type=password]:hover, input[type=email]:focus, input[type=email]:hover, input[type=url]:focus, input[type=url]:hover, input[type=search]:focus, input[type=search]:hover, input[type=tel]:focus, input[type=tel]:hover, input[type=number]:focus, input[type=number]:hover, input[type=date]:focus, input[type=date]:hover,
+  textarea:focus,
+  textarea:hover {
+    border-color: #009cdf; }
+  input[type=text].is-invalid, input[type=password].is-invalid, input[type=email].is-invalid, input[type=url].is-invalid, input[type=search].is-invalid, input[type=tel].is-invalid, input[type=number].is-invalid, input[type=date].is-invalid,
+  textarea.is-invalid {
+    border-color: #df1919; }
+  input[type=text].is-valid, input[type=password].is-valid, input[type=email].is-valid, input[type=url].is-valid, input[type=search].is-valid, input[type=tel].is-valid, input[type=number].is-valid, input[type=date].is-valid,
+  textarea.is-valid {
+    border-color: #61bf33; }
+  input[type=text].is-warning, input[type=password].is-warning, input[type=email].is-warning, input[type=url].is-warning, input[type=search].is-warning, input[type=tel].is-warning, input[type=number].is-warning, input[type=date].is-warning,
+  textarea.is-warning {
+    border-color: #e97326; }
+  input[type=text]:disabled, input[type=text][aria-disabled="true"], input[type=text].is-disabled, input[type=password]:disabled, input[type=password][aria-disabled="true"], input[type=password].is-disabled, input[type=email]:disabled, input[type=email][aria-disabled="true"], input[type=email].is-disabled, input[type=url]:disabled, input[type=url][aria-disabled="true"], input[type=url].is-disabled, input[type=search]:disabled, input[type=search][aria-disabled="true"], input[type=search].is-disabled, input[type=tel]:disabled, input[type=tel][aria-disabled="true"], input[type=tel].is-disabled, input[type=number]:disabled, input[type=number][aria-disabled="true"], input[type=number].is-disabled, input[type=date]:disabled, input[type=date][aria-disabled="true"], input[type=date].is-disabled,
+  textarea:disabled,
+  textarea[aria-disabled="true"],
+  textarea.is-disabled {
+    cursor: not-allowed;
+    color: #63758b;
+    border-color: #e4e4e4;
+    background-color: #f9fbfc; }
+  input[type=text][readonly], input[type=text].is-readonly, input[type=password][readonly], input[type=password].is-readonly, input[type=email][readonly], input[type=email].is-readonly, input[type=url][readonly], input[type=url].is-readonly, input[type=search][readonly], input[type=search].is-readonly, input[type=tel][readonly], input[type=tel].is-readonly, input[type=number][readonly], input[type=number].is-readonly, input[type=date][readonly], input[type=date].is-readonly,
+  textarea[readonly],
+  textarea.is-readonly {
+    color: #21262c;
+    border-color: #e4e4e4;
+    border-width: 0 0 1px; }
+
+textarea {
+  height: 104px;
+  padding-top: 16px; }
+
+select {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #21262c;
+  font-size: 1rem;
+  line-height: 1.5;
+  font-family: 'Open Sans', sans-serif;
+  font-weight: 400;
+  appearance: none;
+  -webkit-appearance: textfield;
+  -moz-appearance: textfield;
+  font-size: inherit;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+  outline: none;
+  border-style: solid;
+  border-width: 1px;
+  border-color: #ccdaeb;
+  border-radius: 0;
+  color: #21262c;
+  background-color: transparent;
+  -webkit-transition: border-color 0.125s;
+  transition: border-color 0.125s;
+  height: 52px;
+  padding-left: 16px;
+  padding-right: 16px;
+  -webkit-appearance: none;
+          appearance: none;
+  -moz-appearance: none;
+  background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMiIgaGVpZ2h0PSI5Ij48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiMyMTI2MkMiIGQ9Ik0xMS45MzUgMS40NzVMNi4xODggNy45MjdhLjI2NC4yNjQgMCAwIDEtLjM3OCAwTC4wNjUgMS40NzVhLjIzNi4yMzYgMCAwIDEgLjAyNi0uMzQzTDEuMzgxLjA1OGEuMjUzLjI1MyAwIDAgMSAuMTYzLS4wNTlMMS41NjMgMGEuMjUyLjI1MiAwIDAgMSAuMTcxLjA4NWw0LjI2NSA0Ljg4IDQuMjY3LTQuODhhLjI1Mi4yNTIgMCAwIDEgLjM1Mi0uMDI3bDEuMjkxIDEuMDc0Yy4wNS4wNDIuMDgxLjEwMi4wODYuMTY2YS4yMzYuMjM2IDAgMCAxLS4wNi4xNzd6Ii8+PC9zdmc+);
+  background-repeat: no-repeat;
+  background-position: calc(100% - 12px) center;
+  padding-right: 44px;
+  width: 100%; }
+  select:focus, select:hover {
+    border-color: #009cdf; }
+  select.is-invalid {
+    border-color: #df1919; }
+  select.is-valid {
+    border-color: #61bf33; }
+  select.is-warning {
+    border-color: #e97326; }
+  select:disabled, select[aria-disabled="true"], select.is-disabled {
+    cursor: not-allowed;
+    color: #63758b;
+    border-color: #e4e4e4;
+    background-color: #f9fbfc; }
+  select[readonly], select.is-readonly {
+    color: #21262c;
+    border-color: #e4e4e4;
+    border-width: 0 0 1px; }
+  select:focus, select:hover {
+    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMiIgaGVpZ2h0PSI5Ij48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiMwMDhGRDIiIGQ9Ik0xMS45MzUgMS40NzVMNi4xODggNy45MjdhLjI2NC4yNjQgMCAwIDEtLjM3OCAwTC4wNjUgMS40NzVhLjIzNi4yMzYgMCAwIDEgLjAyNi0uMzQzTDEuMzgxLjA1OGEuMjUzLjI1MyAwIDAgMSAuMTYzLS4wNTlMMS41NjMgMGEuMjUyLjI1MiAwIDAgMSAuMTcxLjA4NWw0LjI2NSA0Ljg4IDQuMjY3LTQuODhhLjI1Mi4yNTIgMCAwIDEgLjM1Mi0uMDI3bDEuMjkxIDEuMDc0Yy4wNS4wNDIuMDgxLjEwMi4wODYuMTY2YS4yMzYuMjM2IDAgMCAxLS4wNi4xNzd6Ii8+PC9zdmc+); }
+  select[aria-expanded="true"], select.is-expanded {
+    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMiIgaGVpZ2h0PSI4Ij48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiMwMDhGRDIiIGQ9Ik0xMS45MzUgNi41M0w2LjE4OC4xMDRhLjI2NC4yNjQgMCAwIDAtLjM3OCAwTC4wNjUgNi41M2EuMjQuMjQgMCAwIDAtLjA2MS4xNzcuMjM3LjIzNyAwIDAgMCAuMDg3LjE2NWwxLjI5IDEuMDcxYS4yNTguMjU4IDAgMCAwIC4xNjMuMDU4TDEuNTYzIDhhLjI1Mi4yNTIgMCAwIDAgLjE3MS0uMDg1bDQuMjY1LTQuODYxIDQuMjY3IDQuODYxYy4wNDMuMDQ5LjEwNC4wOC4xNy4wODVhLjI2MS4yNjEgMCAwIDAgLjE4Mi0uMDU3bDEuMjkxLTEuMDcxYS4yMzYuMjM2IDAgMCAwIC4wMjYtLjM0MnoiLz48L3N2Zz4=); }
+  select[disabled], select[aria-disabled="true"], select.is-disabled {
+    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMiIgaGVpZ2h0PSI5Ij48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiM2Mzc1OEIiIGQ9Ik0xMS45MzUgMS40NzVMNi4xODggNy45MjdhLjI2NC4yNjQgMCAwIDEtLjM3OCAwTC4wNjUgMS40NzVhLjIzNS4yMzUgMCAwIDEgLjAyNi0uMzQzTDEuMzgxLjA1OGEuMjUzLjI1MyAwIDAgMSAuMTYzLS4wNTlMMS41NjMgMGEuMjUyLjI1MiAwIDAgMSAuMTcxLjA4NWw0LjI2NSA0Ljg4IDQuMjY3LTQuODhhLjI1Mi4yNTIgMCAwIDEgLjM1Mi0uMDI3bDEuMjkxIDEuMDc0Yy4wNS4wNDIuMDgxLjEwMi4wODYuMTY2YS4yMzQuMjM0IDAgMCAxLS4wNi4xNzd6Ii8+PC9zdmc+); }
+  select[multiple] {
+    height: 156px;
+    background-image: none;
+    padding-top: 16px; }
+
+input[type=radio], input[type=checkbox] {
+  height: 28px;
+  width: 28px;
+  margin: 0;
+  vertical-align: middle;
+  position: relative; }
+  input[type=radio]:checked, input[type=checkbox]:checked {
+    border-color: #009cdf;
+    background-color: #009cdf; }
+  input[type=radio][disabled], input[type=radio][aria-disabled="true"], input[type=radio].is-disabled, input[type=checkbox][disabled], input[type=checkbox][aria-disabled="true"], input[type=checkbox].is-disabled {
+    border-color: #e4e4e4;
+    background-color: #f9fbfc; }
+
+input[type="checkbox"]:checked::after {
+  content: "";
+  width: 16px;
+  height: 6px;
+  border-color: #ffffff;
+  border-style: solid;
+  border-width: 0 0 1px 1px;
+  -webkit-transform: rotate(-45deg);
+          transform: rotate(-45deg);
+  position: absolute;
+  z-index: 2;
+  top: calc(50% - 5px);
+  left: calc(50% - 16px/2); }
+
+input[type="checkbox"]:checked[disabled]::after, input[type="checkbox"]:checked[aria-disabled="true"]::after, input[type="checkbox"]:checked.is-disabled::after {
+  border-color: #7f90a4; }
+
+input[type="radio"] {
+  border-radius: 50%; }
+  input[type="radio"]::after {
+    content: "";
+    border-radius: 50%;
+    width: 16px;
+    height: 16px;
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    top: calc(50% - (16px/2));
+    left: calc(50% - (16px/2));
+    -webkit-transition: background-color 0.125s ease-in;
+    transition: background-color 0.125s ease-in;
+    background-color: transparent; }
+  input[type="radio"]:checked {
+    background-color: #ffffff; }
+    input[type="radio"]:checked::after {
+      background-color: #009cdf; }
+    input[type="radio"]:checked[disabled]::after, input[type="radio"]:checked[aria-disabled="true"]::after, input[type="radio"]:checked.is-disabled::after {
+      background-color: #7f90a4; }
+
+/*!
+.fd-section+(--full-bleed, --no-border)
+    .fd-section__header
+        .fd-section__title
+        .fd-section__actions
+    .fd-section__footer
+*/
+.fd-section {
+  padding: 40px 20px 20px;
+  border-bottom: solid 2px #ccdaeb; }
+  .fd-section::after {
+    content: "";
+    display: table;
+    clear: both; }
+  .fd-section:last-child, .fd-section--no-border {
+    border-bottom: 0; }
+  .fd-section--full-bleed {
+    padding-right: 0;
+    padding-left: 0; }
+    .fd-section--full-bleed .fd-section__header, .fd-section--full-bleed .fd-section__footer {
+      margin-left: 20px;
+      margin-right: 20px; }
+  .fd-section__header {
+    min-height: 40px;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-align: center;
+        -ms-flex-align: center;
+            align-items: center;
+    margin-bottom: 16px; }
+  .fd-section__title {
+    font-size: 1.625rem;
+    line-height: 1.23077;
+    font-family: Roboto, sans-serif;
+    font-weight: 600;
+    -webkit-box-flex: 1;
+        -ms-flex: 1;
+            flex: 1;
+    margin-bottom: 0; }
+  .fd-section__actions {
+    margin-left: auto; }
+  .fd-section__footer {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-pack: center;
+        -ms-flex-pack: center;
+            justify-content: center; }
+
+.fd-container {
+  margin-bottom: 20px;
+  max-width: 1290px; }
+  .fd-container::after {
+    content: "";
+    display: table;
+    clear: both; }
+  .fd-container:last-child {
+    margin-bottom: 0; }
+  .fd-container--fluid {
+    max-width: 100%; }
+  .fd-container--flex {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex; }
+  .fd-container--centered {
+    margin-left: auto;
+    margin-right: auto; }
+
+/*
+WHY THIS:
+Other semantic grids don't eaily allow for fixed gutter widths
+nor do they take advantage of the CSS calc function
+and they can get kind of confusing.
+This is meant for simple layout problems — 
+i.e., you have a box and you need three cols inside of equal widths
+with gutters between.
+
+The FLOW terminology is meant to be netural outside of rows and columns
+and comes from the HTML5 spec referring to elements that can contain other elements
+http://w3c.github.io/html/dom.html#kinds-of-content-flow-content
+
+USAGE:
+— Outer containers should contain the `@include flow-box` base styles
+— Columns get `@include flow` with `$span` and `$cols` params
+
+EXAMPLE MARKUP:
+<section>
+  <div class="box">x</div>
+  <div class="box">x</div>
+  <div class="box">x</div>
+  <div class="box">x</div>
+</section>
+
+EXAMPLE CSS:
+section {
+  @include flow-box()
+  .box {
+    @include flow(2);
+    &:first-child {
+      @include flow-shift(2);
+    }
+  }
+}
+
+OUTPUT:
+This will render 4 boxes spanning 2 cols each indented 2 cols
+(based on defaults)
+
+|--| |--| |--| |--| |--| |--| |--| |--| |--| |--| |--| |--|
+          |  box  | |  box  | |  box  | |  box  |
+
+*/
+/*!
+    .fd-col+(--1...12, --shift-1...11)
+*/
+.fd-col {
+  -webkit-box-flex: 1;
+      -ms-flex: 1;
+          flex: 1; }
+  @media (min-width: 800px) {
+    .fd-col--1 {
+      float: left;
+      margin-right: 32px;
+      width: calc( ( ( (100% - 352px) / 12 ) * 1 ) + 0px); }
+      .fd-col--1:last-child {
+        margin-right: 0; }
+    .fd-col--2 {
+      float: left;
+      margin-right: 32px;
+      width: calc( ( ( (100% - 352px) / 12 ) * 2 ) + 32px); }
+      .fd-col--2:last-child {
+        margin-right: 0; }
+    .fd-col--3 {
+      float: left;
+      margin-right: 32px;
+      width: calc( ( ( (100% - 352px) / 12 ) * 3 ) + 64px); }
+      .fd-col--3:last-child {
+        margin-right: 0; }
+    .fd-col--4 {
+      float: left;
+      margin-right: 32px;
+      width: calc( ( ( (100% - 352px) / 12 ) * 4 ) + 96px); }
+      .fd-col--4:last-child {
+        margin-right: 0; }
+    .fd-col--5 {
+      float: left;
+      margin-right: 32px;
+      width: calc( ( ( (100% - 352px) / 12 ) * 5 ) + 128px); }
+      .fd-col--5:last-child {
+        margin-right: 0; }
+    .fd-col--6 {
+      float: left;
+      margin-right: 32px;
+      width: calc( ( ( (100% - 352px) / 12 ) * 6 ) + 160px); }
+      .fd-col--6:last-child {
+        margin-right: 0; }
+    .fd-col--7 {
+      float: left;
+      margin-right: 32px;
+      width: calc( ( ( (100% - 352px) / 12 ) * 7 ) + 192px); }
+      .fd-col--7:last-child {
+        margin-right: 0; }
+    .fd-col--8 {
+      float: left;
+      margin-right: 32px;
+      width: calc( ( ( (100% - 352px) / 12 ) * 8 ) + 224px); }
+      .fd-col--8:last-child {
+        margin-right: 0; }
+    .fd-col--9 {
+      float: left;
+      margin-right: 32px;
+      width: calc( ( ( (100% - 352px) / 12 ) * 9 ) + 256px); }
+      .fd-col--9:last-child {
+        margin-right: 0; }
+    .fd-col--10 {
+      float: left;
+      margin-right: 32px;
+      width: calc( ( ( (100% - 352px) / 12 ) * 10 ) + 288px); }
+      .fd-col--10:last-child {
+        margin-right: 0; }
+    .fd-col--11 {
+      float: left;
+      margin-right: 32px;
+      width: calc( ( ( (100% - 352px) / 12 ) * 11 ) + 320px); }
+      .fd-col--11:last-child {
+        margin-right: 0; }
+    .fd-col--12 {
+      float: left;
+      margin-right: 32px;
+      width: calc( ( ( (100% - 352px) / 12 ) * 12 ) + 352px); }
+      .fd-col--12:last-child {
+        margin-right: 0; }
+    .fd-col--shift-1 {
+      margin-left: calc( ( ( (100% - 352px) / 12 ) * 1 ) + 32px); }
+    .fd-col--shift-2 {
+      margin-left: calc( ( ( (100% - 352px) / 12 ) * 2 ) + 64px); }
+    .fd-col--shift-3 {
+      margin-left: calc( ( ( (100% - 352px) / 12 ) * 3 ) + 96px); }
+    .fd-col--shift-4 {
+      margin-left: calc( ( ( (100% - 352px) / 12 ) * 4 ) + 128px); }
+    .fd-col--shift-5 {
+      margin-left: calc( ( ( (100% - 352px) / 12 ) * 5 ) + 160px); }
+    .fd-col--shift-6 {
+      margin-left: calc( ( ( (100% - 352px) / 12 ) * 6 ) + 192px); }
+    .fd-col--shift-7 {
+      margin-left: calc( ( ( (100% - 352px) / 12 ) * 7 ) + 224px); }
+    .fd-col--shift-8 {
+      margin-left: calc( ( ( (100% - 352px) / 12 ) * 8 ) + 256px); }
+    .fd-col--shift-9 {
+      margin-left: calc( ( ( (100% - 352px) / 12 ) * 9 ) + 288px); }
+    .fd-col--shift-10 {
+      margin-left: calc( ( ( (100% - 352px) / 12 ) * 10 ) + 320px); }
+    .fd-col--shift-11 {
+      margin-left: calc( ( ( (100% - 352px) / 12 ) * 11 ) + 352px); } }
+  [class^="fd-col"] {
+    margin-bottom: 20px; }
+    [class^="fd-col"]:last-child {
+      margin-bottom: 0; }
+    @media (min-width: 800px) {
+      [class^="fd-col"] {
+        margin-bottom: 0; } }
+
+/*!
+.fd-ui+(--fixed)
+    .fd-ui__header+(--fixed)
+    .fd-ui__app
+    .fd-ui__footer+(--fixed)
+    .fd-ui__overlay
+*/
+.fd-ui {
+  position: absolute;
+  min-height: 100vh;
+  width: 100vw;
+  max-width: 100vw; }
+  .fd-ui--fixed {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+        -ms-flex-direction: column;
+            flex-direction: column;
+    max-height: 100vh; }
+    .fd-ui--fixed .fd-ui__header {
+      -webkit-box-flex: 0;
+          -ms-flex: 0 0 50px;
+              flex: 0 0 50px;
+      position: static; }
+    .fd-ui--fixed .fd-ui__footer {
+      -webkit-box-flex: 0;
+          -ms-flex: 0 0 40px;
+              flex: 0 0 40px;
+      position: static; }
+    .fd-ui--fixed .fd-ui__app {
+      overflow: scroll;
+      margin-top: 0;
+      -webkit-box-flex: 1;
+          -ms-flex: 1;
+              flex: 1;
+      min-height: auto; }
+  .fd-ui__header {
+    position: absolute;
+    z-index: 1;
+    background: #006fbb;
+    width: 100%;
+    min-height: 50px;
+    height: 50px; }
+    .fd-ui__header--fixed {
+      position: fixed; }
+  .fd-ui__footer {
+    background: #27394f;
+    width: 100%;
+    min-height: 40px;
+    height: 40px; }
+    .fd-ui__footer--fixed {
+      position: fixed;
+      bottom: 0; }
+  .fd-ui__app {
+    margin-top: 50px;
+    min-height: calc(100vh - 40px - 50px);
+    width: 100%;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    position: relative; }
+  .fd-ui__overlay {
+    position: absolute; }
+
+/*!
+.fd-app
+    .fd-app__sidebar
+    .fd-app__main
+*/
+.fd-app {
+  width: 100%; }
+  @media (min-width: 800px) {
+    .fd-app {
+      display: -webkit-box;
+      display: -ms-flexbox;
+      display: flex; } }
+  .fd-app__sidebar {
+    background-color: #27394f;
+    width: 100vw;
+    max-height: 40px;
+    overflow: scroll; }
+    .fd-app__sidebar:hover {
+      position: absolute;
+      min-height: 100%; }
+    @media (min-width: 800px) {
+      .fd-app__sidebar {
+        width: 80px;
+        max-height: 100%; }
+        .fd-app__sidebar:hover {
+          width: 250px;
+          position: relative;
+          margin-right: -200px; } }
+    @media (min-width: 1440px) {
+      .fd-app__sidebar {
+        width: 250px; }
+        .fd-app__sidebar:hover {
+          width: 250px;
+          margin-right: 0; } }
+  .fd-app__main {
+    -webkit-box-flex: 1;
+        -ms-flex: 1;
+            flex: 1;
+    overflow: scroll; }
+
+.fd-page {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
+  min-height: 100%;
+  width: 100%; }
+  .fd-page__header {
+    border-bottom: solid 1px #ccdaeb;
+    background-color: #f0f5ff;
+    height: 76px; }
+  .fd-page__intro {
+    font-size: 0.875rem;
+    line-height: 1.42858;
+    font-weight: 400;
+    padding: 16px 20px;
+    background-color: #f0f5ff;
+    text-align: center;
+    border-bottom: solid 1px #ccdaeb;
+    margin-bottom: -1px; }
+  .fd-page__content {
+    -webkit-box-flex: 1;
+        -ms-flex-positive: 1;
+            flex-grow: 1; }
+
+/*!
+.fd-section+(--full-bleed, --no-border)
+    .fd-section__header
+        .fd-section__title
+        .fd-section__actions
+    .fd-section__footer
+*/
+.fd-section {
+  padding: 40px 20px 20px;
+  border-bottom: solid 2px #ccdaeb; }
+  .fd-section::after {
+    content: "";
+    display: table;
+    clear: both; }
+  .fd-section:last-child, .fd-section--no-border {
+    border-bottom: 0; }
+  .fd-section--full-bleed {
+    padding-right: 0;
+    padding-left: 0; }
+    .fd-section--full-bleed .fd-section__header, .fd-section--full-bleed .fd-section__footer {
+      margin-left: 20px;
+      margin-right: 20px; }
+  .fd-section__header {
+    min-height: 40px;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-align: center;
+        -ms-flex-align: center;
+            align-items: center;
+    margin-bottom: 16px; }
+  .fd-section__title {
+    font-size: 1.625rem;
+    line-height: 1.23077;
+    font-family: Roboto, sans-serif;
+    font-weight: 600;
+    -webkit-box-flex: 1;
+        -ms-flex: 1;
+            flex: 1;
+    margin-bottom: 0; }
+  .fd-section__actions {
+    margin-left: auto; }
+  .fd-section__footer {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-pack: center;
+        -ms-flex-pack: center;
+            justify-content: center; }
+
+/*!
+.fd-panel
+    .fd-panel__header
+        .fd-panel__title
+        .fd-panel__actions
+    .fd-panel__footer
+*/
+.fd-panel::after {
+  content: "";
+  display: table;
+  clear: both; }
+
+.fd-panel__header {
+  min-height: 40px;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
+  margin-bottom: 16px; }
+
+.fd-panel__title {
+  font-size: 1.625rem;
+  line-height: 1.23077;
+  font-family: Roboto, sans-serif;
+  font-weight: 600;
+  -webkit-box-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
+  margin-bottom: 0; }
+
+.fd-panel__actions {
+  margin-left: auto; }
+
+.fd-panel__footer {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center; }
+
+/*!
+.fd-overlay
+
+*/
+.fd-overlay {
+  position: fixed;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
+  height: 100vh;
+  width: 100vw;
+  top: 0;
+  background: rgba(0, 0, 0, 0.8);
+  z-index: 1000;
+  color: #ffffff; }
+  .fd-overlay[aria-hidden="true"] {
+    display: none; }
+
+/*!
+.fd-alert+(--warning. --error)
+    .fd-alert__close
+*/
+.fd-alert {
+  color: #ffffff;
+  border: solid 1px #d7d7d7;
+  background-color: #63758b;
+  min-height: 52px;
+  padding: 12px; }
+  .fd-alert__close {
+    margin: 0;
+    padding: 0;
+    font-smoothing: antialiased;
+    -webkit-appearance: none;
+       -moz-appearance: none;
+            appearance: none;
+    outline: 0;
+    border: 0;
+    display: inline-block;
+    text-decoration: none;
+    cursor: pointer;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
+    vertical-align: middle;
+    white-space: nowrap;
+    background-color: transparent;
+    color: #ffffff;
+    width: 40px;
+    height: 40px;
+    float: right;
+    margin: -6px; }
+  .fd-alert--warning {
+    background-color: #e97326;
+    color: #21262c; }
+  .fd-alert--error {
+    background-color: #df1919; }
+
+/*!
+.fd-button+( (--small | --large), --icon, --text, --link, --action-bar)+( (.is-disabled | [aria-disabled=true]) | (.is-selected | [aria-selected=true] | (.is-pressed | [aria-pressed=true]))
+*/
+.fd-button, .fd-modal__button-primary, .fd-modal__button-secondary {
+  margin: 0;
+  padding: 0;
+  font-smoothing: antialiased;
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none;
+  outline: 0;
+  border: 0;
+  display: inline-block;
+  text-decoration: none;
+  cursor: pointer;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
+  vertical-align: middle;
+  white-space: nowrap;
+  background-color: transparent;
+  font-size: 1.125rem;
+  line-height: 1.33334;
+  font-family: Roboto, sans-serif;
+  font-weight: 500;
+  display: inline-block;
+  background-color: #009cdf;
+  -webkit-transition: background-color 0.125s ease-in;
+  transition: background-color 0.125s ease-in;
+  color: #f6f8f9;
+  max-height: 52px;
+  height: 52px;
+  line-height: 52px;
+  padding-left: 20px;
+  padding-right: 20px;
+  text-align: center;
+  text-transform: uppercase;
+  border-radius: 0; }
+  .fd-button--small {
+    font-size: 1rem;
+    line-height: 1.5;
+    font-weight: 400;
+    font-weight: 600;
+    max-height: 40px;
+    height: 40px;
+    line-height: 40px;
+    padding-left: 16px;
+    padding-right: 16px; }
+  .fd-button--large, .fd-button--action-bar {
+    font-size: 1.25rem;
+    line-height: 1.4;
+    font-weight: 600;
+    max-height: 76px;
+    height: 76px;
+    line-height: 76px;
+    padding-left: 28px;
+    padding-right: 28px; }
+  .fd-button:hover, .fd-modal__button-primary:hover, .fd-modal__button-secondary:hover {
+    background-color: #008ac6;
+    color: #f6f8f9;
+    text-decoration: none; }
+  .fd-button:focus, .fd-modal__button-primary:focus, .fd-modal__button-secondary:focus {
+    color: #f6f8f9;
+    -webkit-box-shadow: 0 0 4px 1px #8a8fa1;
+            box-shadow: 0 0 4px 1px #8a8fa1;
+    outline: solid 2px #2dc0ff; }
+  .fd-button:active, .fd-modal__button-primary:active, .fd-modal__button-secondary:active, .fd-button.is-active, .is-active.fd-modal__button-primary, .is-active.fd-modal__button-secondary, .fd-button[aria-selected="true"], [aria-selected="true"].fd-modal__button-primary, [aria-selected="true"].fd-modal__button-secondary, .fd-button.is-selected, .is-selected.fd-modal__button-primary, .is-selected.fd-modal__button-secondary, .fd-button[aria-pressed="true"], [aria-pressed="true"].fd-modal__button-primary, [aria-pressed="true"].fd-modal__button-secondary, .fd-button.is-pressed, .is-pressed.fd-modal__button-primary, .is-pressed.fd-modal__button-secondary {
+    background-color: #0078ac;
+    color: #f6f8f9; }
+  .fd-button[aria-disabled="true"], [aria-disabled="true"].fd-modal__button-primary, [aria-disabled="true"].fd-modal__button-secondary, .fd-button.is-disabled, .is-disabled.fd-modal__button-primary, .is-disabled.fd-modal__button-secondary, .fd-button:disabled, .fd-modal__button-primary:disabled, .fd-modal__button-secondary:disabled {
+    outline: solid 1px #d7d7d7;
+    color: #7f90a4;
+    background-color: #f9fbfc;
+    cursor: not-allowed; }
+  .fd-button--text, .fd-modal__button-secondary, .fd-button--link {
+    color: #009cdf;
+    background-color: transparent; }
+    .fd-button--text:hover, .fd-modal__button-secondary:hover, .fd-button--text:focus, .fd-modal__button-secondary:focus, .fd-button--link:hover, .fd-button--link:focus {
+      background-color: transparent;
+      color: #008ac6; }
+    .fd-button--text:active, .fd-modal__button-secondary:active, .fd-button--text[aria-selected="true"], [aria-selected="true"].fd-modal__button-secondary, .fd-button--text.is-selected, .is-selected.fd-modal__button-secondary, .fd-button--text[aria-pressed="true"], [aria-pressed="true"].fd-modal__button-secondary, .fd-button--text.is-pressed, .is-pressed.fd-modal__button-secondary, .fd-button--text[aria-disabled="true"], [aria-disabled="true"].fd-modal__button-secondary, .fd-button--text.is-disabled, .is-disabled.fd-modal__button-secondary, .fd-button--text:disabled, .fd-modal__button-secondary:disabled, .fd-button--link:active, .fd-button--link[aria-selected="true"], .fd-button--link.is-selected, .fd-button--link[aria-pressed="true"], .fd-button--link.is-pressed, .fd-button--link[aria-disabled="true"], .fd-button--link.is-disabled, .fd-button--link:disabled {
+      background-color: transparent;
+      outline: none;
+      -webkit-box-shadow: none;
+              box-shadow: none; }
+    .fd-button--text:active, .fd-modal__button-secondary:active, .fd-button--text[aria-selected="true"], [aria-selected="true"].fd-modal__button-secondary, .fd-button--text.is-selected, .is-selected.fd-modal__button-secondary, .fd-button--text[aria-pressed="true"], [aria-pressed="true"].fd-modal__button-secondary, .fd-button--text.is-pressed, .is-pressed.fd-modal__button-secondary, .fd-button--link:active, .fd-button--link[aria-selected="true"], .fd-button--link.is-selected, .fd-button--link[aria-pressed="true"], .fd-button--link.is-pressed {
+      color: #0078ac; }
+    .fd-button--text[aria-disabled="true"], [aria-disabled="true"].fd-modal__button-secondary, .fd-button--text.is-disabled, .is-disabled.fd-modal__button-secondary, .fd-button--text:disabled, .fd-modal__button-secondary:disabled, .fd-button--link[aria-disabled="true"], .fd-button--link.is-disabled, .fd-button--link:disabled {
+      color: #7f90a4; }
+  .fd-button--link {
+    height: 28px;
+    line-height: 28px;
+    padding-left: 16px;
+    padding-right: 16px;
+    position: relative; }
+    .fd-button--link.fd-button--small {
+      height: 24px;
+      line-height: 24px; }
+    .fd-button--link::after {
+      content: "";
+      border-bottom: solid 2px transparent;
+      width: calc(100% - 16px*2);
+      height: 2px;
+      position: absolute;
+      bottom: 1px;
+      left: 0;
+      margin-left: 16px;
+      -webkit-transition: border-bottom-color 0.125s ease-in;
+      transition: border-bottom-color 0.125s ease-in; }
+    .fd-button--link:focus {
+      outline: none;
+      -webkit-box-shadow: none;
+              box-shadow: none; }
+    .fd-button--link:hover::after, .fd-button--link:focus::after, .fd-button--link:active::after, .fd-button--link[aria-selected="true"]::after, .fd-button--link.is-selected::after, .fd-button--link[aria-pressed="true"]::after, .fd-button--link.is-pressed::after {
+      border-bottom-color: #009cdf; }
+    .fd-button--link[aria-disabled="true"]::after, .fd-button--link.is-disabled::after, .fd-button--link:disabled::after {
+      display: none; }
+  .fd-button > *, .fd-modal__button-primary > *, .fd-modal__button-secondary > * {
+    display: inline-block;
+    vertical-align: top;
+    margin-right: 12px;
+    margin-top: 13px; }
+    .fd-button--icon > * {
+      margin-left: auto;
+      margin-right: auto; }
+    .fd-button--small > * {
+      margin-top: 11px; }
+    .fd-button--large > *, .fd-button--action-bar > * {
+      margin-top: 22px; }
+  .fd-button--action-bar {
+    font-size: 0.75rem;
+    line-height: 1.33334;
+    font-weight: 700;
+    text-transform: uppercase;
+    min-width: 135px;
+    line-height: 32px;
+    vertical-align: middle; }
+    .fd-button--action-bar > * {
+      display: block !important;
+      margin-top: 12px;
+      margin-left: auto;
+      margin-right: auto; }
+
+/*!
+.fd-dropdown+()
+    .fd-dropdown__control+([disabled])
+    .fd-dropdown__menu+()
+*/
+.fd-dropdown {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #21262c;
+  position: relative;
+  display: inline-block; }
+  .fd-dropdown__control {
+    margin: 0;
+    padding: 0;
+    font-smoothing: antialiased;
+    -webkit-appearance: none;
+            appearance: none;
+    outline: 0;
+    border: 0;
+    display: inline-block;
+    text-decoration: none;
+    cursor: pointer;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
+    vertical-align: middle;
+    white-space: nowrap;
+    background-color: transparent;
+    font-size: 1rem;
+    line-height: 1.5;
+    color: #21262c;
+    font-size: 1rem;
+    line-height: 1.5;
+    font-family: 'Open Sans', sans-serif;
+    font-weight: 400;
+    appearance: none;
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    font-size: inherit;
+    -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+    outline: none;
+    border-style: solid;
+    border-width: 1px;
+    border-color: #ccdaeb;
+    border-radius: 0;
+    color: #21262c;
+    background-color: transparent;
+    -webkit-transition: border-color 0.125s;
+    transition: border-color 0.125s;
+    height: 52px;
+    padding-left: 16px;
+    padding-right: 16px;
+    appearance: none;
+    -moz-appearance: none;
+    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMiIgaGVpZ2h0PSI5Ij48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiMyMTI2MkMiIGQ9Ik0xMS45MzUgMS40NzVMNi4xODggNy45MjdhLjI2NC4yNjQgMCAwIDEtLjM3OCAwTC4wNjUgMS40NzVhLjIzNi4yMzYgMCAwIDEgLjAyNi0uMzQzTDEuMzgxLjA1OGEuMjUzLjI1MyAwIDAgMSAuMTYzLS4wNTlMMS41NjMgMGEuMjUyLjI1MiAwIDAgMSAuMTcxLjA4NWw0LjI2NSA0Ljg4IDQuMjY3LTQuODhhLjI1Mi4yNTIgMCAwIDEgLjM1Mi0uMDI3bDEuMjkxIDEuMDc0Yy4wNS4wNDIuMDgxLjEwMi4wODYuMTY2YS4yMzYuMjM2IDAgMCAxLS4wNi4xNzd6Ii8+PC9zdmc+);
+    background-repeat: no-repeat;
+    background-position: calc(100% - 12px) center;
+    padding-right: 44px;
+    position: relative;
+    line-height: 52px; }
+    .fd-dropdown__control:focus, .fd-dropdown__control:hover {
+      border-color: #009cdf; }
+    .fd-dropdown__control.is-invalid {
+      border-color: #df1919; }
+    .fd-dropdown__control.is-valid {
+      border-color: #61bf33; }
+    .fd-dropdown__control.is-warning {
+      border-color: #e97326; }
+    .fd-dropdown__control:disabled, .fd-dropdown__control[aria-disabled="true"], .fd-dropdown__control.is-disabled {
+      cursor: not-allowed;
+      color: #63758b;
+      border-color: #e4e4e4;
+      background-color: #f9fbfc; }
+    .fd-dropdown__control[readonly], .fd-dropdown__control.is-readonly {
+      color: #21262c;
+      border-color: #e4e4e4;
+      border-width: 0 0 1px; }
+    .fd-dropdown__control:focus, .fd-dropdown__control:hover {
+      background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMiIgaGVpZ2h0PSI5Ij48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiMwMDhGRDIiIGQ9Ik0xMS45MzUgMS40NzVMNi4xODggNy45MjdhLjI2NC4yNjQgMCAwIDEtLjM3OCAwTC4wNjUgMS40NzVhLjIzNi4yMzYgMCAwIDEgLjAyNi0uMzQzTDEuMzgxLjA1OGEuMjUzLjI1MyAwIDAgMSAuMTYzLS4wNTlMMS41NjMgMGEuMjUyLjI1MiAwIDAgMSAuMTcxLjA4NWw0LjI2NSA0Ljg4IDQuMjY3LTQuODhhLjI1Mi4yNTIgMCAwIDEgLjM1Mi0uMDI3bDEuMjkxIDEuMDc0Yy4wNS4wNDIuMDgxLjEwMi4wODYuMTY2YS4yMzYuMjM2IDAgMCAxLS4wNi4xNzd6Ii8+PC9zdmc+); }
+    .fd-dropdown__control[aria-expanded="true"], .fd-dropdown__control.is-expanded {
+      background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMiIgaGVpZ2h0PSI4Ij48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiMwMDhGRDIiIGQ9Ik0xMS45MzUgNi41M0w2LjE4OC4xMDRhLjI2NC4yNjQgMCAwIDAtLjM3OCAwTC4wNjUgNi41M2EuMjQuMjQgMCAwIDAtLjA2MS4xNzcuMjM3LjIzNyAwIDAgMCAuMDg3LjE2NWwxLjI5IDEuMDcxYS4yNTguMjU4IDAgMCAwIC4xNjMuMDU4TDEuNTYzIDhhLjI1Mi4yNTIgMCAwIDAgLjE3MS0uMDg1bDQuMjY1LTQuODYxIDQuMjY3IDQuODYxYy4wNDMuMDQ5LjEwNC4wOC4xNy4wODVhLjI2MS4yNjEgMCAwIDAgLjE4Mi0uMDU3bDEuMjkxLTEuMDcxYS4yMzYuMjM2IDAgMCAwIC4wMjYtLjM0MnoiLz48L3N2Zz4=); }
+    .fd-dropdown__control[disabled], .fd-dropdown__control[aria-disabled="true"], .fd-dropdown__control.is-disabled {
+      background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMiIgaGVpZ2h0PSI5Ij48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiM2Mzc1OEIiIGQ9Ik0xMS45MzUgMS40NzVMNi4xODggNy45MjdhLjI2NC4yNjQgMCAwIDEtLjM3OCAwTC4wNjUgMS40NzVhLjIzNS4yMzUgMCAwIDEgLjAyNi0uMzQzTDEuMzgxLjA1OGEuMjUzLjI1MyAwIDAgMSAuMTYzLS4wNTlMMS41NjMgMGEuMjUyLjI1MiAwIDAgMSAuMTcxLjA4NWw0LjI2NSA0Ljg4IDQuMjY3LTQuODhhLjI1Mi4yNTIgMCAwIDEgLjM1Mi0uMDI3bDEuMjkxIDEuMDc0Yy4wNS4wNDIuMDgxLjEwMi4wODYuMTY2YS4yMzQuMjM0IDAgMCAxLS4wNi4xNzd6Ii8+PC9zdmc+); }
+    .fd-dropdown__control[aria-expanded="true"], .fd-dropdown__control.is-expanded {
+      border-color: #009cdf;
+      z-index: 3;
+      -webkit-box-shadow: 0 0 4px 1px rgba(138, 143, 161, 0.2);
+              box-shadow: 0 0 4px 1px rgba(138, 143, 161, 0.2); }
+    .fd-dropdown__control--no-border {
+      border-color: transparent; }
+      .fd-dropdown__control--no-border[aria-disabled="true"], .fd-dropdown__control--no-border.is-disabled, .fd-dropdown__control--no-border:disabled {
+        border-color: transparent; }
+  .fd-dropdown__icon {
+    margin-right: 12px;
+    vertical-align: middle;
+    -webkit-transform: translateY(-2px);
+            transform: translateY(-2px); }
+  .fd-dropdown__menu, .fd-dropdown__options {
+    margin-left: 0;
+    padding-left: 0;
+    list-style: none;
+    min-width: 100%;
+    border: solid 1px #ccdaeb;
+    background: #ffffff;
+    position: absolute;
+    white-space: nowrap;
+    z-index: 2;
+    -webkit-transform: translateY(-1px);
+            transform: translateY(-1px);
+    -webkit-box-shadow: 0 0 4px 1px rgba(138, 143, 161, 0.2);
+            box-shadow: 0 0 4px 1px rgba(138, 143, 161, 0.2);
+    opacity: 1;
+    visibility: visible;
+    -webkit-transition: opacity 0.125s ease-in;
+    transition: opacity 0.125s ease-in; }
+    .fd-dropdown__menu[aria-hidden="true"], .fd-dropdown__menu.is-hidden, .fd-dropdown__options[aria-hidden="true"], .fd-dropdown__options.is-hidden {
+      opacity: 0;
+      visibility: hidden; }
+  .fd-dropdown__group {
+    margin-left: 0;
+    padding-left: 0;
+    list-style: none; }
+  .fd-dropdown__item, .fd-dropdown__option {
+    font-size: 1rem;
+    line-height: 1.5;
+    color: #21262c;
+    font-size: 0.875rem;
+    line-height: 1.42858;
+    font-family: 'Open Sans', sans-serif;
+    font-weight: 400;
+    display: block;
+    padding-left: 0;
+    list-style: none;
+    padding: 12px 16px; }
+    .fd-dropdown__item:hover, .fd-dropdown__option:hover {
+      color: #ffffff;
+      background-color: #008ac6;
+      text-decoration: none; }
+  .fd-dropdown__separator {
+    font-size: 1rem;
+    line-height: 1.5;
+    color: #21262c;
+    font-size: 0.75rem;
+    line-height: 1.33334;
+    font-family: 'Open Sans', sans-serif;
+    font-weight: 400;
+    text-transform: none;
+    display: block;
+    color: #7f90a4;
+    padding: 12px 16px;
+    padding-top: 16px;
+    border-top: solid 1px #ccdaeb; }
+
+/*!
+.fd-contextual-menu
+*/
+.fd-contextual-menu {
+  min-width: 169px;
+  right: 0; }
+
+/*!
+.fd-action-bar
+	.fd-action-bar__navigation
+	.fd-action-bar__title
+	.fd-action-bar__actions+(.is-disabled | aria-hidden)?
+        .fd-action-bar__action-item
+*/
+.fd-action-bar {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #21262c;
+  height: 76px;
+  background-color: #f0f5ff;
+  border-style: solid;
+  border-width: 1px 0;
+  border-color: #ccdaeb;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center; }
+  .fd-action-bar__title {
+    font-size: 1rem;
+    line-height: 1.5;
+    color: #21262c;
+    font-size: 1.625rem;
+    line-height: 1.23077;
+    font-family: Roboto, sans-serif;
+    font-weight: 500;
+    -webkit-box-flex: 1;
+        -ms-flex: 1;
+            flex: 1;
+    margin-bottom: 0; }
+    .fd-action-bar__title:first-child {
+      padding-left: 24px; }
+  .fd-action-bar__actions {
+    font-size: 1rem;
+    line-height: 1.5;
+    color: #21262c;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-transition: opacity 0.25s ease-in;
+    transition: opacity 0.25s ease-in;
+    visibility: visible; }
+    .fd-action-bar__actions.is-disabled, .fd-action-bar__actions[aria-hidden="true"] {
+      opacity: 0;
+      visibility: hidden; }
+
+/*!
+.fd-badge+(( --success | --warning | --error ), --pill)
+*/
+.fd-badge {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #21262c;
+  font-size: 0.75rem;
+  line-height: 1.33334;
+  font-weight: 700;
+  text-transform: uppercase;
+  line-height: 20px;
+  border-radius: 5px;
+  border-width: 1px;
+  border-style: solid;
+  padding: 4px 8px;
+  vertical-align: middle; }
+  .fd-badge--pill {
+    border-radius: 12.5px; }
+  .fd-badge--success {
+    color: #61bf33; }
+  .fd-badge--warning {
+    color: #e97326; }
+  .fd-badge--error {
+    color: #df1919; }
+
+/*!
+.fd-button+( (--small | --large), --icon, --text, --link, --action-bar)+( (.is-disabled | [aria-disabled=true]) | (.is-selected | [aria-selected=true] | (.is-pressed | [aria-pressed=true]))
+*/
+.fd-button, .fd-modal__button-primary, .fd-modal__button-secondary {
+  margin: 0;
+  padding: 0;
+  font-smoothing: antialiased;
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none;
+  outline: 0;
+  border: 0;
+  display: inline-block;
+  text-decoration: none;
+  cursor: pointer;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
+  vertical-align: middle;
+  white-space: nowrap;
+  background-color: transparent;
+  font-size: 1.125rem;
+  line-height: 1.33334;
+  font-family: Roboto, sans-serif;
+  font-weight: 500;
+  display: inline-block;
+  background-color: #009cdf;
+  -webkit-transition: background-color 0.125s ease-in;
+  transition: background-color 0.125s ease-in;
+  color: #f6f8f9;
+  max-height: 52px;
+  height: 52px;
+  line-height: 52px;
+  padding-left: 20px;
+  padding-right: 20px;
+  text-align: center;
+  text-transform: uppercase;
+  border-radius: 0; }
+  .fd-button--small {
+    font-size: 1rem;
+    line-height: 1.5;
+    font-weight: 400;
+    font-weight: 600;
+    max-height: 40px;
+    height: 40px;
+    line-height: 40px;
+    padding-left: 16px;
+    padding-right: 16px; }
+  .fd-button--large, .fd-button--action-bar {
+    font-size: 1.25rem;
+    line-height: 1.4;
+    font-weight: 600;
+    max-height: 76px;
+    height: 76px;
+    line-height: 76px;
+    padding-left: 28px;
+    padding-right: 28px; }
+  .fd-button:hover, .fd-modal__button-primary:hover, .fd-modal__button-secondary:hover {
+    background-color: #008ac6;
+    color: #f6f8f9;
+    text-decoration: none; }
+  .fd-button:focus, .fd-modal__button-primary:focus, .fd-modal__button-secondary:focus {
+    color: #f6f8f9;
+    -webkit-box-shadow: 0 0 4px 1px #8a8fa1;
+            box-shadow: 0 0 4px 1px #8a8fa1;
+    outline: solid 2px #2dc0ff; }
+  .fd-button:active, .fd-modal__button-primary:active, .fd-modal__button-secondary:active, .fd-button.is-active, .is-active.fd-modal__button-primary, .is-active.fd-modal__button-secondary, .fd-button[aria-selected="true"], [aria-selected="true"].fd-modal__button-primary, [aria-selected="true"].fd-modal__button-secondary, .fd-button.is-selected, .is-selected.fd-modal__button-primary, .is-selected.fd-modal__button-secondary, .fd-button[aria-pressed="true"], [aria-pressed="true"].fd-modal__button-primary, [aria-pressed="true"].fd-modal__button-secondary, .fd-button.is-pressed, .is-pressed.fd-modal__button-primary, .is-pressed.fd-modal__button-secondary {
+    background-color: #0078ac;
+    color: #f6f8f9; }
+  .fd-button[aria-disabled="true"], [aria-disabled="true"].fd-modal__button-primary, [aria-disabled="true"].fd-modal__button-secondary, .fd-button.is-disabled, .is-disabled.fd-modal__button-primary, .is-disabled.fd-modal__button-secondary, .fd-button:disabled, .fd-modal__button-primary:disabled, .fd-modal__button-secondary:disabled {
+    outline: solid 1px #d7d7d7;
+    color: #7f90a4;
+    background-color: #f9fbfc;
+    cursor: not-allowed; }
+  .fd-button--text, .fd-modal__button-secondary, .fd-button--link {
+    color: #009cdf;
+    background-color: transparent; }
+    .fd-button--text:hover, .fd-modal__button-secondary:hover, .fd-button--text:focus, .fd-modal__button-secondary:focus, .fd-button--link:hover, .fd-button--link:focus {
+      background-color: transparent;
+      color: #008ac6; }
+    .fd-button--text:active, .fd-modal__button-secondary:active, .fd-button--text[aria-selected="true"], [aria-selected="true"].fd-modal__button-secondary, .fd-button--text.is-selected, .is-selected.fd-modal__button-secondary, .fd-button--text[aria-pressed="true"], [aria-pressed="true"].fd-modal__button-secondary, .fd-button--text.is-pressed, .is-pressed.fd-modal__button-secondary, .fd-button--text[aria-disabled="true"], [aria-disabled="true"].fd-modal__button-secondary, .fd-button--text.is-disabled, .is-disabled.fd-modal__button-secondary, .fd-button--text:disabled, .fd-modal__button-secondary:disabled, .fd-button--link:active, .fd-button--link[aria-selected="true"], .fd-button--link.is-selected, .fd-button--link[aria-pressed="true"], .fd-button--link.is-pressed, .fd-button--link[aria-disabled="true"], .fd-button--link.is-disabled, .fd-button--link:disabled {
+      background-color: transparent;
+      outline: none;
+      -webkit-box-shadow: none;
+              box-shadow: none; }
+    .fd-button--text:active, .fd-modal__button-secondary:active, .fd-button--text[aria-selected="true"], [aria-selected="true"].fd-modal__button-secondary, .fd-button--text.is-selected, .is-selected.fd-modal__button-secondary, .fd-button--text[aria-pressed="true"], [aria-pressed="true"].fd-modal__button-secondary, .fd-button--text.is-pressed, .is-pressed.fd-modal__button-secondary, .fd-button--link:active, .fd-button--link[aria-selected="true"], .fd-button--link.is-selected, .fd-button--link[aria-pressed="true"], .fd-button--link.is-pressed {
+      color: #0078ac; }
+    .fd-button--text[aria-disabled="true"], [aria-disabled="true"].fd-modal__button-secondary, .fd-button--text.is-disabled, .is-disabled.fd-modal__button-secondary, .fd-button--text:disabled, .fd-modal__button-secondary:disabled, .fd-button--link[aria-disabled="true"], .fd-button--link.is-disabled, .fd-button--link:disabled {
+      color: #7f90a4; }
+  .fd-button--link {
+    height: 28px;
+    line-height: 28px;
+    padding-left: 16px;
+    padding-right: 16px;
+    position: relative; }
+    .fd-button--link.fd-button--small {
+      height: 24px;
+      line-height: 24px; }
+    .fd-button--link::after {
+      content: "";
+      border-bottom: solid 2px transparent;
+      width: calc(100% - 16px*2);
+      height: 2px;
+      position: absolute;
+      bottom: 1px;
+      left: 0;
+      margin-left: 16px;
+      -webkit-transition: border-bottom-color 0.125s ease-in;
+      transition: border-bottom-color 0.125s ease-in; }
+    .fd-button--link:focus {
+      outline: none;
+      -webkit-box-shadow: none;
+              box-shadow: none; }
+    .fd-button--link:hover::after, .fd-button--link:focus::after, .fd-button--link:active::after, .fd-button--link[aria-selected="true"]::after, .fd-button--link.is-selected::after, .fd-button--link[aria-pressed="true"]::after, .fd-button--link.is-pressed::after {
+      border-bottom-color: #009cdf; }
+    .fd-button--link[aria-disabled="true"]::after, .fd-button--link.is-disabled::after, .fd-button--link:disabled::after {
+      display: none; }
+  .fd-button > *, .fd-modal__button-primary > *, .fd-modal__button-secondary > * {
+    display: inline-block;
+    vertical-align: top;
+    margin-right: 12px;
+    margin-top: 13px; }
+    .fd-button--icon > * {
+      margin-left: auto;
+      margin-right: auto; }
+    .fd-button--small > * {
+      margin-top: 11px; }
+    .fd-button--large > *, .fd-button--action-bar > * {
+      margin-top: 22px; }
+  .fd-button--action-bar {
+    font-size: 0.75rem;
+    line-height: 1.33334;
+    font-weight: 700;
+    text-transform: uppercase;
+    min-width: 135px;
+    line-height: 32px;
+    vertical-align: middle; }
+    .fd-button--action-bar > * {
+      display: block !important;
+      margin-top: 12px;
+      margin-left: auto;
+      margin-right: auto; }
+
+/*!
+    card structure
+    .fd-card+(--button,--vertical)+(.is-disabled|[aria-disabled=true])
+        .fd-card__media+(--round,--fill)
+        .fd-card__content
+            .fd-card__header, .fd-card__description, .fd-card__status
+        .fd-card__actions
+*/
+.fd-card {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #21262c;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  margin-bottom: 20px;
+  border-style: solid;
+  border-width: 1px;
+  border-color: #ccdaeb;
+  background-color: #ffffff; }
+  .fd-card--vertical {
+    display: block; }
+    .fd-card--vertical .fd-card__media {
+      width: 100%;
+      height: 370px;
+      margin: 0; }
+  .fd-card--button, .fd-card[role="button"] {
+    cursor: default; }
+    .fd-card--button .fd-card__header, .fd-card[role="button"] .fd-card__header {
+      color: #009cdf; }
+  .fd-card--compact .fd-card__media {
+    margin: 10px 0 10px 10px; }
+    .fd-card--compact .fd-card__media--fill {
+      margin: 0;
+      width: 105px; }
+  .fd-card--compact .fd-card__content {
+    padding: 10px 10px; }
+  .fd-card--compact.fd-card--vertical .fd-card__media {
+    margin: 0; }
+  .fd-card--button, .fd-card[role="button"] {
+    cursor: pointer;
+    -webkit-transition: background-color 0.125s ease-in, border-color 0.125s ease-in, -webkit-box-shadow 0.125s ease-in;
+    transition: background-color 0.125s ease-in, border-color 0.125s ease-in, -webkit-box-shadow 0.125s ease-in;
+    transition: background-color 0.125s ease-in, border-color 0.125s ease-in, box-shadow 0.125s ease-in;
+    transition: background-color 0.125s ease-in, border-color 0.125s ease-in, box-shadow 0.125s ease-in, -webkit-box-shadow 0.125s ease-in; }
+    .fd-card--button:hover, .fd-card[role="button"]:hover {
+      border-color: #009cdf;
+      background-color: #ffffff;
+      -webkit-box-shadow: 0 0 5px 0 rgba(138, 143, 161, 0.4);
+              box-shadow: 0 0 5px 0 rgba(138, 143, 161, 0.4);
+      text-decoration: none;
+      color: inherit; }
+  .fd-card[aria-disabled="true"], .fd-card.is-disabled {
+    background-color: #f9fbfc !important;
+    border-color: #e4e4e4 !important;
+    -webkit-box-shadow: none !important;
+            box-shadow: none !important;
+    cursor: default; }
+    .fd-card[aria-disabled="true"] *, .fd-card.is-disabled * {
+      color: #63758b !important; }
+  .fd-card__media {
+    background-repeat: no-repeat;
+    background-position: center center;
+    background-size: cover;
+    min-width: 75px;
+    min-height: 75px;
+    margin: 20px 0 20px 20px; }
+    .fd-card__media--fill {
+      margin: 0;
+      width: 135px;
+      background-size: cover; }
+      .fd-card__media--fill + .fd-card__content {
+        padding-left: 10px; }
+    .fd-card__media--round {
+      border-radius: 50%; }
+  .fd-card__content {
+    padding: 20px 20px;
+    max-width: 100%;
+    -webkit-box-flex: 1;
+        -ms-flex: 1;
+            flex: 1;
+    overflow: hidden; }
+  .fd-card__header {
+    color: #21262c;
+    font-size: 1.125rem;
+    line-height: 1.33334;
+    font-weight: 600;
+    margin-bottom: 1px; }
+  .fd-card__description {
+    font-size: 0.8125rem;
+    line-height: 1.53847;
+    font-weight: 400;
+    margin-bottom: 12px;
+    overflow: hidden;
+    text-overflow: ellipsis; }
+  .fd-card__status {
+    font-size: 0.75rem;
+    line-height: 1.33334;
+    font-weight: 700;
+    text-transform: uppercase; }
+  .fd-card__actions {
+    padding: 20px 10px; }
+  .fd-card a {
+    color: #009cdf; }
+    .fd-card a:hover {
+      color: #009cdf; }
+
+/*!
+.fd-card-group+(--2col | --4col)
+*/
+.fd-card-group {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #21262c;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column; }
+  .fd-card-group::after {
+    content: "";
+    display: table;
+    clear: both; }
+  .fd-card-group:last-child {
+    margin-bottom: -20px; }
+  @media (min-width: 800px) {
+    .fd-card-group {
+      -webkit-box-orient: horizontal;
+      -webkit-box-direction: normal;
+          -ms-flex-direction: row;
+              flex-direction: row; }
+      .fd-card-group > * {
+        -webkit-box-flex: 1;
+            -ms-flex: 1;
+                flex: 1;
+        margin-right: 20px;
+        min-width: calc((100% - 20px*2) / 3);
+        max-width: calc((100% - 20px*2) / 3); }
+        .fd-card-group > *:nth-child(3n) {
+          margin-right: 0; }
+      .fd-card-group--2col > * {
+        min-width: calc((100% - 20px*1) / 2);
+        max-width: calc((100% - 20px*1) / 2); }
+        .fd-card-group--2col > *:nth-child(3n+3) {
+          margin-right: 20px; }
+        .fd-card-group--2col > *:nth-child(2n+2) {
+          margin-right: 0; }
+      .fd-card-group--4col > * {
+        min-width: calc((100% - 20px*3) / 4);
+        max-width: calc((100% - 20px*3) / 4); }
+        .fd-card-group--4col > *:nth-child(3n+3) {
+          margin-right: 20px; }
+        .fd-card-group--4col > *:nth-child(4n+4) {
+          margin-right: 0; } }
+
+/*!
+.fd-dropdown+()
+    .fd-dropdown__control+([disabled])
+    .fd-dropdown__menu+()
+*/
+.fd-dropdown {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #21262c;
+  position: relative;
+  display: inline-block; }
+  .fd-dropdown__control {
+    margin: 0;
+    padding: 0;
+    font-smoothing: antialiased;
+    -webkit-appearance: none;
+            appearance: none;
+    outline: 0;
+    border: 0;
+    display: inline-block;
+    text-decoration: none;
+    cursor: pointer;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
+    vertical-align: middle;
+    white-space: nowrap;
+    background-color: transparent;
+    font-size: 1rem;
+    line-height: 1.5;
+    color: #21262c;
+    font-size: 1rem;
+    line-height: 1.5;
+    font-family: 'Open Sans', sans-serif;
+    font-weight: 400;
+    appearance: none;
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    font-size: inherit;
+    -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+    outline: none;
+    border-style: solid;
+    border-width: 1px;
+    border-color: #ccdaeb;
+    border-radius: 0;
+    color: #21262c;
+    background-color: transparent;
+    -webkit-transition: border-color 0.125s;
+    transition: border-color 0.125s;
+    height: 52px;
+    padding-left: 16px;
+    padding-right: 16px;
+    appearance: none;
+    -moz-appearance: none;
+    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMiIgaGVpZ2h0PSI5Ij48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiMyMTI2MkMiIGQ9Ik0xMS45MzUgMS40NzVMNi4xODggNy45MjdhLjI2NC4yNjQgMCAwIDEtLjM3OCAwTC4wNjUgMS40NzVhLjIzNi4yMzYgMCAwIDEgLjAyNi0uMzQzTDEuMzgxLjA1OGEuMjUzLjI1MyAwIDAgMSAuMTYzLS4wNTlMMS41NjMgMGEuMjUyLjI1MiAwIDAgMSAuMTcxLjA4NWw0LjI2NSA0Ljg4IDQuMjY3LTQuODhhLjI1Mi4yNTIgMCAwIDEgLjM1Mi0uMDI3bDEuMjkxIDEuMDc0Yy4wNS4wNDIuMDgxLjEwMi4wODYuMTY2YS4yMzYuMjM2IDAgMCAxLS4wNi4xNzd6Ii8+PC9zdmc+);
+    background-repeat: no-repeat;
+    background-position: calc(100% - 12px) center;
+    padding-right: 44px;
+    position: relative;
+    line-height: 52px; }
+    .fd-dropdown__control:focus, .fd-dropdown__control:hover {
+      border-color: #009cdf; }
+    .fd-dropdown__control.is-invalid {
+      border-color: #df1919; }
+    .fd-dropdown__control.is-valid {
+      border-color: #61bf33; }
+    .fd-dropdown__control.is-warning {
+      border-color: #e97326; }
+    .fd-dropdown__control:disabled, .fd-dropdown__control[aria-disabled="true"], .fd-dropdown__control.is-disabled {
+      cursor: not-allowed;
+      color: #63758b;
+      border-color: #e4e4e4;
+      background-color: #f9fbfc; }
+    .fd-dropdown__control[readonly], .fd-dropdown__control.is-readonly {
+      color: #21262c;
+      border-color: #e4e4e4;
+      border-width: 0 0 1px; }
+    .fd-dropdown__control:focus, .fd-dropdown__control:hover {
+      background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMiIgaGVpZ2h0PSI5Ij48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiMwMDhGRDIiIGQ9Ik0xMS45MzUgMS40NzVMNi4xODggNy45MjdhLjI2NC4yNjQgMCAwIDEtLjM3OCAwTC4wNjUgMS40NzVhLjIzNi4yMzYgMCAwIDEgLjAyNi0uMzQzTDEuMzgxLjA1OGEuMjUzLjI1MyAwIDAgMSAuMTYzLS4wNTlMMS41NjMgMGEuMjUyLjI1MiAwIDAgMSAuMTcxLjA4NWw0LjI2NSA0Ljg4IDQuMjY3LTQuODhhLjI1Mi4yNTIgMCAwIDEgLjM1Mi0uMDI3bDEuMjkxIDEuMDc0Yy4wNS4wNDIuMDgxLjEwMi4wODYuMTY2YS4yMzYuMjM2IDAgMCAxLS4wNi4xNzd6Ii8+PC9zdmc+); }
+    .fd-dropdown__control[aria-expanded="true"], .fd-dropdown__control.is-expanded {
+      background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMiIgaGVpZ2h0PSI4Ij48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiMwMDhGRDIiIGQ9Ik0xMS45MzUgNi41M0w2LjE4OC4xMDRhLjI2NC4yNjQgMCAwIDAtLjM3OCAwTC4wNjUgNi41M2EuMjQuMjQgMCAwIDAtLjA2MS4xNzcuMjM3LjIzNyAwIDAgMCAuMDg3LjE2NWwxLjI5IDEuMDcxYS4yNTguMjU4IDAgMCAwIC4xNjMuMDU4TDEuNTYzIDhhLjI1Mi4yNTIgMCAwIDAgLjE3MS0uMDg1bDQuMjY1LTQuODYxIDQuMjY3IDQuODYxYy4wNDMuMDQ5LjEwNC4wOC4xNy4wODVhLjI2MS4yNjEgMCAwIDAgLjE4Mi0uMDU3bDEuMjkxLTEuMDcxYS4yMzYuMjM2IDAgMCAwIC4wMjYtLjM0MnoiLz48L3N2Zz4=); }
+    .fd-dropdown__control[disabled], .fd-dropdown__control[aria-disabled="true"], .fd-dropdown__control.is-disabled {
+      background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMiIgaGVpZ2h0PSI5Ij48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiM2Mzc1OEIiIGQ9Ik0xMS45MzUgMS40NzVMNi4xODggNy45MjdhLjI2NC4yNjQgMCAwIDEtLjM3OCAwTC4wNjUgMS40NzVhLjIzNS4yMzUgMCAwIDEgLjAyNi0uMzQzTDEuMzgxLjA1OGEuMjUzLjI1MyAwIDAgMSAuMTYzLS4wNTlMMS41NjMgMGEuMjUyLjI1MiAwIDAgMSAuMTcxLjA4NWw0LjI2NSA0Ljg4IDQuMjY3LTQuODhhLjI1Mi4yNTIgMCAwIDEgLjM1Mi0uMDI3bDEuMjkxIDEuMDc0Yy4wNS4wNDIuMDgxLjEwMi4wODYuMTY2YS4yMzQuMjM0IDAgMCAxLS4wNi4xNzd6Ii8+PC9zdmc+); }
+    .fd-dropdown__control[aria-expanded="true"], .fd-dropdown__control.is-expanded {
+      border-color: #009cdf;
+      z-index: 3;
+      -webkit-box-shadow: 0 0 4px 1px rgba(138, 143, 161, 0.2);
+              box-shadow: 0 0 4px 1px rgba(138, 143, 161, 0.2); }
+    .fd-dropdown__control--no-border {
+      border-color: transparent; }
+      .fd-dropdown__control--no-border[aria-disabled="true"], .fd-dropdown__control--no-border.is-disabled, .fd-dropdown__control--no-border:disabled {
+        border-color: transparent; }
+  .fd-dropdown__icon {
+    margin-right: 12px;
+    vertical-align: middle;
+    -webkit-transform: translateY(-2px);
+            transform: translateY(-2px); }
+  .fd-dropdown__menu, .fd-dropdown__options {
+    margin-left: 0;
+    padding-left: 0;
+    list-style: none;
+    min-width: 100%;
+    border: solid 1px #ccdaeb;
+    background: #ffffff;
+    position: absolute;
+    white-space: nowrap;
+    z-index: 2;
+    -webkit-transform: translateY(-1px);
+            transform: translateY(-1px);
+    -webkit-box-shadow: 0 0 4px 1px rgba(138, 143, 161, 0.2);
+            box-shadow: 0 0 4px 1px rgba(138, 143, 161, 0.2);
+    opacity: 1;
+    visibility: visible;
+    -webkit-transition: opacity 0.125s ease-in;
+    transition: opacity 0.125s ease-in; }
+    .fd-dropdown__menu[aria-hidden="true"], .fd-dropdown__menu.is-hidden, .fd-dropdown__options[aria-hidden="true"], .fd-dropdown__options.is-hidden {
+      opacity: 0;
+      visibility: hidden; }
+  .fd-dropdown__group {
+    margin-left: 0;
+    padding-left: 0;
+    list-style: none; }
+  .fd-dropdown__item, .fd-dropdown__option {
+    font-size: 1rem;
+    line-height: 1.5;
+    color: #21262c;
+    font-size: 0.875rem;
+    line-height: 1.42858;
+    font-family: 'Open Sans', sans-serif;
+    font-weight: 400;
+    display: block;
+    padding-left: 0;
+    list-style: none;
+    padding: 12px 16px; }
+    .fd-dropdown__item:hover, .fd-dropdown__option:hover {
+      color: #ffffff;
+      background-color: #008ac6;
+      text-decoration: none; }
+  .fd-dropdown__separator {
+    font-size: 1rem;
+    line-height: 1.5;
+    color: #21262c;
+    font-size: 0.75rem;
+    line-height: 1.33334;
+    font-family: 'Open Sans', sans-serif;
+    font-weight: 400;
+    text-transform: none;
+    display: block;
+    color: #7f90a4;
+    padding: 12px 16px;
+    padding-top: 16px;
+    border-top: solid 1px #ccdaeb; }
+
+/*!
+.fd-form
+    .fd-form__set?
+        .fd-form__legend(.is-required)
+        .fd-form__group?
+            .fd-form__item+(--check, --inline)
+                .fd-form__label(.is-required)
+                .fd-form__control
+            .fd-form__message(--help, --error, --warning)
+*/
+.fd-form__group::after {
+  content: "";
+  display: table;
+  clear: both; }
+
+.fd-form__group:last-child {
+  margin-bottom: 0;
+  margin-right: 0; }
+
+.fd-form__group .fd-form__item {
+  margin-right: 32px; }
+  .fd-form__group .fd-form__item:last-child {
+    margin-bottom: 0;
+    margin-right: 0; }
+
+.fd-form__set {
+  margin-bottom: 32px; }
+  .fd-form__set .fd-form__item--inline {
+    margin-bottom: 0; }
+  .fd-form__set .fd-form__message {
+    margin-top: 8px; }
+
+.fd-form__item {
+  margin-bottom: 32px; }
+  .fd-form__item:last-child {
+    margin-bottom: 0;
+    margin-right: 0; }
+  .fd-form__item--check {
+    position: relative;
+    display: block; }
+    .fd-form__item--check::after {
+      content: "";
+      display: table;
+      clear: both; }
+    .fd-form__item--check .fd-form__label {
+      font-size: 1rem;
+      line-height: 1.5;
+      font-weight: 400;
+      margin-bottom: 0;
+      vertical-align: middle;
+      display: -webkit-box;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-align: center;
+          -ms-flex-align: center;
+              align-items: center;
+      line-height: 28px; }
+    .fd-form__item--check .fd-form__control {
+      float: left;
+      vertical-align: middle;
+      margin-right: 12px; }
+    .fd-form__item--check .fd-form__help {
+      float: none;
+      margin-left: 12px; }
+  .fd-form__item--inline {
+    float: left; }
+    .fd-form__item--inline .fd-form__label {
+      margin-top: 4px;
+      width: auto; }
+
+.fd-form__label, .fd-form__legend {
+  font-size: 0.875rem;
+  line-height: 1.42858;
+  font-weight: 400;
+  display: block;
+  margin-bottom: 8px;
+  border: 0;
+  color: #63758b; }
+  .fd-form__label.is-required, .fd-form__legend.is-required {
+    font-weight: 700; }
+
+.fd-form__control {
+  min-width: 28px; }
+
+.fd-form__legend {
+  margin-bottom: 20px; }
+
+.fd-form__help {
+  float: right; }
+
+.fd-form__message {
+  clear: both;
+  display: block;
+  font-size: 0.875rem;
+  line-height: 1.42858;
+  font-weight: 400;
+  color: #7f90a4;
+  padding: 4px 0;
+  font-style: italic;
+  position: relative; }
+  .fd-form__item--check + .fd-form__message {
+    -webkit-transform: translateY(-12px);
+            transform: translateY(-12px);
+    margin-bottom: -12px; }
+  .fd-form__item--inline.fd-form__item--check + .fd-form__message {
+    -webkit-transform: translateY(8px);
+            transform: translateY(8px);
+    margin-bottom: 8px; }
+  .fd-form__message::before {
+    width: 18px;
+    height: 18px;
+    font-style: normal;
+    position: absolute;
+    left: 0;
+    color: #ffffff;
+    border-radius: 50%;
+    background-color: #63758b;
+    text-align: center; }
+  .fd-form__message--help {
+    padding-left: 28px; }
+    .fd-form__message--help::before {
+      content: "?"; }
+  .fd-form__message--warning, .fd-form__message--error {
+    padding-left: 36px;
+    color: #21262c; }
+    .fd-form__message--warning::before, .fd-form__message--error::before {
+      content: "!";
+      left: 8px; }
+  .fd-form__message--warning {
+    background-color: #f8d5be; }
+    .fd-form__message--warning::before {
+      background-color: transparent;
+      border-radius: 0;
+      height: 0;
+      width: 0;
+      border-bottom: 18px solid #e97326;
+      border-left: 10px solid transparent;
+      border-right: 10px solid transparent;
+      text-indent: -0.1em; }
+  .fd-form__message--error {
+    background-color: #f7b8b8; }
+    .fd-form__message--error::before {
+      background-color: #df1919;
+      color: #ffffff; }
+
+/*!
+.fd-input-group+(--inline)
+    .fd-input-group__addon+()
+        .fd-input-group__button
+*/
+.fd-input-group {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #21262c;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  vertical-align: bottom;
+  max-height: 52px; }
+  .fd-input-group [type="number"] {
+    -moz-appearance: textfield; }
+    .fd-input-group [type="number"]::-webkit-outer-spin-button, .fd-input-group [type="number"]::-webkit-inner-spin-button {
+      -webkit-appearance: none;
+      margin: 0; }
+  .fd-input-group [type="search"] {
+    background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNiIgaGVpZ2h0PSIyNiI+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBmaWxsPSIjNEQ1QTZDIiBkPSJNOS43NTQgMTkuNDk2YTkuNjg0IDkuNjg0IDAgMCAwIDYuMDk3LTIuMTU4bDguMjg5IDguMzRhMS4wODQgMS4wODQgMCAwIDAgMS41MzUtMS41MjlsLTguMy04LjM1YTkuNjg5IDkuNjg5IDAgMCAwIDIuMTItNi4wNTRjMC01LjM3Ny00LjM2OS05Ljc1MS05Ljc0MS05Ljc1MVMuMDEzIDQuMzY4LjAxMyA5Ljc0NXM0LjM2OSA5Ljc1MSA5Ljc0MSA5Ljc1MXptMC0xNy4zMzVjNC4xNzcgMCA3LjU3NyAzLjQwMiA3LjU3NyA3LjU4NCAwIDQuMTgyLTMuNCA3LjU4NC03LjU3NyA3LjU4NC00LjE3OCAwLTcuNTc3LTMuNDAyLTcuNTc3LTcuNTg0IDAtNC4xODIgMy4zOTktNy41ODQgNy41NzctNy41ODR6Ii8+PC9zdmc+");
+    background-repeat: no-repeat;
+    background-position: 16px center;
+    padding-left: 60px;
+    padding-right: 60px;
+    -moz-appearance: textfield; }
+    .fd-input-group [type="search"]::-webkit-search-decoration {
+      -webkit-appearance: none;
+      margin: 0; }
+    .fd-input-group [type="search"]::-webkit-search-cancel-button {
+      -webkit-appearance: none;
+      margin: 0; }
+  .fd-input-group--inline {
+    display: -webkit-inline-box;
+    display: -ms-inline-flexbox;
+    display: inline-flex; }
+  .fd-input-group--no-border input {
+    border-color: transparent; }
+  .fd-input-group__addon {
+    font-size: 0.8125rem;
+    line-height: 1.53847;
+    font-family: 'Open Sans', sans-serif;
+    font-weight: 700;
+    text-transform: normal;
+    color: #63758b;
+    padding: 0 16px;
+    border-style: solid;
+    border-width: 1px;
+    border-color: #ccdaeb;
+    background-color: #f9fbfc;
+    -webkit-box-pack: center;
+        -ms-flex-pack: center;
+            justify-content: center;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+        -ms-flex-direction: column;
+            flex-direction: column; }
+    .fd-input-group__addon:first-child {
+      border-right-width: 0; }
+    .fd-input-group__addon:last-child {
+      border-left-width: 0; }
+    .fd-input-group__addon--button {
+      padding: 0; }
+    [readonly] + .fd-input-group__addon {
+      border-top-color: transparent;
+      border-right-color: transparent; }
+    [type="search"] + .fd-input-group__addon {
+      border: 0;
+      width: 0; }
+  .fd-input-group__button {
+    margin: 0;
+    padding: 0;
+    font-smoothing: antialiased;
+    -webkit-appearance: none;
+       -moz-appearance: none;
+            appearance: none;
+    outline: 0;
+    border: 0;
+    display: inline-block;
+    text-decoration: none;
+    cursor: pointer;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
+    vertical-align: middle;
+    white-space: nowrap;
+    background-color: transparent;
+    -webkit-box-flex: 1;
+        -ms-flex: 1;
+            flex: 1;
+    width: 100%;
+    display: block;
+    min-width: 48px; }
+    .fd-input-group__button--step-up, .fd-input-group__button--step-down {
+      font-size: 10px; }
+      .fd-input-group__button--step-up::after, .fd-input-group__button--step-down::after {
+        content: "";
+        position: relative; }
+    .fd-input-group__button--step-up {
+      border-bottom: solid 1px #ccdaeb; }
+      .fd-input-group__button--step-up::after {
+        height: 0;
+        width: 0;
+        border-bottom: 8px solid black;
+        border-left: 6.5px solid transparent;
+        border-right: 6.5px solid transparent;
+        top: -10px; }
+    .fd-input-group__button--step-down::after {
+      height: 0;
+      width: 0;
+      border-left: 6.5px solid transparent;
+      border-right: 6.5px solid transparent;
+      border-top: 8px solid black;
+      top: 10px; }
+    .fd-input-group__button--clear {
+      background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNiIgaGVpZ2h0PSIyNiI+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBmaWxsPSIjMDA5Q0RGIiBkPSJNMTMgMEM1LjgyIDAgMCA1LjgyIDAgMTNzNS44MiAxMyAxMyAxMyAxMy01LjgyIDEzLTEzUzIwLjE4IDAgMTMgMHptNS4xOTUgMTcuMzk2YS41NjQuNTY0IDAgMSAxLS43OTkuNzk5TDEzIDEzLjc5OWwtNC4zOTYgNC4zOTZhLjU2NC41NjQgMCAxIDEtLjc5OS0uNzk5TDEyLjIwMSAxMyA3LjgwNSA4LjYwNGEuNTY0LjU2NCAwIDEgMSAuNzk5LS43OTlMMTMgMTIuMjAxbDQuMzk2LTQuMzk2YS41NjQuNTY0IDAgMSAxIC43OTkuNzk5TDEzLjc5OSAxM2w0LjM5NiA0LjM5NnoiLz48L3N2Zz4=");
+      background-repeat: no-repeat;
+      background-position: center;
+      position: relative;
+      left: -52px; }
+
+/*!
+.fd-label+(--success | --warning | --error)
+*/
+.fd-label {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #21262c;
+  font-size: 0.75rem;
+  line-height: 1.33334;
+  font-weight: 700;
+  text-transform: uppercase; }
+  .fd-label--success {
+    color: #61bf33; }
+  .fd-label--warning {
+    color: #e97326; }
+  .fd-label--error {
+    color: #df1919; }
+
+/*!
+.fd-button+( (--small | --large), --icon, --text, --link, --action-bar)+( (.is-disabled | [aria-disabled=true]) | (.is-selected | [aria-selected=true] | (.is-pressed | [aria-pressed=true]))
+*/
+.fd-button, .fd-modal__button-primary, .fd-modal__button-secondary {
+  margin: 0;
+  padding: 0;
+  font-smoothing: antialiased;
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none;
+  outline: 0;
+  border: 0;
+  display: inline-block;
+  text-decoration: none;
+  cursor: pointer;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
+  vertical-align: middle;
+  white-space: nowrap;
+  background-color: transparent;
+  font-size: 1.125rem;
+  line-height: 1.33334;
+  font-family: Roboto, sans-serif;
+  font-weight: 500;
+  display: inline-block;
+  background-color: #009cdf;
+  -webkit-transition: background-color 0.125s ease-in;
+  transition: background-color 0.125s ease-in;
+  color: #f6f8f9;
+  max-height: 52px;
+  height: 52px;
+  line-height: 52px;
+  padding-left: 20px;
+  padding-right: 20px;
+  text-align: center;
+  text-transform: uppercase;
+  border-radius: 0; }
+  .fd-button--small {
+    font-size: 1rem;
+    line-height: 1.5;
+    font-weight: 400;
+    font-weight: 600;
+    max-height: 40px;
+    height: 40px;
+    line-height: 40px;
+    padding-left: 16px;
+    padding-right: 16px; }
+  .fd-button--large, .fd-button--action-bar {
+    font-size: 1.25rem;
+    line-height: 1.4;
+    font-weight: 600;
+    max-height: 76px;
+    height: 76px;
+    line-height: 76px;
+    padding-left: 28px;
+    padding-right: 28px; }
+  .fd-button:hover, .fd-modal__button-primary:hover, .fd-modal__button-secondary:hover {
+    background-color: #008ac6;
+    color: #f6f8f9;
+    text-decoration: none; }
+  .fd-button:focus, .fd-modal__button-primary:focus, .fd-modal__button-secondary:focus {
+    color: #f6f8f9;
+    -webkit-box-shadow: 0 0 4px 1px #8a8fa1;
+            box-shadow: 0 0 4px 1px #8a8fa1;
+    outline: solid 2px #2dc0ff; }
+  .fd-button:active, .fd-modal__button-primary:active, .fd-modal__button-secondary:active, .fd-button.is-active, .is-active.fd-modal__button-primary, .is-active.fd-modal__button-secondary, .fd-button[aria-selected="true"], [aria-selected="true"].fd-modal__button-primary, [aria-selected="true"].fd-modal__button-secondary, .fd-button.is-selected, .is-selected.fd-modal__button-primary, .is-selected.fd-modal__button-secondary, .fd-button[aria-pressed="true"], [aria-pressed="true"].fd-modal__button-primary, [aria-pressed="true"].fd-modal__button-secondary, .fd-button.is-pressed, .is-pressed.fd-modal__button-primary, .is-pressed.fd-modal__button-secondary {
+    background-color: #0078ac;
+    color: #f6f8f9; }
+  .fd-button[aria-disabled="true"], [aria-disabled="true"].fd-modal__button-primary, [aria-disabled="true"].fd-modal__button-secondary, .fd-button.is-disabled, .is-disabled.fd-modal__button-primary, .is-disabled.fd-modal__button-secondary, .fd-button:disabled, .fd-modal__button-primary:disabled, .fd-modal__button-secondary:disabled {
+    outline: solid 1px #d7d7d7;
+    color: #7f90a4;
+    background-color: #f9fbfc;
+    cursor: not-allowed; }
+  .fd-button--text, .fd-modal__button-secondary, .fd-button--link {
+    color: #009cdf;
+    background-color: transparent; }
+    .fd-button--text:hover, .fd-modal__button-secondary:hover, .fd-button--text:focus, .fd-modal__button-secondary:focus, .fd-button--link:hover, .fd-button--link:focus {
+      background-color: transparent;
+      color: #008ac6; }
+    .fd-button--text:active, .fd-modal__button-secondary:active, .fd-button--text[aria-selected="true"], [aria-selected="true"].fd-modal__button-secondary, .fd-button--text.is-selected, .is-selected.fd-modal__button-secondary, .fd-button--text[aria-pressed="true"], [aria-pressed="true"].fd-modal__button-secondary, .fd-button--text.is-pressed, .is-pressed.fd-modal__button-secondary, .fd-button--text[aria-disabled="true"], [aria-disabled="true"].fd-modal__button-secondary, .fd-button--text.is-disabled, .is-disabled.fd-modal__button-secondary, .fd-button--text:disabled, .fd-modal__button-secondary:disabled, .fd-button--link:active, .fd-button--link[aria-selected="true"], .fd-button--link.is-selected, .fd-button--link[aria-pressed="true"], .fd-button--link.is-pressed, .fd-button--link[aria-disabled="true"], .fd-button--link.is-disabled, .fd-button--link:disabled {
+      background-color: transparent;
+      outline: none;
+      -webkit-box-shadow: none;
+              box-shadow: none; }
+    .fd-button--text:active, .fd-modal__button-secondary:active, .fd-button--text[aria-selected="true"], [aria-selected="true"].fd-modal__button-secondary, .fd-button--text.is-selected, .is-selected.fd-modal__button-secondary, .fd-button--text[aria-pressed="true"], [aria-pressed="true"].fd-modal__button-secondary, .fd-button--text.is-pressed, .is-pressed.fd-modal__button-secondary, .fd-button--link:active, .fd-button--link[aria-selected="true"], .fd-button--link.is-selected, .fd-button--link[aria-pressed="true"], .fd-button--link.is-pressed {
+      color: #0078ac; }
+    .fd-button--text[aria-disabled="true"], [aria-disabled="true"].fd-modal__button-secondary, .fd-button--text.is-disabled, .is-disabled.fd-modal__button-secondary, .fd-button--text:disabled, .fd-modal__button-secondary:disabled, .fd-button--link[aria-disabled="true"], .fd-button--link.is-disabled, .fd-button--link:disabled {
+      color: #7f90a4; }
+  .fd-button--link {
+    height: 28px;
+    line-height: 28px;
+    padding-left: 16px;
+    padding-right: 16px;
+    position: relative; }
+    .fd-button--link.fd-button--small {
+      height: 24px;
+      line-height: 24px; }
+    .fd-button--link::after {
+      content: "";
+      border-bottom: solid 2px transparent;
+      width: calc(100% - 16px*2);
+      height: 2px;
+      position: absolute;
+      bottom: 1px;
+      left: 0;
+      margin-left: 16px;
+      -webkit-transition: border-bottom-color 0.125s ease-in;
+      transition: border-bottom-color 0.125s ease-in; }
+    .fd-button--link:focus {
+      outline: none;
+      -webkit-box-shadow: none;
+              box-shadow: none; }
+    .fd-button--link:hover::after, .fd-button--link:focus::after, .fd-button--link:active::after, .fd-button--link[aria-selected="true"]::after, .fd-button--link.is-selected::after, .fd-button--link[aria-pressed="true"]::after, .fd-button--link.is-pressed::after {
+      border-bottom-color: #009cdf; }
+    .fd-button--link[aria-disabled="true"]::after, .fd-button--link.is-disabled::after, .fd-button--link:disabled::after {
+      display: none; }
+  .fd-button > *, .fd-modal__button-primary > *, .fd-modal__button-secondary > * {
+    display: inline-block;
+    vertical-align: top;
+    margin-right: 12px;
+    margin-top: 13px; }
+    .fd-button--icon > * {
+      margin-left: auto;
+      margin-right: auto; }
+    .fd-button--small > * {
+      margin-top: 11px; }
+    .fd-button--large > *, .fd-button--action-bar > * {
+      margin-top: 22px; }
+  .fd-button--action-bar {
+    font-size: 0.75rem;
+    line-height: 1.33334;
+    font-weight: 700;
+    text-transform: uppercase;
+    min-width: 135px;
+    line-height: 32px;
+    vertical-align: middle; }
+    .fd-button--action-bar > * {
+      display: block !important;
+      margin-top: 12px;
+      margin-left: auto;
+      margin-right: auto; }
+
+/*!
+.fd-dropdown+()
+    .fd-dropdown__control+([disabled])
+    .fd-dropdown__menu+()
+*/
+.fd-dropdown {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #21262c;
+  position: relative;
+  display: inline-block; }
+  .fd-dropdown__control {
+    margin: 0;
+    padding: 0;
+    font-smoothing: antialiased;
+    -webkit-appearance: none;
+            appearance: none;
+    outline: 0;
+    border: 0;
+    display: inline-block;
+    text-decoration: none;
+    cursor: pointer;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
+    vertical-align: middle;
+    white-space: nowrap;
+    background-color: transparent;
+    font-size: 1rem;
+    line-height: 1.5;
+    color: #21262c;
+    font-size: 1rem;
+    line-height: 1.5;
+    font-family: 'Open Sans', sans-serif;
+    font-weight: 400;
+    appearance: none;
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    font-size: inherit;
+    -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+    outline: none;
+    border-style: solid;
+    border-width: 1px;
+    border-color: #ccdaeb;
+    border-radius: 0;
+    color: #21262c;
+    background-color: transparent;
+    -webkit-transition: border-color 0.125s;
+    transition: border-color 0.125s;
+    height: 52px;
+    padding-left: 16px;
+    padding-right: 16px;
+    appearance: none;
+    -moz-appearance: none;
+    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMiIgaGVpZ2h0PSI5Ij48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiMyMTI2MkMiIGQ9Ik0xMS45MzUgMS40NzVMNi4xODggNy45MjdhLjI2NC4yNjQgMCAwIDEtLjM3OCAwTC4wNjUgMS40NzVhLjIzNi4yMzYgMCAwIDEgLjAyNi0uMzQzTDEuMzgxLjA1OGEuMjUzLjI1MyAwIDAgMSAuMTYzLS4wNTlMMS41NjMgMGEuMjUyLjI1MiAwIDAgMSAuMTcxLjA4NWw0LjI2NSA0Ljg4IDQuMjY3LTQuODhhLjI1Mi4yNTIgMCAwIDEgLjM1Mi0uMDI3bDEuMjkxIDEuMDc0Yy4wNS4wNDIuMDgxLjEwMi4wODYuMTY2YS4yMzYuMjM2IDAgMCAxLS4wNi4xNzd6Ii8+PC9zdmc+);
+    background-repeat: no-repeat;
+    background-position: calc(100% - 12px) center;
+    padding-right: 44px;
+    position: relative;
+    line-height: 52px; }
+    .fd-dropdown__control:focus, .fd-dropdown__control:hover {
+      border-color: #009cdf; }
+    .fd-dropdown__control.is-invalid {
+      border-color: #df1919; }
+    .fd-dropdown__control.is-valid {
+      border-color: #61bf33; }
+    .fd-dropdown__control.is-warning {
+      border-color: #e97326; }
+    .fd-dropdown__control:disabled, .fd-dropdown__control[aria-disabled="true"], .fd-dropdown__control.is-disabled {
+      cursor: not-allowed;
+      color: #63758b;
+      border-color: #e4e4e4;
+      background-color: #f9fbfc; }
+    .fd-dropdown__control[readonly], .fd-dropdown__control.is-readonly {
+      color: #21262c;
+      border-color: #e4e4e4;
+      border-width: 0 0 1px; }
+    .fd-dropdown__control:focus, .fd-dropdown__control:hover {
+      background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMiIgaGVpZ2h0PSI5Ij48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiMwMDhGRDIiIGQ9Ik0xMS45MzUgMS40NzVMNi4xODggNy45MjdhLjI2NC4yNjQgMCAwIDEtLjM3OCAwTC4wNjUgMS40NzVhLjIzNi4yMzYgMCAwIDEgLjAyNi0uMzQzTDEuMzgxLjA1OGEuMjUzLjI1MyAwIDAgMSAuMTYzLS4wNTlMMS41NjMgMGEuMjUyLjI1MiAwIDAgMSAuMTcxLjA4NWw0LjI2NSA0Ljg4IDQuMjY3LTQuODhhLjI1Mi4yNTIgMCAwIDEgLjM1Mi0uMDI3bDEuMjkxIDEuMDc0Yy4wNS4wNDIuMDgxLjEwMi4wODYuMTY2YS4yMzYuMjM2IDAgMCAxLS4wNi4xNzd6Ii8+PC9zdmc+); }
+    .fd-dropdown__control[aria-expanded="true"], .fd-dropdown__control.is-expanded {
+      background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMiIgaGVpZ2h0PSI4Ij48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiMwMDhGRDIiIGQ9Ik0xMS45MzUgNi41M0w2LjE4OC4xMDRhLjI2NC4yNjQgMCAwIDAtLjM3OCAwTC4wNjUgNi41M2EuMjQuMjQgMCAwIDAtLjA2MS4xNzcuMjM3LjIzNyAwIDAgMCAuMDg3LjE2NWwxLjI5IDEuMDcxYS4yNTguMjU4IDAgMCAwIC4xNjMuMDU4TDEuNTYzIDhhLjI1Mi4yNTIgMCAwIDAgLjE3MS0uMDg1bDQuMjY1LTQuODYxIDQuMjY3IDQuODYxYy4wNDMuMDQ5LjEwNC4wOC4xNy4wODVhLjI2MS4yNjEgMCAwIDAgLjE4Mi0uMDU3bDEuMjkxLTEuMDcxYS4yMzYuMjM2IDAgMCAwIC4wMjYtLjM0MnoiLz48L3N2Zz4=); }
+    .fd-dropdown__control[disabled], .fd-dropdown__control[aria-disabled="true"], .fd-dropdown__control.is-disabled {
+      background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMiIgaGVpZ2h0PSI5Ij48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiM2Mzc1OEIiIGQ9Ik0xMS45MzUgMS40NzVMNi4xODggNy45MjdhLjI2NC4yNjQgMCAwIDEtLjM3OCAwTC4wNjUgMS40NzVhLjIzNS4yMzUgMCAwIDEgLjAyNi0uMzQzTDEuMzgxLjA1OGEuMjUzLjI1MyAwIDAgMSAuMTYzLS4wNTlMMS41NjMgMGEuMjUyLjI1MiAwIDAgMSAuMTcxLjA4NWw0LjI2NSA0Ljg4IDQuMjY3LTQuODhhLjI1Mi4yNTIgMCAwIDEgLjM1Mi0uMDI3bDEuMjkxIDEuMDc0Yy4wNS4wNDIuMDgxLjEwMi4wODYuMTY2YS4yMzQuMjM0IDAgMCAxLS4wNi4xNzd6Ii8+PC9zdmc+); }
+    .fd-dropdown__control[aria-expanded="true"], .fd-dropdown__control.is-expanded {
+      border-color: #009cdf;
+      z-index: 3;
+      -webkit-box-shadow: 0 0 4px 1px rgba(138, 143, 161, 0.2);
+              box-shadow: 0 0 4px 1px rgba(138, 143, 161, 0.2); }
+    .fd-dropdown__control--no-border {
+      border-color: transparent; }
+      .fd-dropdown__control--no-border[aria-disabled="true"], .fd-dropdown__control--no-border.is-disabled, .fd-dropdown__control--no-border:disabled {
+        border-color: transparent; }
+  .fd-dropdown__icon {
+    margin-right: 12px;
+    vertical-align: middle;
+    -webkit-transform: translateY(-2px);
+            transform: translateY(-2px); }
+  .fd-dropdown__menu, .fd-dropdown__options {
+    margin-left: 0;
+    padding-left: 0;
+    list-style: none;
+    min-width: 100%;
+    border: solid 1px #ccdaeb;
+    background: #ffffff;
+    position: absolute;
+    white-space: nowrap;
+    z-index: 2;
+    -webkit-transform: translateY(-1px);
+            transform: translateY(-1px);
+    -webkit-box-shadow: 0 0 4px 1px rgba(138, 143, 161, 0.2);
+            box-shadow: 0 0 4px 1px rgba(138, 143, 161, 0.2);
+    opacity: 1;
+    visibility: visible;
+    -webkit-transition: opacity 0.125s ease-in;
+    transition: opacity 0.125s ease-in; }
+    .fd-dropdown__menu[aria-hidden="true"], .fd-dropdown__menu.is-hidden, .fd-dropdown__options[aria-hidden="true"], .fd-dropdown__options.is-hidden {
+      opacity: 0;
+      visibility: hidden; }
+  .fd-dropdown__group {
+    margin-left: 0;
+    padding-left: 0;
+    list-style: none; }
+  .fd-dropdown__item, .fd-dropdown__option {
+    font-size: 1rem;
+    line-height: 1.5;
+    color: #21262c;
+    font-size: 0.875rem;
+    line-height: 1.42858;
+    font-family: 'Open Sans', sans-serif;
+    font-weight: 400;
+    display: block;
+    padding-left: 0;
+    list-style: none;
+    padding: 12px 16px; }
+    .fd-dropdown__item:hover, .fd-dropdown__option:hover {
+      color: #ffffff;
+      background-color: #008ac6;
+      text-decoration: none; }
+  .fd-dropdown__separator {
+    font-size: 1rem;
+    line-height: 1.5;
+    color: #21262c;
+    font-size: 0.75rem;
+    line-height: 1.33334;
+    font-family: 'Open Sans', sans-serif;
+    font-weight: 400;
+    text-transform: none;
+    display: block;
+    color: #7f90a4;
+    padding: 12px 16px;
+    padding-top: 16px;
+    border-top: solid 1px #ccdaeb; }
+
+/*!
+.fd-toolbar+()
+    .fd-toolbar__row
+        .fd-toolbar__group
+        .fd-toolbar__item
+*/
+.fd-toolbar {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #21262c;
+  min-height: 52px;
+  background-color: #f0f5ff;
+  border-color: #ccdaeb;
+  border-style: solid;
+  border-width: 1px 0;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap; }
+  .fd-toolbar [role="separator"] {
+    display: inline-block;
+    vertical-align: middle;
+    max-width: 1px;
+    height: 52px;
+    border-left: solid 1px #ccdaeb; }
+  .fd-toolbar__group {
+    min-height: 52px;
+    overflow: visible;
+    -webkit-transition: all 0.15s ease-in;
+    transition: all 0.15s ease-in;
+    width: 100%; }
+    .fd-toolbar__group--view {
+      -webkit-box-ordinal-group: 6;
+          -ms-flex-order: 5;
+              order: 5;
+      display: -webkit-box;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-align: center;
+          -ms-flex-align: center;
+              align-items: center;
+      border-top: solid 1px #ccdaeb; }
+      @media (min-width: 800px) {
+        .fd-toolbar__group--view {
+          border-top: none; } }
+    .fd-toolbar__group--filter {
+      display: -webkit-box;
+      display: -ms-flexbox;
+      display: flex; }
+    .fd-toolbar__group--filter-options {
+      background-color: #ffffff;
+      border-top: solid 1px #ccdaeb; }
+    .fd-toolbar__group--applied-filters {
+      border-top: solid 1px #ccdaeb;
+      display: -webkit-box;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-align: center;
+          -ms-flex-align: center;
+              align-items: center; }
+    @media (min-width: 800px) {
+      .fd-toolbar__group--filter {
+        width: auto; }
+      .fd-toolbar__group--view {
+        width: auto;
+        -webkit-box-ordinal-group: 1;
+            -ms-flex-order: 0;
+                order: 0;
+        margin-left: auto; }
+      .fd-toolbar__group--view-as {
+        display: block;
+        margin-left: auto; } }
+    .fd-toolbar__group[aria-hidden="true"] {
+      display: none;
+      border: none; }
+  .fd-toolbar__pagination {
+    margin: 0 auto; }
+    @media (min-width: 800px) {
+      .fd-toolbar__pagination {
+        margin-right: 20px; } }
+  .fd-toolbar__view-as {
+    display: none; }
+    @media (min-width: 800px) {
+      .fd-toolbar__view-as {
+        display: block;
+        border-left: solid 1px #ccdaeb; } }
+  .fd-toolbar__button[aria-expanded="true"] {
+    background-color: #ffffff; }
+  .fd-toolbar__applied-filter-list {
+    margin-left: 20px;
+    list-style: none;
+    margin-bottom: 0;
+    -ms-flex-wrap: wrap;
+        flex-wrap: wrap; }
+    @media (min-width: 320px) {
+      .fd-toolbar__applied-filter-list {
+        display: -webkit-inline-box;
+        display: -ms-inline-flexbox;
+        display: inline-flex;
+        -webkit-box-align: center;
+            -ms-flex-align: center;
+                align-items: center; } }
+  .fd-toolbar__applied-filter-item {
+    font-size: 0.75rem;
+    line-height: 1.33334;
+    font-family: 'Open Sans', sans-serif;
+    font-weight: 400;
+    text-transform: none;
+    line-height: inherit;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-align: center;
+        -ms-flex-align: center;
+            align-items: center;
+    margin-right: 20px; }
+    @media (min-width: 320px) {
+      .fd-toolbar__applied-filter-item {
+        display: -webkit-inline-box;
+        display: -ms-inline-flexbox;
+        display: inline-flex; } }
+    .fd-toolbar__applied-filter-item::after {
+      content: "•"; }
+    .fd-toolbar__applied-filter-item:last-child::after {
+      display: none; }
+  .fd-toolbar__applied-filter-clear {
+    font-size: 0.75rem;
+    line-height: 1.33334;
+    font-family: 'Open Sans', sans-serif;
+    font-weight: 600;
+    text-transform: uppercase; }
+
+/*!
+.fd-button+( (--small | --large), --icon, --text, --link, --action-bar)+( (.is-disabled | [aria-disabled=true]) | (.is-selected | [aria-selected=true] | (.is-pressed | [aria-pressed=true]))
+*/
+.fd-button, .fd-modal__button-primary, .fd-modal__button-secondary {
+  margin: 0;
+  padding: 0;
+  font-smoothing: antialiased;
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none;
+  outline: 0;
+  border: 0;
+  display: inline-block;
+  text-decoration: none;
+  cursor: pointer;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
+  vertical-align: middle;
+  white-space: nowrap;
+  background-color: transparent;
+  font-size: 1.125rem;
+  line-height: 1.33334;
+  font-family: Roboto, sans-serif;
+  font-weight: 500;
+  display: inline-block;
+  background-color: #009cdf;
+  -webkit-transition: background-color 0.125s ease-in;
+  transition: background-color 0.125s ease-in;
+  color: #f6f8f9;
+  max-height: 52px;
+  height: 52px;
+  line-height: 52px;
+  padding-left: 20px;
+  padding-right: 20px;
+  text-align: center;
+  text-transform: uppercase;
+  border-radius: 0; }
+  .fd-button--small {
+    font-size: 1rem;
+    line-height: 1.5;
+    font-weight: 400;
+    font-weight: 600;
+    max-height: 40px;
+    height: 40px;
+    line-height: 40px;
+    padding-left: 16px;
+    padding-right: 16px; }
+  .fd-button--large, .fd-button--action-bar {
+    font-size: 1.25rem;
+    line-height: 1.4;
+    font-weight: 600;
+    max-height: 76px;
+    height: 76px;
+    line-height: 76px;
+    padding-left: 28px;
+    padding-right: 28px; }
+  .fd-button:hover, .fd-modal__button-primary:hover, .fd-modal__button-secondary:hover {
+    background-color: #008ac6;
+    color: #f6f8f9;
+    text-decoration: none; }
+  .fd-button:focus, .fd-modal__button-primary:focus, .fd-modal__button-secondary:focus {
+    color: #f6f8f9;
+    -webkit-box-shadow: 0 0 4px 1px #8a8fa1;
+            box-shadow: 0 0 4px 1px #8a8fa1;
+    outline: solid 2px #2dc0ff; }
+  .fd-button:active, .fd-modal__button-primary:active, .fd-modal__button-secondary:active, .fd-button.is-active, .is-active.fd-modal__button-primary, .is-active.fd-modal__button-secondary, .fd-button[aria-selected="true"], [aria-selected="true"].fd-modal__button-primary, [aria-selected="true"].fd-modal__button-secondary, .fd-button.is-selected, .is-selected.fd-modal__button-primary, .is-selected.fd-modal__button-secondary, .fd-button[aria-pressed="true"], [aria-pressed="true"].fd-modal__button-primary, [aria-pressed="true"].fd-modal__button-secondary, .fd-button.is-pressed, .is-pressed.fd-modal__button-primary, .is-pressed.fd-modal__button-secondary {
+    background-color: #0078ac;
+    color: #f6f8f9; }
+  .fd-button[aria-disabled="true"], [aria-disabled="true"].fd-modal__button-primary, [aria-disabled="true"].fd-modal__button-secondary, .fd-button.is-disabled, .is-disabled.fd-modal__button-primary, .is-disabled.fd-modal__button-secondary, .fd-button:disabled, .fd-modal__button-primary:disabled, .fd-modal__button-secondary:disabled {
+    outline: solid 1px #d7d7d7;
+    color: #7f90a4;
+    background-color: #f9fbfc;
+    cursor: not-allowed; }
+  .fd-button--text, .fd-modal__button-secondary, .fd-button--link {
+    color: #009cdf;
+    background-color: transparent; }
+    .fd-button--text:hover, .fd-modal__button-secondary:hover, .fd-button--text:focus, .fd-modal__button-secondary:focus, .fd-button--link:hover, .fd-button--link:focus {
+      background-color: transparent;
+      color: #008ac6; }
+    .fd-button--text:active, .fd-modal__button-secondary:active, .fd-button--text[aria-selected="true"], [aria-selected="true"].fd-modal__button-secondary, .fd-button--text.is-selected, .is-selected.fd-modal__button-secondary, .fd-button--text[aria-pressed="true"], [aria-pressed="true"].fd-modal__button-secondary, .fd-button--text.is-pressed, .is-pressed.fd-modal__button-secondary, .fd-button--text[aria-disabled="true"], [aria-disabled="true"].fd-modal__button-secondary, .fd-button--text.is-disabled, .is-disabled.fd-modal__button-secondary, .fd-button--text:disabled, .fd-modal__button-secondary:disabled, .fd-button--link:active, .fd-button--link[aria-selected="true"], .fd-button--link.is-selected, .fd-button--link[aria-pressed="true"], .fd-button--link.is-pressed, .fd-button--link[aria-disabled="true"], .fd-button--link.is-disabled, .fd-button--link:disabled {
+      background-color: transparent;
+      outline: none;
+      -webkit-box-shadow: none;
+              box-shadow: none; }
+    .fd-button--text:active, .fd-modal__button-secondary:active, .fd-button--text[aria-selected="true"], [aria-selected="true"].fd-modal__button-secondary, .fd-button--text.is-selected, .is-selected.fd-modal__button-secondary, .fd-button--text[aria-pressed="true"], [aria-pressed="true"].fd-modal__button-secondary, .fd-button--text.is-pressed, .is-pressed.fd-modal__button-secondary, .fd-button--link:active, .fd-button--link[aria-selected="true"], .fd-button--link.is-selected, .fd-button--link[aria-pressed="true"], .fd-button--link.is-pressed {
+      color: #0078ac; }
+    .fd-button--text[aria-disabled="true"], [aria-disabled="true"].fd-modal__button-secondary, .fd-button--text.is-disabled, .is-disabled.fd-modal__button-secondary, .fd-button--text:disabled, .fd-modal__button-secondary:disabled, .fd-button--link[aria-disabled="true"], .fd-button--link.is-disabled, .fd-button--link:disabled {
+      color: #7f90a4; }
+  .fd-button--link {
+    height: 28px;
+    line-height: 28px;
+    padding-left: 16px;
+    padding-right: 16px;
+    position: relative; }
+    .fd-button--link.fd-button--small {
+      height: 24px;
+      line-height: 24px; }
+    .fd-button--link::after {
+      content: "";
+      border-bottom: solid 2px transparent;
+      width: calc(100% - 16px*2);
+      height: 2px;
+      position: absolute;
+      bottom: 1px;
+      left: 0;
+      margin-left: 16px;
+      -webkit-transition: border-bottom-color 0.125s ease-in;
+      transition: border-bottom-color 0.125s ease-in; }
+    .fd-button--link:focus {
+      outline: none;
+      -webkit-box-shadow: none;
+              box-shadow: none; }
+    .fd-button--link:hover::after, .fd-button--link:focus::after, .fd-button--link:active::after, .fd-button--link[aria-selected="true"]::after, .fd-button--link.is-selected::after, .fd-button--link[aria-pressed="true"]::after, .fd-button--link.is-pressed::after {
+      border-bottom-color: #009cdf; }
+    .fd-button--link[aria-disabled="true"]::after, .fd-button--link.is-disabled::after, .fd-button--link:disabled::after {
+      display: none; }
+  .fd-button > *, .fd-modal__button-primary > *, .fd-modal__button-secondary > * {
+    display: inline-block;
+    vertical-align: top;
+    margin-right: 12px;
+    margin-top: 13px; }
+    .fd-button--icon > * {
+      margin-left: auto;
+      margin-right: auto; }
+    .fd-button--small > * {
+      margin-top: 11px; }
+    .fd-button--large > *, .fd-button--action-bar > * {
+      margin-top: 22px; }
+  .fd-button--action-bar {
+    font-size: 0.75rem;
+    line-height: 1.33334;
+    font-weight: 700;
+    text-transform: uppercase;
+    min-width: 135px;
+    line-height: 32px;
+    vertical-align: middle; }
+    .fd-button--action-bar > * {
+      display: block !important;
+      margin-top: 12px;
+      margin-left: auto;
+      margin-right: auto; }
+
+@font-face {
+  font-family: "FundamentalIcons";
+  src: url("FundamentalIcons.woff2") format("woff2"), url("FundamentalIcons.woff") format("woff");
+  font-weight: normal;
+  font-style: normal; }
+
+.fd-icon {
+  font-size: 1.125rem;
+  font-family: "FundamentalIcons";
+  line-height: 1;
+  font-style: normal;
+  font-weight: normal;
+  text-align: center;
+  display: inline-block;
+  text-decoration: inherit;
+  text-transform: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale; }
+  .fd-icon--medium {
+    font-size: 1.625rem; }
+  .fd-icon--large {
+    font-size: 2rem; }
+  .fd-icon::before {
+    display: inline;
+    text-align: center; }
+  .fd-icon--add::before {
+    content: ""; }
+  .fd-icon--arrow::before {
+    content: ""; }
+  .fd-icon--backarrow::before {
+    content: ""; }
+  .fd-icon--caution::before {
+    content: ""; }
+  .fd-icon--change::before {
+    content: ""; }
+  .fd-icon--checked::before {
+    content: ""; }
+  .fd-icon--chevron::before, .fd-pagination__item .fd-icon--chevron-back::before {
+    content: ""; }
+  .fd-icon--clone::before {
+    content: ""; }
+  .fd-icon--close::before {
+    content: ""; }
+  .fd-icon--collapse::before {
+    content: ""; }
+  .fd-icon--delete::before {
+    content: ""; }
+  .fd-icon--done::before {
+    content: ""; }
+  .fd-icon--doublechevron::before {
+    content: ""; }
+  .fd-icon--dragdroplist::before {
+    content: ""; }
+  .fd-icon--dragdropobject::before {
+    content: ""; }
+  .fd-icon--edit::before {
+    content: ""; }
+  .fd-icon--expand::before {
+    content: ""; }
+  .fd-icon--feedback::before {
+    content: ""; }
+  .fd-icon--filter::before {
+    content: ""; }
+  .fd-icon--filterremove::before {
+    content: ""; }
+  .fd-icon--grid::before {
+    content: ""; }
+  .fd-icon--help::before {
+    content: ""; }
+  .fd-icon--infoon::before {
+    content: ""; }
+  .fd-icon--link::before {
+    content: ""; }
+  .fd-icon--list::before {
+    content: ""; }
+  .fd-icon--localization::before {
+    content: ""; }
+  .fd-icon--lock::before {
+    content: ""; }
+  .fd-icon--maximize::before {
+    content: ""; }
+  .fd-icon--minimize::before {
+    content: ""; }
+  .fd-icon--more::before {
+    content: ""; }
+  .fd-icon--noimage::before {
+    content: ""; }
+  .fd-icon--options::before {
+    content: ""; }
+  .fd-icon--search::before {
+    content: ""; }
+  .fd-icon--sort::before {
+    content: ""; }
+  .fd-icon--sync::before {
+    content: ""; }
+  .fd-icon--top::before {
+    content: ""; }
+  .fd-icon--visibilityoff::before {
+    content: ""; }
+  .fd-icon--visibilityon::before {
+    content: ""; }
+  .fd-icon--warning::before {
+    content: ""; }
+
+/*!
+.fd-pagination
+*/
+.fd-pagination {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #21262c;
+  font-size: 0.875rem;
+  line-height: 1.42858;
+  font-weight: 400;
+  display: inline-block;
+  margin-bottom: 0;
+  padding-left: 0;
+  list-style: none; }
+  .fd-pagination__link {
+    color: #009cdf;
+    background-color: transparent;
+    padding-left: 12px;
+    padding-right: 12px;
+    position: relative; }
+    .fd-pagination__link::after {
+      content: "";
+      border-bottom: solid 2px transparent;
+      width: calc(100% - 8px*2);
+      height: 2px;
+      position: absolute;
+      bottom: -6px;
+      left: 0;
+      margin-left: 8px; }
+    .fd-pagination__link:hover, .fd-pagination__link:focus {
+      color: #008ac6;
+      text-decoration: none; }
+      .fd-pagination__link:hover::after, .fd-pagination__link:focus::after {
+        border-bottom-color: #008ac6; }
+    .fd-pagination__link:active, .fd-pagination__link[aria-selected="true"], .fd-pagination__link.is-selected {
+      background-color: transparent;
+      outline: none;
+      -webkit-box-shadow: none;
+              box-shadow: none; }
+      .fd-pagination__link:active::after, .fd-pagination__link[aria-selected="true"]::after, .fd-pagination__link.is-selected::after {
+        border-bottom-color: transparent; }
+    .fd-pagination__link[aria-disabled="true"], .fd-pagination__link.is-disabled {
+      color: #7f90a4;
+      text-decoration: none;
+      cursor: default; }
+      .fd-pagination__link[aria-disabled="true"]::after, .fd-pagination__link.is-disabled::after {
+        border-bottom-color: transparent; }
+    .fd-pagination__link:active, .fd-pagination__link[aria-selected="true"], .fd-pagination__link.is-selected {
+      color: #21262c;
+      text-decoration: none;
+      cursor: default; }
+  .fd-pagination__item {
+    display: inline-block; }
+    .fd-pagination__item .fd-icon--chevron-back {
+      -webkit-transform: rotate(180deg);
+      transform: rotate(180deg); }
+  .fd-pagination__more {
+    font-size: 0.75rem;
+    line-height: 1.33334;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: #21262c;
+    vertical-align: sub;
+    padding-left: 12px;
+    padding-right: 12px; }
+    .fd-pagination__more:hover, .fd-pagination__more:focus {
+      background-color: transparent;
+      color: #21262c;
+      cursor: default; }
+  .fd-pagination__total {
+    color: #7f90a4; }
+
+/*!
+.fd-table
+    thead
+    tbody
+        tr+([aria-selected])
+*/
+.fd-table {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #21262c;
+  width: 100%;
+  max-width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 20px;
+  border-top: solid 1px #ccdaeb; }
+  .fd-table:last-child {
+    margin-bottom: 0;
+    margin-right: 0; }
+  .fd-table tr {
+    -webkit-transition: background-color 0.125s ease-in;
+    transition: background-color 0.125s ease-in; }
+    .fd-table tr:hover {
+      background-color: #f1f5f9; }
+    .fd-table tr.is-selected, .fd-table tr[aria-selected="true"] {
+      background-color: #dee7f2; }
+  .fd-table thead {
+    font-size: 0.875rem;
+    line-height: 1.42858;
+    font-weight: 400;
+    color: #7f90a4; }
+    .fd-table thead tr:hover {
+      background-color: inherit; }
+    .fd-table thead td,
+    .fd-table thead th {
+      border: none; }
+  .fd-table td,
+  .fd-table th {
+    text-align: left;
+    padding: 12px 32px 12px 0;
+    border-style: solid;
+    border-width: 1px 0;
+    border-color: #ccdaeb; }
+    .fd-table td:first-child,
+    .fd-table th:first-child {
+      padding-left: 32px; }
+  .fd-table a {
+    color: #009cdf; }
+    .fd-table a:hover {
+      color: #009cdf; }
+
+/*!
+.fd-tabs+()
+    .fd-tabs__item?
+    .fd-tabs__link+((.is-selected|[aria-selected=true]),(.is-disabled|[aria-disabled=true]))
+.fd-tabs__panel+([aria-expanded]|.is-expanded)
+*/
+.fd-tabs {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #21262c;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
+  padding-left: 0;
+  margin-bottom: 40px;
+  list-style: none;
+  border-bottom: solid 1px #ccdaeb; }
+  .fd-tabs__link {
+    display: block;
+    padding: 12px 20px;
+    font-size: 1.125rem;
+    line-height: 1.33334;
+    font-family: Roboto, sans-serif;
+    font-weight: 500;
+    text-transform: uppercase;
+    color: #009cdf;
+    border-bottom: solid 2px transparent;
+    -webkit-transition: all 0.125s ease-in;
+    transition: all 0.125s ease-in;
+    cursor: pointer; }
+    .fd-tabs__link:hover {
+      border-bottom: solid 2px #009cdf;
+      color: #008ac6; }
+    .fd-tabs__link.is-selected, .fd-tabs__link[aria-selected="true"] {
+      color: #21262c;
+      border-bottom: solid 2px #009cdf; }
+    .fd-tabs__link.is-disabled, .fd-tabs__link[aria-disabled="true"] {
+      color: #7f90a4;
+      cursor: not-allowed; }
+      .fd-tabs__link.is-disabled:hover, .fd-tabs__link[aria-disabled="true"]:hover {
+        border-bottom-color: transparent; }
+  .fd-tabs__panel[aria-expanded="false"] {
+    display: none; }
+  .fd-tabs__panel.is-expanded, .fd-tabs__panel[aria-expanded="true"] {
+    display: block; }
+
+/*!
+.fd-button+( (--small | --large), --icon, --text, --link, --action-bar)+( (.is-disabled | [aria-disabled=true]) | (.is-selected | [aria-selected=true] | (.is-pressed | [aria-pressed=true]))
+*/
+.fd-button, .fd-modal__button-primary, .fd-modal__button-secondary {
+  margin: 0;
+  padding: 0;
+  font-smoothing: antialiased;
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none;
+  outline: 0;
+  border: 0;
+  display: inline-block;
+  text-decoration: none;
+  cursor: pointer;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
+  vertical-align: middle;
+  white-space: nowrap;
+  background-color: transparent;
+  font-size: 1.125rem;
+  line-height: 1.33334;
+  font-family: Roboto, sans-serif;
+  font-weight: 500;
+  display: inline-block;
+  background-color: #009cdf;
+  -webkit-transition: background-color 0.125s ease-in;
+  transition: background-color 0.125s ease-in;
+  color: #f6f8f9;
+  max-height: 52px;
+  height: 52px;
+  line-height: 52px;
+  padding-left: 20px;
+  padding-right: 20px;
+  text-align: center;
+  text-transform: uppercase;
+  border-radius: 0; }
+  .fd-button--small {
+    font-size: 1rem;
+    line-height: 1.5;
+    font-weight: 400;
+    font-weight: 600;
+    max-height: 40px;
+    height: 40px;
+    line-height: 40px;
+    padding-left: 16px;
+    padding-right: 16px; }
+  .fd-button--large, .fd-button--action-bar {
+    font-size: 1.25rem;
+    line-height: 1.4;
+    font-weight: 600;
+    max-height: 76px;
+    height: 76px;
+    line-height: 76px;
+    padding-left: 28px;
+    padding-right: 28px; }
+  .fd-button:hover, .fd-modal__button-primary:hover, .fd-modal__button-secondary:hover {
+    background-color: #008ac6;
+    color: #f6f8f9;
+    text-decoration: none; }
+  .fd-button:focus, .fd-modal__button-primary:focus, .fd-modal__button-secondary:focus {
+    color: #f6f8f9;
+    -webkit-box-shadow: 0 0 4px 1px #8a8fa1;
+            box-shadow: 0 0 4px 1px #8a8fa1;
+    outline: solid 2px #2dc0ff; }
+  .fd-button:active, .fd-modal__button-primary:active, .fd-modal__button-secondary:active, .fd-button.is-active, .is-active.fd-modal__button-primary, .is-active.fd-modal__button-secondary, .fd-button[aria-selected="true"], [aria-selected="true"].fd-modal__button-primary, [aria-selected="true"].fd-modal__button-secondary, .fd-button.is-selected, .is-selected.fd-modal__button-primary, .is-selected.fd-modal__button-secondary, .fd-button[aria-pressed="true"], [aria-pressed="true"].fd-modal__button-primary, [aria-pressed="true"].fd-modal__button-secondary, .fd-button.is-pressed, .is-pressed.fd-modal__button-primary, .is-pressed.fd-modal__button-secondary {
+    background-color: #0078ac;
+    color: #f6f8f9; }
+  .fd-button[aria-disabled="true"], [aria-disabled="true"].fd-modal__button-primary, [aria-disabled="true"].fd-modal__button-secondary, .fd-button.is-disabled, .is-disabled.fd-modal__button-primary, .is-disabled.fd-modal__button-secondary, .fd-button:disabled, .fd-modal__button-primary:disabled, .fd-modal__button-secondary:disabled {
+    outline: solid 1px #d7d7d7;
+    color: #7f90a4;
+    background-color: #f9fbfc;
+    cursor: not-allowed; }
+  .fd-button--text, .fd-modal__button-secondary, .fd-button--link {
+    color: #009cdf;
+    background-color: transparent; }
+    .fd-button--text:hover, .fd-modal__button-secondary:hover, .fd-button--text:focus, .fd-modal__button-secondary:focus, .fd-button--link:hover, .fd-button--link:focus {
+      background-color: transparent;
+      color: #008ac6; }
+    .fd-button--text:active, .fd-modal__button-secondary:active, .fd-button--text[aria-selected="true"], [aria-selected="true"].fd-modal__button-secondary, .fd-button--text.is-selected, .is-selected.fd-modal__button-secondary, .fd-button--text[aria-pressed="true"], [aria-pressed="true"].fd-modal__button-secondary, .fd-button--text.is-pressed, .is-pressed.fd-modal__button-secondary, .fd-button--text[aria-disabled="true"], [aria-disabled="true"].fd-modal__button-secondary, .fd-button--text.is-disabled, .is-disabled.fd-modal__button-secondary, .fd-button--text:disabled, .fd-modal__button-secondary:disabled, .fd-button--link:active, .fd-button--link[aria-selected="true"], .fd-button--link.is-selected, .fd-button--link[aria-pressed="true"], .fd-button--link.is-pressed, .fd-button--link[aria-disabled="true"], .fd-button--link.is-disabled, .fd-button--link:disabled {
+      background-color: transparent;
+      outline: none;
+      -webkit-box-shadow: none;
+              box-shadow: none; }
+    .fd-button--text:active, .fd-modal__button-secondary:active, .fd-button--text[aria-selected="true"], [aria-selected="true"].fd-modal__button-secondary, .fd-button--text.is-selected, .is-selected.fd-modal__button-secondary, .fd-button--text[aria-pressed="true"], [aria-pressed="true"].fd-modal__button-secondary, .fd-button--text.is-pressed, .is-pressed.fd-modal__button-secondary, .fd-button--link:active, .fd-button--link[aria-selected="true"], .fd-button--link.is-selected, .fd-button--link[aria-pressed="true"], .fd-button--link.is-pressed {
+      color: #0078ac; }
+    .fd-button--text[aria-disabled="true"], [aria-disabled="true"].fd-modal__button-secondary, .fd-button--text.is-disabled, .is-disabled.fd-modal__button-secondary, .fd-button--text:disabled, .fd-modal__button-secondary:disabled, .fd-button--link[aria-disabled="true"], .fd-button--link.is-disabled, .fd-button--link:disabled {
+      color: #7f90a4; }
+  .fd-button--link {
+    height: 28px;
+    line-height: 28px;
+    padding-left: 16px;
+    padding-right: 16px;
+    position: relative; }
+    .fd-button--link.fd-button--small {
+      height: 24px;
+      line-height: 24px; }
+    .fd-button--link::after {
+      content: "";
+      border-bottom: solid 2px transparent;
+      width: calc(100% - 16px*2);
+      height: 2px;
+      position: absolute;
+      bottom: 1px;
+      left: 0;
+      margin-left: 16px;
+      -webkit-transition: border-bottom-color 0.125s ease-in;
+      transition: border-bottom-color 0.125s ease-in; }
+    .fd-button--link:focus {
+      outline: none;
+      -webkit-box-shadow: none;
+              box-shadow: none; }
+    .fd-button--link:hover::after, .fd-button--link:focus::after, .fd-button--link:active::after, .fd-button--link[aria-selected="true"]::after, .fd-button--link.is-selected::after, .fd-button--link[aria-pressed="true"]::after, .fd-button--link.is-pressed::after {
+      border-bottom-color: #009cdf; }
+    .fd-button--link[aria-disabled="true"]::after, .fd-button--link.is-disabled::after, .fd-button--link:disabled::after {
+      display: none; }
+  .fd-button > *, .fd-modal__button-primary > *, .fd-modal__button-secondary > * {
+    display: inline-block;
+    vertical-align: top;
+    margin-right: 12px;
+    margin-top: 13px; }
+    .fd-button--icon > * {
+      margin-left: auto;
+      margin-right: auto; }
+    .fd-button--small > * {
+      margin-top: 11px; }
+    .fd-button--large > *, .fd-button--action-bar > * {
+      margin-top: 22px; }
+  .fd-button--action-bar {
+    font-size: 0.75rem;
+    line-height: 1.33334;
+    font-weight: 700;
+    text-transform: uppercase;
+    min-width: 135px;
+    line-height: 32px;
+    vertical-align: middle; }
+    .fd-button--action-bar > * {
+      display: block !important;
+      margin-top: 12px;
+      margin-left: auto;
+      margin-right: auto; }
+
+/*!
+.fd-modal
+    .fd-modal__header
+        .fd-form__title
+    .fd-form__body
+    .fd-form__footer-items
+      .fd-modal__button-primary
+      .fd-modal__button-secondary
+*/
+.fd-modal {
+  width: 700px;
+  margin: 32px auto; }
+  .fd-modal__content {
+    background-color: #ffffff; }
+    .fd-modal__content button {
+      float: right; }
+  .fd-modal__header {
+    border-bottom: 1px solid #ccdaeb;
+    padding-left: 40px;
+    padding-top: 40px;
+    padding-right: 20px; }
+  .fd-modal__title {
+    font-size: 2.1875rem;
+    line-height: 1.25715;
+    font-family: Roboto, sans-serif;
+    font-weight: 500; }
+  .fd-modal__body {
+    padding: 40px; }
+  .fd-modal__footer-items {
+    display: block;
+    overflow: auto;
+    border-top: 1px solid #ccdaeb;
+    padding: 40px;
+    padding-top: 20px; }
+
+/*!
+.fd-tree+(--header)
+    .fd-tree__group+(--sublevel-1...-6, ([aria-hidden] | .is-hidden))
+    .fd-tree__item
+        .fd-tree__row+(--header, ([aria-selected] | .is-selected))
+            .fd-tree__col+(--control, --actions)
+                .fd-tree__control+([aria-pressed] | .is-pressed)
+*/
+.fd-tree {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #21262c;
+  position: relative;
+  width: 100%;
+  max-width: 100%;
+  border-bottom: solid 1px #ccdaeb;
+  margin-bottom: 20px;
+  margin-left: 0; }
+  .fd-tree:last-child {
+    margin-bottom: 0;
+    margin-right: 0; }
+  .fd-tree:last-child {
+    margin-bottom: 0; }
+  .fd-tree--header {
+    border-bottom: 0;
+    border-top: solid 1px #ccdaeb;
+    margin-bottom: 0; }
+  .fd-tree__group {
+    -webkit-transition: opacity 0.125s linear;
+    transition: opacity 0.125s linear;
+    max-height: auto;
+    opacity: 1;
+    margin-bottom: 0;
+    margin-left: 0; }
+    .fd-tree__group.is-hidden, .fd-tree__group[aria-hidden="true"] {
+      max-height: 0;
+      opacity: 0;
+      overflow: hidden; }
+  .fd-tree__item {
+    border-top: solid 1px #ccdaeb;
+    margin-bottom: 0;
+    list-style: none; }
+  .fd-tree__row {
+    padding: 0 32px;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-align: center;
+        -ms-flex-align: center;
+            align-items: center;
+    position: relative;
+    -webkit-transition: background-color 0.125s ease-in;
+    transition: background-color 0.125s ease-in; }
+    .fd-tree__row:hover {
+      background-color: #f1f5f9; }
+    .fd-tree__row--header {
+      font-size: 0.875rem;
+      line-height: 1.42858;
+      font-weight: 400;
+      font-weight: 700;
+      color: #7f90a4; }
+      .fd-tree__row--header:hover {
+        background-color: transparent; }
+    .fd-tree__row.is-selected, .fd-tree__row[aria-selected="true"] {
+      background-color: #dee7f2; }
+  .fd-tree__col {
+    -webkit-box-flex: 1;
+        -ms-flex: 1;
+            flex: 1;
+    padding: 12px 0;
+    padding-left: 30px; }
+    .fd-tree__col--control {
+      -webkit-box-flex: 1;
+          -ms-flex: auto;
+              flex: auto;
+      width: 25%; }
+      .fd-tree__group--sublevel-1 .fd-tree__col--control {
+        padding-left: 60px; }
+      .fd-tree__group--sublevel-2 .fd-tree__col--control {
+        padding-left: 90px; }
+      .fd-tree__group--sublevel-3 .fd-tree__col--control {
+        padding-left: 120px; }
+      .fd-tree__group--sublevel-4 .fd-tree__col--control {
+        padding-left: 150px; }
+      .fd-tree__group--sublevel-5 .fd-tree__col--control {
+        padding-left: 180px; }
+      .fd-tree__group--sublevel-6 .fd-tree__col--control {
+        padding-left: 210px; }
+      .fd-tree__group--sublevel-7 .fd-tree__col--control {
+        padding-left: 240px; }
+      .fd-tree__group--sublevel-8 .fd-tree__col--control {
+        padding-left: 270px; }
+    .fd-tree__col--actions {
+      padding-top: 0;
+      padding-bottom: 0;
+      text-align: right; }
+  .fd-tree__control {
+    margin: 0;
+    padding: 0;
+    font-smoothing: antialiased;
+    -webkit-appearance: none;
+       -moz-appearance: none;
+            appearance: none;
+    outline: 0;
+    border: 0;
+    display: inline-block;
+    text-decoration: none;
+    cursor: pointer;
+    -webkit-user-select: none;
+       -moz-user-select: none;
+        -ms-user-select: none;
+            user-select: none;
+    vertical-align: middle;
+    white-space: nowrap;
+    background-color: transparent;
+    position: absolute;
+    top: calc(50% - 18px/2);
+    margin-left: -30px;
+    width: 18px;
+    height: 18px;
+    margin-right: 12px;
+    background: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMiIgaGVpZ2h0PSI5Ij48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiMwMDhGRDIiIGQ9Ik0xMS45MzUgMS40NzVMNi4xODggNy45MjdhLjI2NC4yNjQgMCAwIDEtLjM3OCAwTC4wNjUgMS40NzVhLjIzNi4yMzYgMCAwIDEgLjAyNi0uMzQzTDEuMzgxLjA1OGEuMjUzLjI1MyAwIDAgMSAuMTYzLS4wNTlMMS41NjMgMGEuMjUyLjI1MiAwIDAgMSAuMTcxLjA4NWw0LjI2NSA0Ljg4IDQuMjY3LTQuODhhLjI1Mi4yNTIgMCAwIDEgLjM1Mi0uMDI3bDEuMjkxIDEuMDc0Yy4wNS4wNDIuMDgxLjEwMi4wODYuMTY2YS4yMzYuMjM2IDAgMCAxLS4wNi4xNzd6Ii8+PC9zdmc+") no-repeat 50%;
+    background-size: contain;
+    -webkit-transform: rotate(-90deg);
+            transform: rotate(-90deg);
+    vertical-align: middle;
+    -webkit-transition: -webkit-transform 0.125s linear;
+    transition: -webkit-transform 0.125s linear;
+    transition: transform 0.125s linear;
+    transition: transform 0.125s linear, -webkit-transform 0.125s linear; }
+    .fd-tree__control[aria-pressed="true"], .fd-tree__control.is-pressed {
+      -webkit-transform: rotate(0);
+              transform: rotate(0); }
+  .fd-tree a {
+    color: #009cdf; }
+    .fd-tree a:hover {
+      color: #009cdf; }
+
+/*!
+.fd-list-group
+  .fd-list-group__item
+      .fd-list-group__action
+*/
+.fd-list-group {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #21262c;
+  margin-left: 0; }
+  .fd-list-group__item {
+    list-style: none;
+    border: 1px solid #e4e4e4;
+    border-top: none;
+    padding: 16px;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    position: relative;
+    background-color: none;
+    -webkit-transition: background-color 0.125s ease-in;
+    transition: background-color 0.125s ease-in; }
+    .fd-list-group__item:first-child {
+      border-top: 1px solid #e4e4e4; }
+    .fd-list-group__item:hover {
+      background-color: #f1f5f9; }
+  .fd-list-group__action {
+    -webkit-box-flex: 1;
+        -ms-flex: 1;
+            flex: 1;
+    text-align: right;
+    position: relative;
+    display: inline-block;
+    max-height: 40px;
+    padding-top: 4px;
+    top: -16px;
+    margin-bottom: -32px;
+    right: -16px; }
+
+/*!
+.fd-tooltip
+    .fd-tooltip__content+(left, right, bottom-left, bottom-right)
+*/
+.fd-inline-help {
+  font-size: 0.875rem;
+  line-height: 1.42858;
+  font-weight: 400;
+  position: relative;
+  display: inline-block;
+  width: 18px;
+  height: 18px;
+  top: 3px; }
+  .fd-inline-help::before {
+    content: "?";
+    width: 18px;
+    height: 18px;
+    font-style: normal;
+    position: absolute;
+    left: 0;
+    color: #ffffff;
+    border-radius: 50%;
+    background-color: #63758b;
+    text-align: center; }
+  .fd-inline-help__content {
+    font-size: 0.8125rem;
+    line-height: 1.53847;
+    font-weight: 400;
+    background: #63758b;
+    padding: 12px;
+    display: block;
+    position: absolute;
+    color: #ffffff;
+    top: 30px;
+    right: -12px;
+    min-width: 350px;
+    visibility: hidden;
+    opacity: 0;
+    -webkit-transition: opacity 0.125s ease-in;
+    transition: opacity 0.125s ease-in;
+    text-align: left;
+    z-index: 1; }
+    .fd-inline-help__content::before {
+      width: 0;
+      height: 0;
+      border-style: solid;
+      border-width: 0 10px 10px 10px;
+      border-color: transparent transparent #63758b transparent;
+      position: absolute;
+      content: "";
+      top: -10px;
+      right: 10px; }
+    .fd-inline-help__content--left {
+      top: -12px;
+      left: 30px; }
+      .fd-inline-help__content--left::before {
+        top: 15px;
+        left: -15px;
+        -webkit-transform: rotate(-90deg);
+                transform: rotate(-90deg); }
+    .fd-inline-help__content--right {
+      top: -12px;
+      right: 30px; }
+      .fd-inline-help__content--right::before {
+        top: 15px;
+        right: -15px;
+        -webkit-transform: rotate(90deg);
+                transform: rotate(90deg); }
+    .fd-inline-help__content--bottom-left {
+      left: -10px; }
+      .fd-inline-help__content--bottom-left::before {
+        top: -10px;
+        left: 10px; }
+  .fd-inline-help:hover .fd-inline-help__content {
+    visibility: visible;
+    opacity: 1;
+    overflow: visible; }
+
+/*!
+.fd-nav+(--vertical)
+    .fd-nav__item
+    .fd-nav__link+((.is-selected|[aria-selected=true]),(.is-disabled|[aria-disabled=true]))
+*/
+.fd-nav {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #21262c;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
+  padding-left: 0;
+  margin-bottom: 0;
+  list-style: none; }
+  .fd-nav--vertical {
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+        -ms-flex-direction: column;
+            flex-direction: column; }
+  .fd-nav__link {
+    display: block;
+    padding: 8px; }
+    .fd-nav__link.is-selected, .fd-nav__link[aria-selected="true"] {
+      color: #21262c; }
+
+/*!
+.fd-tabs+()
+    .fd-tabs__item?
+    .fd-tabs__link+((.is-selected|[aria-selected=true]),(.is-disabled|[aria-disabled=true]))
+.fd-tabs__panel+([aria-expanded]|.is-expanded)
+*/
+.fd-tabs {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #21262c;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
+  padding-left: 0;
+  margin-bottom: 40px;
+  list-style: none;
+  border-bottom: solid 1px #ccdaeb; }
+  .fd-tabs__link {
+    display: block;
+    padding: 12px 20px;
+    font-size: 1.125rem;
+    line-height: 1.33334;
+    font-family: Roboto, sans-serif;
+    font-weight: 500;
+    text-transform: uppercase;
+    color: #009cdf;
+    border-bottom: solid 2px transparent;
+    -webkit-transition: all 0.125s ease-in;
+    transition: all 0.125s ease-in;
+    cursor: pointer; }
+    .fd-tabs__link:hover {
+      border-bottom: solid 2px #009cdf;
+      color: #008ac6; }
+    .fd-tabs__link.is-selected, .fd-tabs__link[aria-selected="true"] {
+      color: #21262c;
+      border-bottom: solid 2px #009cdf; }
+    .fd-tabs__link.is-disabled, .fd-tabs__link[aria-disabled="true"] {
+      color: #7f90a4;
+      cursor: not-allowed; }
+      .fd-tabs__link.is-disabled:hover, .fd-tabs__link[aria-disabled="true"]:hover {
+        border-bottom-color: transparent; }
+  .fd-tabs__panel[aria-expanded="false"] {
+    display: none; }
+  .fd-tabs__panel.is-expanded, .fd-tabs__panel[aria-expanded="true"] {
+    display: block; }
+
+/*!
+.fd-toggle+(--no-border)
+    .fd-toggle__content+()
+    .fd-toggle__title+()
+*/
+.fd-toggle {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #21262c;
+  position: relative;
+  display: inline-block;
+  height: 40px;
+  width: 76px; }
+  .fd-toggle__switch {
+    height: 32px;
+    width: 32px;
+    border-radius: 50%;
+    position: absolute;
+    top: 4px;
+    left: 4px;
+    background-color: white;
+    -webkit-transition: left 0.125s ease-in;
+    transition: left 0.125s ease-in;
+    pointer-events: none; }
+  .fd-toggle input {
+    background-color: #ccdaeb;
+    border-radius: 20px;
+    width: 100%;
+    height: 100%;
+    border-color: transparent;
+    vertical-align: middle; }
+    .fd-toggle input:checked::after {
+      display: none; }
+    .fd-toggle input:checked + .fd-toggle__switch {
+      left: calc(50% + 2px); }
+    .fd-toggle input[disabled], .fd-toggle input.is-disabled, .fd-toggle input[aria-disabled="true"] {
+      border-color: #ccdaeb; }
+      .fd-toggle input[disabled] + .fd-toggle__switch, .fd-toggle input.is-disabled + .fd-toggle__switch, .fd-toggle input[aria-disabled="true"] + .fd-toggle__switch {
+        background-color: #d7d7d7; }
+  .fd-toggle--small {
+    height: 32px;
+    width: 60px; }
+    .fd-toggle--small input {
+      border-radius: 16px; }
+    .fd-toggle--small .fd-toggle__switch {
+      height: 24px;
+      width: 24px; }
+  .fd-toggle--large {
+    height: 52px;
+    width: 100px; }
+    .fd-toggle--large input {
+      border-radius: 26px; }
+    .fd-toggle--large .fd-toggle__switch {
+      height: 44px;
+      width: 44px; }
+
+/*!
+.fd-spinner+(.is-hidden|[aria-hidden=true])
+
+Inspired by line scale spinner from Load Awesome v1.1.0 (http://github.danielcardoso.net/load-awesome/)
+* Copyright 2015 Daniel Cardoso <@DanielCardoso>
+* Licensed under MIT
+*/
+.fd-spinner {
+  position: relative;
+  width: 29px;
+  height: 40px;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
+  margin: 0 auto; }
+  .fd-spinner.is-hidden, .fd-spinner[aria-hidden="true"] {
+    display: none; }
+  .is-busy, [aria-busy="true"] {
+    position: relative;
+    min-height: 40px; }
+    .is-busy::before, [aria-busy="true"]::before {
+      position: absolute;
+      background-color: rgba(255, 255, 255, 0.95);
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      z-index: 1;
+      content: ""; }
+    .is-busy .fd-spinner, [aria-busy="true"] .fd-spinner {
+      position: absolute;
+      z-index: 2;
+      left: calc(50% - 29px/2);
+      top: calc(50% - 40px/2); }
+  .fd-spinner::before, .fd-spinner::after {
+    content: "";
+    position: relative;
+    width: 5px;
+    height: 100%;
+    background-color: #009cdf; }
+  .fd-spinner div::before, .fd-spinner div::after {
+    content: "";
+    position: absolute;
+    width: 5px;
+    height: 100%;
+    background-color: #009cdf; }
+  .fd-spinner div::before {
+    left: 8px; }
+  .fd-spinner div::after {
+    right: 8px; }
+  .fd-spinner::before {
+    -webkit-animation: line-scale 1s infinite ease;
+            animation: line-scale 1s infinite ease;
+    -webkit-animation-delay: -1s;
+            animation-delay: -1s; }
+  .fd-spinner div::before {
+    -webkit-animation: line-scale 1s infinite ease;
+            animation: line-scale 1s infinite ease;
+    -webkit-animation-delay: -0.9s;
+            animation-delay: -0.9s; }
+  .fd-spinner div::after {
+    -webkit-animation: line-scale 1s infinite ease;
+            animation: line-scale 1s infinite ease;
+    -webkit-animation-delay: -0.8s;
+            animation-delay: -0.8s; }
+  .fd-spinner::after {
+    -webkit-animation: line-scale 1s infinite ease;
+            animation: line-scale 1s infinite ease;
+    -webkit-animation-delay: -0.7s;
+            animation-delay: -0.7s; }
+
+@-webkit-keyframes line-scale {
+  0%,
+  40%,
+  100% {
+    -webkit-transform: scaleY(0.4);
+            transform: scaleY(0.4); }
+  80% {
+    -webkit-transform: scaleY(1);
+            transform: scaleY(1); } }
+
+@keyframes line-scale {
+  0%,
+  40%,
+  100% {
+    -webkit-transform: scaleY(0.4);
+            transform: scaleY(0.4); }
+  80% {
+    -webkit-transform: scaleY(1);
+            transform: scaleY(1); } }
+
+/*!
+.fd-image+((--rounded|--circle), (--xs|--s|--m|--l|--xl|--xxl), (--product|--profile))
+*/
+.fd-image {
+  display: inline-block;
+  vertical-align: middle;
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: 50%; }
+  .fd-image--xs {
+    width: 20px;
+    height: 20px; }
+  .fd-image--s {
+    width: 36px;
+    height: 36px; }
+  .fd-image--m {
+    width: 52px;
+    height: 52px; }
+  .fd-image--l {
+    width: 72px;
+    height: 72px; }
+  .fd-image--xl {
+    width: 92px;
+    height: 92px; }
+  .fd-image--xxl {
+    width: 120px;
+    height: 120px; }
+  .fd-image--rounded {
+    border-radius: 8px; }
+    .fd-image--rounded.fd-image--xs, .fd-image--rounded.fd-image--s {
+      border-radius: 4px; }
+  .fd-image--circle {
+    border-radius: 50%; }
+  .fd-image--profile, .fd-image--product {
+    background-color: #d7d7d7; }
+  .fd-image--profile {
+    background-image: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTIiIGhlaWdodD0iNTIiIHZpZXdCb3g9IjAgMCA1MiA1MiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU+dG4taW1hZ2UtYmFja2dyb3VuZC1pbWFnZS0tcHJvZmlsZTwvdGl0bGU+PHBhdGggZD0iTTI2IDM5di0xaDExYy0yLjc1NC42NjctNi40MiAxLTExIDF6bTAgMGMtMi4xNDggMC01LjgxNS0uMzMzLTExLTFoMTF2MXptMTEtMUgxNWMwLTUuNTU4IDMuNDY0LTEwLjIzNCA4LjE2NS0xMS41OThBNy4wMDIgNy4wMDIgMCAwIDEgMjYgMTNhNyA3IDAgMCAxIDIuODM1IDEzLjQwMkMzMy41MzYgMjcuNzY2IDM3IDMyLjQ0MiAzNyAzOHoiIGZpbGwtcnVsZT0ibm9uemVybyIgZmlsbD0iI0ZGRiIvPjwvc3ZnPg=="); }
+  .fd-image--product {
+    background-image: url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTIiIGhlaWdodD0iNTIiIHZpZXdCb3g9IjAgMCA1MiA1MiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU+dG4taW1hZ2UtYmFja2dyb3VuZC1pbWFnZS0tcHJvZHVjdDwvdGl0bGU+PHBhdGggZD0iTTEzLjg3NiAxOC4yMjNsNS44NzQtMi41NTUgMTEgNS45MzQtNS4yOTEgMi4xNzgtMTEuNTgzLTUuNTU3ek0xMyAzMy4wNDN2LTE0LjAzbDExLjkxNyA1LjcxdjE0LjA5MWwtMTEuNTktNS4yNzVhLjU0LjU0IDAgMCAxLS4zMjctLjQ5N3ptMy4yNS05LjIwOXY1LjQxN2EuNTQuNTQgMCAwIDAgLjMxNy40OTNsNS40MTcgMi43MDhjLjM1OC4xNjMuNzY2LS4xLjc2Ni0uNDkzdi01LjQxN2EuNTQyLjU0MiAwIDAgMC0uMzE3LS40OTJsLTUuNDE3LTIuNzA5YS41NDIuNTQyIDAgMCAwLS43NjYuNDkzem05Ljc1Ljg4OWwxMy01LjcxdjE0LjAzYS41NC41NCAwIDAgMS0uMzI2LjQ5NkwyNiAzOC44MTVWMjQuNzIzem0xMi4xMjQtNi41bC02LjE0IDIuODEzLTEwLjk3LTUuOTE3IDQuNzctMi4wNzNhLjUzNi41MzYgMCAwIDEgLjQzMiAwbDExLjkwOCA1LjE3N3oiIGZpbGwtcnVsZT0ibm9uemVybyIgZmlsbD0iI0ZGRiIvPjwvc3ZnPg=="); }
+
+@font-face {
+  font-family: "FundamentalIcons";
+  src: url("FundamentalIcons.woff2") format("woff2"), url("FundamentalIcons.woff") format("woff");
+  font-weight: normal;
+  font-style: normal; }
+
+.fd-icon {
+  font-size: 1.125rem;
+  font-family: "FundamentalIcons";
+  line-height: 1;
+  font-style: normal;
+  font-weight: normal;
+  text-align: center;
+  display: inline-block;
+  text-decoration: inherit;
+  text-transform: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale; }
+  .fd-icon--medium {
+    font-size: 1.625rem; }
+  .fd-icon--large {
+    font-size: 2rem; }
+  .fd-icon::before {
+    display: inline;
+    text-align: center; }
+  .fd-icon--add::before {
+    content: ""; }
+  .fd-icon--arrow::before {
+    content: ""; }
+  .fd-icon--backarrow::before {
+    content: ""; }
+  .fd-icon--caution::before {
+    content: ""; }
+  .fd-icon--change::before {
+    content: ""; }
+  .fd-icon--checked::before {
+    content: ""; }
+  .fd-icon--chevron::before, .fd-pagination__item .fd-icon--chevron-back::before {
+    content: ""; }
+  .fd-icon--clone::before {
+    content: ""; }
+  .fd-icon--close::before {
+    content: ""; }
+  .fd-icon--collapse::before {
+    content: ""; }
+  .fd-icon--delete::before {
+    content: ""; }
+  .fd-icon--done::before {
+    content: ""; }
+  .fd-icon--doublechevron::before {
+    content: ""; }
+  .fd-icon--dragdroplist::before {
+    content: ""; }
+  .fd-icon--dragdropobject::before {
+    content: ""; }
+  .fd-icon--edit::before {
+    content: ""; }
+  .fd-icon--expand::before {
+    content: ""; }
+  .fd-icon--feedback::before {
+    content: ""; }
+  .fd-icon--filter::before {
+    content: ""; }
+  .fd-icon--filterremove::before {
+    content: ""; }
+  .fd-icon--grid::before {
+    content: ""; }
+  .fd-icon--help::before {
+    content: ""; }
+  .fd-icon--infoon::before {
+    content: ""; }
+  .fd-icon--link::before {
+    content: ""; }
+  .fd-icon--list::before {
+    content: ""; }
+  .fd-icon--localization::before {
+    content: ""; }
+  .fd-icon--lock::before {
+    content: ""; }
+  .fd-icon--maximize::before {
+    content: ""; }
+  .fd-icon--minimize::before {
+    content: ""; }
+  .fd-icon--more::before {
+    content: ""; }
+  .fd-icon--noimage::before {
+    content: ""; }
+  .fd-icon--options::before {
+    content: ""; }
+  .fd-icon--search::before {
+    content: ""; }
+  .fd-icon--sort::before {
+    content: ""; }
+  .fd-icon--sync::before {
+    content: ""; }
+  .fd-icon--top::before {
+    content: ""; }
+  .fd-icon--visibilityoff::before {
+    content: ""; }
+  .fd-icon--visibilityon::before {
+    content: ""; }
+  .fd-icon--warning::before {
+    content: ""; }
+
+.fd-text-transform-none {
+  text-transform: none !important; }
+
+.fd-has-font-weight-bold {
+  font-weight: bold !important; }
+
+.fd-has-font-style-italic {
+  font-style: italic !important; }
+
+.fd-has-text-align-center {
+  text-align: center !important; }
+
+.fd-has-text-align-right {
+  text-align: right !important; }
+
+.fd-has-float-left {
+  float: left !important; }
+
+.fd-has-float-right {
+  float: right !important; }
+
+.fd-has-border-radius-50percent {
+  border-radius: 50% !important; }
+
+.fd-has-type-minus-3 {
+  font-size: 0.75rem;
+  line-height: 1.33334;
+  font-weight: 700;
+  text-transform: uppercase; }
+
+.fd-has-type-minus-2 {
+  font-size: 0.8125rem;
+  line-height: 1.53847;
+  font-weight: 400; }
+
+.fd-has-type-minus-1 {
+  font-size: 0.875rem;
+  line-height: 1.42858;
+  font-weight: 400; }
+
+.fd-has-type-base,
+.fd-has-type-0 {
+  font-size: 1rem;
+  line-height: 1.5;
+  font-weight: 400; }
+
+.fd-has-type-1 {
+  font-size: 1.125rem;
+  line-height: 1.33334;
+  font-weight: 600; }
+
+.fd-has-type-2 {
+  font-size: 1.25rem;
+  line-height: 1.4;
+  font-weight: 600; }
+
+.fd-has-type-3 {
+  font-size: 1.625rem;
+  line-height: 1.23077;
+  font-family: Roboto, sans-serif;
+  font-weight: 600; }
+
+.fd-has-type-4 {
+  font-size: 2.1875rem;
+  line-height: 1.25715;
+  font-family: Roboto, sans-serif;
+  font-weight: 700; }
+
+.fd-has-type-5 {
+  font-size: 2.8125rem;
+  line-height: 1.15556;
+  font-family: Roboto, sans-serif;
+  font-weight: 500; }
+
+.fd-has-font-family-body {
+  font-family: 'Open Sans', sans-serif; }
+
+.fd-has-font-family-header {
+  font-family: Roboto, sans-serif; }
+
+.fd-has-font-family-code {
+  font-family: 'Courier New', monospace; }
+
+.fd-has-font-weight-light {
+  font-weight: 300; }
+
+.fd-has-font-weight-reg {
+  font-weight: 400; }
+
+.fd-has-font-weight-med {
+  font-weight: 500; }
+
+.fd-has-font-weight-semi {
+  font-weight: 600; }
+
+.fd-has-font-weight-bold {
+  font-weight: 700; }
+
+.fd-has-color-primary,
+.fd-has-color-primary-1 {
+  color: #006fbb !important; }
+
+.fd-has-color-primary-2 {
+  color: #27394f !important; }
+
+.fd-has-color-action,
+.fd-has-color-action-1 {
+  color: #009cdf !important; }
+
+.fd-has-color-action-2 {
+  color: #8D9DBC !important; }
+
+.fd-has-color-text,
+.fd-has-color-text-1 {
+  color: #21262c !important; }
+
+.fd-has-color-text-2 {
+  color: #7f90a4 !important; }
+
+.fd-has-color-text-3 {
+  color: #63758b !important; }
+
+.fd-has-color-text-inverse,
+.fd-has-color-text-inverse-1 {
+  color: #ffffff !important; }
+
+.fd-has-color-text-inverse-2 {
+  color: #f6f8f9 !important; }
+
+.fd-has-color-text-inverse-3 {
+  color: #eef1f3 !important; }
+
+.fd-has-color-background,
+.fd-has-color-background-1 {
+  color: #ffffff !important; }
+
+.fd-has-color-background-2 {
+  color: #f0f5ff !important; }
+
+.fd-has-color-background-3 {
+  color: #000000 !important; }
+
+.fd-has-color-neutral,
+.fd-has-color-neutral-1 {
+  color: #f9fbfc !important; }
+
+.fd-has-color-neutral-2 {
+  color: #d7d7d7 !important; }
+
+.fd-has-color-neutral-3 {
+  color: #ccdaeb !important; }
+
+.fd-has-color-neutral-4 {
+  color: #8a8fa1 !important; }
+
+.fd-has-color-status,
+.fd-has-color-status-1 {
+  color: #61bf33 !important; }
+
+.fd-has-color-status-2 {
+  color: #e97326 !important; }
+
+.fd-has-color-status-3 {
+  color: #df1919 !important; }
+
+.fd-has-background-image {
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain; }
+
+.fd-has-background-fixed {
+  background-repeat: no-repeat;
+  background-position: center;
+  background-attachment: fixed; }
+
+.fd-has-background-size-contain {
+  background-size: contain !important; }
+
+.fd-has-background-size-cover {
+  background-size: cover !important; }
+
+.fd-has-background-color-primary,
+.fd-has-background-color-primary-1 {
+  background-color: #006fbb !important; }
+
+.fd-has-background-color-primary-2 {
+  background-color: #27394f !important; }
+
+.fd-has-background-color-action,
+.fd-has-background-color-action-1 {
+  background-color: #009cdf !important; }
+
+.fd-has-background-color-action-2 {
+  background-color: #8D9DBC !important; }
+
+.fd-has-background-color-text,
+.fd-has-background-color-text-1 {
+  background-color: #21262c !important; }
+
+.fd-has-background-color-text-2 {
+  background-color: #7f90a4 !important; }
+
+.fd-has-background-color-text-3 {
+  background-color: #63758b !important; }
+
+.fd-has-background-color-text-inverse,
+.fd-has-background-color-text-inverse-1 {
+  background-color: #ffffff !important; }
+
+.fd-has-background-color-text-inverse-2 {
+  background-color: #f6f8f9 !important; }
+
+.fd-has-background-color-text-inverse-3 {
+  background-color: #eef1f3 !important; }
+
+.fd-has-background-color-background,
+.fd-has-background-color-background-1 {
+  background-color: #ffffff !important; }
+
+.fd-has-background-color-background-2 {
+  background-color: #f0f5ff !important; }
+
+.fd-has-background-color-background-3 {
+  background-color: #000000 !important; }
+
+.fd-has-background-color-neutral,
+.fd-has-background-color-neutral-1 {
+  background-color: #f9fbfc !important; }
+
+.fd-has-background-color-neutral-2 {
+  background-color: #d7d7d7 !important; }
+
+.fd-has-background-color-neutral-3 {
+  background-color: #ccdaeb !important; }
+
+.fd-has-background-color-neutral-4 {
+  background-color: #8a8fa1 !important; }
+
+.fd-has-background-color-status,
+.fd-has-background-color-status-1 {
+  background-color: #61bf33 !important; }
+
+.fd-has-background-color-status-2 {
+  background-color: #e97326 !important; }
+
+.fd-has-background-color-status-3 {
+  background-color: #df1919 !important; }
+
+.fd-has-margin-none {
+  margin: 0; }
+
+.fd-has-padding-none {
+  padding: 0; }
+
+.fd-has-margin-top-none {
+  margin-top: 0; }
+
+.fd-has-padding-top-none {
+  padding-top: 0; }
+
+.fd-has-margin-right-none {
+  margin-right: 0; }
+
+.fd-has-padding-right-none {
+  padding-right: 0; }
+
+.fd-has-margin-bottom-none {
+  margin-bottom: 0; }
+
+.fd-has-padding-bottom-none {
+  padding-bottom: 0; }
+
+.fd-has-margin-left-none {
+  margin-left: 0; }
+
+.fd-has-padding-left-none {
+  padding-left: 0; }
+
+.fd-has-margin-base {
+  margin: 4px; }
+
+.fd-has-padding-base {
+  padding: 4px; }
+
+.fd-has-margin-top-base {
+  margin-top: 4px; }
+
+.fd-has-padding-top-base {
+  padding-top: 4px; }
+
+.fd-has-margin-right-base {
+  margin-right: 4px; }
+
+.fd-has-padding-right-base {
+  padding-right: 4px; }
+
+.fd-has-margin-bottom-base {
+  margin-bottom: 4px; }
+
+.fd-has-padding-bottom-base {
+  padding-bottom: 4px; }
+
+.fd-has-margin-left-base {
+  margin-left: 4px; }
+
+.fd-has-padding-left-base {
+  padding-left: 4px; }
+
+.fd-has-margin-xs {
+  margin: 8px; }
+
+.fd-has-padding-xs {
+  padding: 8px; }
+
+.fd-has-margin-top-xs {
+  margin-top: 8px; }
+
+.fd-has-padding-top-xs {
+  padding-top: 8px; }
+
+.fd-has-margin-right-xs {
+  margin-right: 8px; }
+
+.fd-has-padding-right-xs {
+  padding-right: 8px; }
+
+.fd-has-margin-bottom-xs {
+  margin-bottom: 8px; }
+
+.fd-has-padding-bottom-xs {
+  padding-bottom: 8px; }
+
+.fd-has-margin-left-xs {
+  margin-left: 8px; }
+
+.fd-has-padding-left-xs {
+  padding-left: 8px; }
+
+.fd-has-margin-s {
+  margin: 12px; }
+
+.fd-has-padding-s {
+  padding: 12px; }
+
+.fd-has-margin-top-s {
+  margin-top: 12px; }
+
+.fd-has-padding-top-s {
+  padding-top: 12px; }
+
+.fd-has-margin-right-s {
+  margin-right: 12px; }
+
+.fd-has-padding-right-s {
+  padding-right: 12px; }
+
+.fd-has-margin-bottom-s {
+  margin-bottom: 12px; }
+
+.fd-has-padding-bottom-s {
+  padding-bottom: 12px; }
+
+.fd-has-margin-left-s {
+  margin-left: 12px; }
+
+.fd-has-padding-left-s {
+  padding-left: 12px; }
+
+.fd-has-margin-reg {
+  margin: 20px; }
+
+.fd-has-padding-reg {
+  padding: 20px; }
+
+.fd-has-margin-top-reg {
+  margin-top: 20px; }
+
+.fd-has-padding-top-reg {
+  padding-top: 20px; }
+
+.fd-has-margin-right-reg {
+  margin-right: 20px; }
+
+.fd-has-padding-right-reg {
+  padding-right: 20px; }
+
+.fd-has-margin-bottom-reg {
+  margin-bottom: 20px; }
+
+.fd-has-padding-bottom-reg {
+  padding-bottom: 20px; }
+
+.fd-has-margin-left-reg {
+  margin-left: 20px; }
+
+.fd-has-padding-left-reg {
+  padding-left: 20px; }
+
+.fd-has-margin-m {
+  margin: 40px; }
+
+.fd-has-padding-m {
+  padding: 40px; }
+
+.fd-has-margin-top-m {
+  margin-top: 40px; }
+
+.fd-has-padding-top-m {
+  padding-top: 40px; }
+
+.fd-has-margin-right-m {
+  margin-right: 40px; }
+
+.fd-has-padding-right-m {
+  padding-right: 40px; }
+
+.fd-has-margin-bottom-m {
+  margin-bottom: 40px; }
+
+.fd-has-padding-bottom-m {
+  padding-bottom: 40px; }
+
+.fd-has-margin-left-m {
+  margin-left: 40px; }
+
+.fd-has-padding-left-m {
+  padding-left: 40px; }
+
+.fd-has-margin-l {
+  margin: 100px; }
+
+.fd-has-padding-l {
+  padding: 100px; }
+
+.fd-has-margin-top-l {
+  margin-top: 100px; }
+
+.fd-has-padding-top-l {
+  padding-top: 100px; }
+
+.fd-has-margin-right-l {
+  margin-right: 100px; }
+
+.fd-has-padding-right-l {
+  padding-right: 100px; }
+
+.fd-has-margin-bottom-l {
+  margin-bottom: 100px; }
+
+.fd-has-padding-bottom-l {
+  padding-bottom: 100px; }
+
+.fd-has-margin-left-l {
+  margin-left: 100px; }
+
+.fd-has-padding-left-l {
+  padding-left: 100px; }
+
+.fd-has-margin-xl {
+  margin: 148px; }
+
+.fd-has-padding-xl {
+  padding: 148px; }
+
+.fd-has-margin-top-xl {
+  margin-top: 148px; }
+
+.fd-has-padding-top-xl {
+  padding-top: 148px; }
+
+.fd-has-margin-right-xl {
+  margin-right: 148px; }
+
+.fd-has-padding-right-xl {
+  padding-right: 148px; }
+
+.fd-has-margin-bottom-xl {
+  margin-bottom: 148px; }
+
+.fd-has-padding-bottom-xl {
+  padding-bottom: 148px; }
+
+.fd-has-margin-left-xl {
+  margin-left: 148px; }
+
+.fd-has-padding-left-xl {
+  padding-left: 148px; }
+
+.fd-has-clearfix::after {
+  content: "";
+  display: table;
+  clear: both; }
+
+.fd-has-display-flex {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex; }
+
+.fd-has-display-block {
+  display: block; }
+
+.fd-has-align-items-center {
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center; }
+
+.fd-has-flex-grow-1 {
+  -webkit-box-flex: 1;
+      -ms-flex-positive: 1;
+          flex-grow: 1; }
+
+/*# sourceMappingURL=data:application/json;charset=utf8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImFsbC5jc3MiLCJ0aGVtZS90ZWNobmUuc2NzcyIsImNvcmUvZWxlbWVudHMuc2NzcyIsImNvcmUvX3NldHRpbmdzLnNjc3MiLCJjb3JlL2Zvcm1zLnNjc3MiLCJjb3JlL19taXhpbnMuc2NzcyIsImNvcmUvX2Z1bmN0aW9ucy5zY3NzIiwibGF5b3V0L3NlY3Rpb24uc2NzcyIsImxheW91dC9jb250YWluZXIuc2NzcyIsImxheW91dC9fbWl4aW5zLnNjc3MiLCJsYXlvdXQvY29sLnNjc3MiLCJsYXlvdXQvdWkuc2NzcyIsImxheW91dC9hcHAuc2NzcyIsImxheW91dC9wYWdlLnNjc3MiLCJsYXlvdXQvcGFuZWwuc2NzcyIsImxheW91dC9vdmVybGF5LnNjc3MiLCJjb21wb25lbnRzL2FsZXJ0LnNjc3MiLCJjb21wb25lbnRzL19taXhpbnMuc2NzcyIsImNvbXBvbmVudHMvYnV0dG9uLnNjc3MiLCJjb21wb25lbnRzL2Ryb3Bkb3duLnNjc3MiLCJjb21wb25lbnRzL2NvbnRleHR1YWwtbWVudS5zY3NzIiwiY29tcG9uZW50cy9hY3Rpb24tYmFyLnNjc3MiLCJjb21wb25lbnRzL2JhZGdlLnNjc3MiLCJjb21wb25lbnRzL2NhcmQuc2NzcyIsImNvbXBvbmVudHMvY2FyZC1ncm91cC5zY3NzIiwiY29tcG9uZW50cy9mb3JtLnNjc3MiLCJjb21wb25lbnRzL2lucHV0LWdyb3VwLnNjc3MiLCJjb21wb25lbnRzL2xhYmVsLnNjc3MiLCJjb21wb25lbnRzL3Rvb2xiYXIuc2NzcyIsImljb25zL2ljb24uc2NzcyIsImNvbXBvbmVudHMvcGFnaW5hdGlvbi5zY3NzIiwiY29tcG9uZW50cy90YWJsZS5zY3NzIiwiY29tcG9uZW50cy90YWJzLnNjc3MiLCJjb21wb25lbnRzL21vZGFsLnNjc3MiLCJjb21wb25lbnRzL3RyZWUuc2NzcyIsImNvbXBvbmVudHMvbGlzdC1ncm91cC5zY3NzIiwiY29tcG9uZW50cy9pbmxpbmUtaGVscC5zY3NzIiwiY29tcG9uZW50cy9uYXYuc2NzcyIsImNvbXBvbmVudHMvdG9nZ2xlLnNjc3MiLCJjb21wb25lbnRzL3NwaW5uZXIuc2NzcyIsImNvbXBvbmVudHMvaW1hZ2Uuc2NzcyIsImhlbHBlcnMvX2dlbmVyYWwuc2NzcyIsImhlbHBlcnMvX3R5cGUuc2NzcyIsImhlbHBlcnMvX2NvbG9ycy5zY3NzIiwiaGVscGVycy9fYmFja2dyb3VuZHMuc2NzcyIsImhlbHBlcnMvX3NwYWNpbmcuc2NzcyIsImhlbHBlcnMvX2xheW91dC5zY3NzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUFBLGlCQUFpQjtBQ0FqQixvRUFBWTtBQUNaLGlGQUFZO0FDUVo7OztFQUdFO0FBQ0Y7RUFDSSwrQkFBc0I7VUFBdEIsdUJBQXNCO0VBQ3RCLGlCQUFnQixFQUNuQjs7QUFDRDs7RUFFSSxnQkNhTztFRFpQLHFDRGhCa0M7RUNpQmxDLGlCQ1dXLEVEVmQ7O0FBQ0Q7RUFDSSw0QkFBbUI7VUFBbkIsb0JBQW1CLEVBS3RCO0VBTkQ7SUFJUSw0QkFBbUI7WUFBbkIsb0JBQW1CLEVBQ3RCOztBQUVMO0VBQ0ksVUFBUztFQUNULDBCQzRDYztFRDNDZCxvQ0FBbUM7RUFDbkMsZUNnQ2MsRUQvQmpCOztBQUVEOzs7RUFHRTtBQUNGO0VBQ0ksbUNBQWtDO0VBQ2xDLG9CQ3ZCMEI7RUR3QjFCLGNBQWEsRUFDaEI7O0FBRUQ7OztFQUdFO0FBQ0Y7RUFDSSxjQUFhO0VBQ2Isb0JDakMwQixFRHFDN0I7RUFORDtJQUlRLGlCQUFnQixFQUNuQjs7QUFHTDs7O0VBR0U7QUFDRjtFQUNJLGdCQUFlLEVBRWxCOztBQUdEOzs7RUFHRTtBQUNGO0VBQ0ksZUFBYztFQUNkLHVCQUFzQixFQUN6Qjs7QUFFRDtFQUNJLGVDakJjO0VEa0JkLHNCQUFxQixFQWN4QjtFQWhCRDtJQUlRLGVDdUN5QyxFRHRDNUM7RUFMTDtJQVFRLGVDbUN5QztJRGxDekMsY0FBYSxFQUNoQjtFQVZMO0lBYVEsZUN4QlU7SUR5QlYsb0JBQW1CLEVBQ3RCOztBQUdMOzs7RUFHRTtBQUNGOztFQUVJLFVBQVM7RUFDVCxXQUFVLEVBQ2I7O0FFL0ZEO0VDSkksZ0JGMkJPO0VFMUJQLGlCRjBCVztFRXpCWCxlRjJEYztFRWdGZCxnQkZsSE87RUVtSFAsaUJGbkhXO0VFd0hILHFDSnBKMEI7RUl3TDlCLGlCQUFnQjtFQTVLcEIsaUJBQWdCO0VBQ2hCLDhCQUE2QjtFQUM3QiwyQkFBMEI7RUFDMUIsbUJBQWtCO0VBQ2xCLCtCQUFzQjtVQUF0Qix1QkFBc0I7RUFDdEIsY0FBYTtFQUNiLG9CQUFtQjtFQUNuQixrQkFBaUI7RUFDakIsc0JGMkRjO0VFMURkLGlCQUFnQjtFQUNoQixlRndDYztFRXRDZCw4QkFBNkI7RUFDN0Isd0NGc0d3QjtFRXRHeEIsZ0NGc0d3QjtFQ3hIeEIsa0hBSnFEO0VBSXJELDBHQUpxRCxFQVd4RDtFQVREO0lDd0JRLHNCRjZCVSxFRTNCYjtFRDFCTDtJQzRCUSxzQkZvRFUsRUVuRGI7RUQ3Qkw7SUMrQlEsc0JGK0NVLEVFOUNiO0VEaENMO0lDa0NRLHNCRjZDVSxFRTVDYjtFRG5DTDtJQ3VDUSxvQkFBbUI7SUFDbkIsZUZtQlU7SUVsQlYsc0JGb0cyRDtJRW5HM0QsMEJGOEJVLEVFN0JiO0VEM0NMO0lDOENRLGVGV1U7SUVUVixzQkY2RjJEO0lFNUYzRCxzQkFBcUIsRUFDeEI7RURsREw7SUFJUSxnREFOaUQ7SUFNakQsd0NBTmlELEVBT3BEO0VBTEw7SUFPUSxlRG9EVSxFQ25EYjtFQVJMO0lBT1EsZURvRFUsRUNuRGI7RUFSTDtJQU9RLGVEb0RVLEVDbkRiOztBQUVMO0VBQ0ksVUFBUztFQUNULFdBQVU7RUFDVixVQUFTLEVBQ1o7O0FBQ0Q7O0VDbkJJLGdCRjJCTztFRTFCUCxpQkYwQlc7RUV6QlgsZUYyRGM7RUVnRmQsZ0JGbEhPO0VFbUhQLGlCRm5IVztFRXdISCxxQ0pwSjBCO0VJd0w5QixpQkFBZ0I7RUE1S3BCLGlCQUFnQjtFQUNoQiw4QkFBNkI7RUFDN0IsMkJBQTBCO0VBQzFCLG1CQUFrQjtFQUNsQiwrQkFBc0I7VUFBdEIsdUJBQXNCO0VBQ3RCLGNBQWE7RUFDYixvQkFBbUI7RUFDbkIsa0JBQWlCO0VBQ2pCLHNCRjJEYztFRTFEZCxpQkFBZ0I7RUFDaEIsZUZ3Q2M7RUV0Q2QsOEJBQTZCO0VBQzdCLHdDRnNHd0I7RUV0R3hCLGdDRnNHd0I7RUVuRXhCLGFDM0IwQjtFRDRCMUIsbUJDNUIwQjtFRDZCMUIsb0JDN0IwQjtFRlYxQixZQUFXLEVBQ2Q7RUFKRDs7O0lDU1Esc0JGNkJVLEVFM0JiO0VEWEw7O0lDYVEsc0JGb0RVLEVFbkRiO0VEZEw7O0lDZ0JRLHNCRitDVSxFRTlDYjtFRGpCTDs7SUNtQlEsc0JGNkNVLEVFNUNiO0VEcEJMOzs7O0lDd0JRLG9CQUFtQjtJQUNuQixlRm1CVTtJRWxCVixzQkZvRzJEO0lFbkczRCwwQkY4QlUsRUU3QmI7RUQ1Qkw7OztJQytCUSxlRldVO0lFVFYsc0JGNkYyRDtJRTVGM0Qsc0JBQXFCLEVBQ3hCOztBRDlCTDtFQUNJLGNBQXdDO0VBQ3hDLGtCRU0wQixFRkw3Qjs7QUFDRDtFQzVCSSxnQkYyQk87RUUxQlAsaUJGMEJXO0VFekJYLGVGMkRjO0VFZ0ZkLGdCRmxITztFRW1IUCxpQkZuSFc7RUV3SEgscUNKcEowQjtFSXdMOUIsaUJBQWdCO0VBNUtwQixpQkFBZ0I7RUFDaEIsOEJBQTZCO0VBQzdCLDJCQUEwQjtFQUMxQixtQkFBa0I7RUFDbEIsK0JBQXNCO1VBQXRCLHVCQUFzQjtFQUN0QixjQUFhO0VBQ2Isb0JBQW1CO0VBQ25CLGtCQUFpQjtFQUNqQixzQkYyRGM7RUUxRGQsaUJBQWdCO0VBQ2hCLGVGd0NjO0VFdENkLDhCQUE2QjtFQUM3Qix3Q0ZzR3dCO0VFdEd4QixnQ0ZzR3dCO0VFbkV4QixhQzNCMEI7RUQ0QjFCLG1CQzVCMEI7RUQ2QjFCLG9CQzdCMEI7RURrQzFCLHlCQUFnQjtVQUFoQixpQkFBZ0I7RUFDaEIsc0JBQXFCO0VBQ3JCLGtpQkFBdUI7RUFDdkIsNkJBQTRCO0VBQzVCLDhDQUFvRjtFQUNwRixvQkFBaUY7RUR6Q2pGLFlBQVcsRUFNZDtFQVJEO0lDQVEsc0JGNkJVLEVFM0JiO0VERkw7SUNJUSxzQkZvRFUsRUVuRGI7RURMTDtJQ09RLHNCRitDVSxFRTlDYjtFRFJMO0lDVVEsc0JGNkNVLEVFNUNiO0VEWEw7SUNlUSxvQkFBbUI7SUFDbkIsZUZtQlU7SUVsQlYsc0JGb0cyRDtJRW5HM0QsMEJGOEJVLEVFN0JiO0VEbkJMO0lDc0JRLGVGV1U7SUVUVixzQkY2RjJEO0lFNUYzRCxzQkFBcUIsRUFDeEI7RUQxQkw7SUM4Q1Esa2lCQUF1QixFQUMxQjtFRC9DTDtJQ2tEUSw4akJBQXVCLEVBQzFCO0VEbkRMO0lDdURRLGtpQkFBdUIsRUFDMUI7RUR4REw7SUFJUSxjQUF3QztJQUN4Qyx1QkFBc0I7SUFDdEIsa0JFRnNCLEVGR3pCOztBQUVMO0VBRUksYUVQMEI7RUZRMUIsWUVSMEI7RUZTMUIsVUFBUztFQUNULHVCQUFzQjtFQUN0QixtQkFBa0IsRUFXckI7RUFqQkQ7SUFRUSxzQkRZVTtJQ1hWLDBCRFdVLEVDVmI7RUFWTDtJQWNRLHNCRDhGMkQ7SUM3RjNELDBCRHdCVSxFQ3ZCYjs7QUFFTDtFQUdZLFlBQVc7RUFDWCxZQUFXO0VBQ1gsWUFBVztFQUNYLHNCRFVNO0VDVE4sb0JBQW1CO0VBQ25CLDBCQUF5QjtFQUN6QixrQ0FBeUI7VUFBekIsMEJBQXlCO0VBQ3pCLG1CQUFrQjtFQUNsQixXQUFVO0VBQ1YscUJBQW9CO0VBQ3BCLHlCQUF3QixFQUMzQjs7QUFkVDtFQW1CZ0Isc0JEWkUsRUNhTDs7QUFJYjtFQUNJLG1CQUFrQixFQTRCckI7RUE3QkQ7SUFJUSxZQUFXO0lBQ1gsbUJBQWtCO0lBQ2xCLFlFckRzQjtJRnNEdEIsYUV0RHNCO0lGdUR0QixtQkFBa0I7SUFDbEIsVUFBUztJQUNULFNBQVE7SUFDUiwwQkFBb0M7SUFDcEMsMkJBQXFDO0lBQ3JDLG9EQTFGaUQ7SUEwRmpELDRDQTFGaUQ7SUEyRmpELDhCQUE2QixFQUNoQztFQWZMO0lBaUJRLDBCRHpCVSxFQ29DYjtJQTVCTDtNQW1CWSwwQkR6Q00sRUMwQ1Q7SUFwQlQ7TUF5QmdCLDBCRDFDRSxFQzJDTDs7QUcxR2I7Ozs7OztFQU1FO0FBR0Y7RUFRSSx3QkpEMEI7RUlFMUIsaUNKNkRjLEVJOUJqQjtFRjJDRztJQUNJLFlBQVc7SUFDWCxlQUFjO0lBQ2QsWUFBVyxFQUNkO0VFdkZMO0lBWVEsaUJBQWdCLEVBQ25CO0VBQ0Q7SUFDSSxpQkFBZ0I7SUFDaEIsZ0JBQWUsRUFLbEI7SUFQRDtNQUlRLGtCSlhrQjtNSVlsQixtQkpaa0IsRUlhckI7RUFFTDtJQUNJLGlCRENzQjtJQ0F0QixxQkFBYTtJQUFiLHFCQUFhO0lBQWIsY0FBYTtJQUNiLDBCQUFtQjtRQUFuQix1QkFBbUI7WUFBbkIsb0JBQW1CO0lBQ25CLG9CREZzQixFQ0d6QjtFQUNEO0lGeUdBLG9CRi9HVztJRWdIWCxxQkZoSG1CO0lFNkhYLGdDSjNKdUI7SUkyTDNCLGlCQUFnQjtJRXJKaEIsb0JBQU87UUFBUCxZQUFPO1lBQVAsUUFBTztJQUNQLGlCQUFnQixFQUNuQjtFQUNEO0lBQ0ksa0JBQWlCLEVBQ3BCO0VBQ0Q7SUFDSSxxQkFBYTtJQUFiLHFCQUFhO0lBQWIsY0FBYTtJQUNiLHlCQUF1QjtRQUF2QixzQkFBdUI7WUFBdkIsd0JBQXVCLEVBQzFCOztBQy9DTDtFQUdJLG9CTFkwQjtFS1gxQixrQkwyRnFCLEVLMUV4QjtFSHNFRztJQUNJLFlBQVc7SUFDWCxlQUFjO0lBQ2QsWUFBVyxFQUNkO0VHL0ZMO0lBTVEsaUJBQWdCLEVBQ25CO0VBQ0Q7SUFDSSxnQkFBZSxFQUNsQjtFQUlEO0lBQ0kscUJBQWE7SUFBYixxQkFBYTtJQUFiLGNBQWEsRUFDaEI7RUFDRDtJQUNJLGtCQUFpQjtJQUNqQixtQkFBa0IsRUFDckI7O0FDRkw7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7RUEyQ0U7QUMzREY7O0VBRUU7QUFDRjtFQUNJLG9CQUFPO01BQVAsWUFBTztVQUFQLFFBQU8sRUF3QlY7RUxvRkc7SUt6R1E7TUQrRFYsWUFBVztNQUdYLG1CSDNDNEI7TUcyRDVCLG9EQU9DLEVDdkZVO01BRkQ7UURvRVIsZ0JBQWUsRUFDaEI7SUNyRVM7TUQrRFYsWUFBVztNQUdYLG1CSDNDNEI7TUcyRDVCLHFEQU9DLEVDdkZVO01BRkQ7UURvRVIsZ0JBQWUsRUFDaEI7SUNyRVM7TUQrRFYsWUFBVztNQUdYLG1CSDNDNEI7TUcyRDVCLHFEQU9DLEVDdkZVO01BRkQ7UURvRVIsZ0JBQWUsRUFDaEI7SUNyRVM7TUQrRFYsWUFBVztNQUdYLG1CSDNDNEI7TUcyRDVCLHFEQU9DLEVDdkZVO01BRkQ7UURvRVIsZ0JBQWUsRUFDaEI7SUNyRVM7TUQrRFYsWUFBVztNQUdYLG1CSDNDNEI7TUcyRDVCLHNEQU9DLEVDdkZVO01BRkQ7UURvRVIsZ0JBQWUsRUFDaEI7SUNyRVM7TUQrRFYsWUFBVztNQUdYLG1CSDNDNEI7TUcyRDVCLHNEQU9DLEVDdkZVO01BRkQ7UURvRVIsZ0JBQWUsRUFDaEI7SUNyRVM7TUQrRFYsWUFBVztNQUdYLG1CSDNDNEI7TUcyRDVCLHNEQU9DLEVDdkZVO01BRkQ7UURvRVIsZ0JBQWUsRUFDaEI7SUNyRVM7TUQrRFYsWUFBVztNQUdYLG1CSDNDNEI7TUcyRDVCLHNEQU9DLEVDdkZVO01BRkQ7UURvRVIsZ0JBQWUsRUFDaEI7SUNyRVM7TUQrRFYsWUFBVztNQUdYLG1CSDNDNEI7TUcyRDVCLHNEQU9DLEVDdkZVO01BRkQ7UURvRVIsZ0JBQWUsRUFDaEI7SUNyRVM7TUQrRFYsWUFBVztNQUdYLG1CSDNDNEI7TUcyRDVCLHVEQU9DLEVDdkZVO01BRkQ7UURvRVIsZ0JBQWUsRUFDaEI7SUNyRVM7TUQrRFYsWUFBVztNQUdYLG1CSDNDNEI7TUcyRDVCLHVEQU9DLEVDdkZVO01BRkQ7UURvRVIsZ0JBQWUsRUFDaEI7SUNyRVM7TUQrRFYsWUFBVztNQUdYLG1CSDNDNEI7TUcyRDVCLHVEQU9DLEVDdkZVO01BRkQ7UURvRVIsZ0JBQWUsRUFDaEI7SUNoRVM7TURpR1YsMkRBT0MsRUN0R1U7SUFGRDtNRGlHViwyREFPQyxFQ3RHVTtJQUZEO01EaUdWLDJEQU9DLEVDdEdVO0lBRkQ7TURpR1YsNERBT0MsRUN0R1U7SUFGRDtNRGlHViw0REFPQyxFQ3RHVTtJQUZEO01EaUdWLDREQU9DLEVDdEdVO0lBRkQ7TURpR1YsNERBT0MsRUN0R1U7SUFGRDtNRGlHViw0REFPQyxFQ3RHVTtJQUZEO01EaUdWLDREQU9DLEVDdEdVO0lBRkQ7TURpR1YsNkRBT0MsRUN0R1U7SUFGRDtNRGlHViw2REFPQyxFQ3RHVSxFQUFBO0VWK2RYO0lVMWRVLG9CUE5rQixFT2FyQjtJVnFkTDtNVTFkWSxpQkFBZ0IsRUFDbkI7SUwwRlQ7TUxrWUU7UVUxZFUsaUJBQWdCLEVBRXZCLEVBQUE7O0FDM0JUOzs7Ozs7RUFNRTtBQUVGO0VBYUksbUJBQWtCO0VBQ2xCLGtCQUFpQjtFQUNqQixhQUFZO0VBQ1osaUJBQWdCLEVBMEZuQjtFQXpGRztJQUNJLHFCQUFhO0lBQWIscUJBQWE7SUFBYixjQUFhO0lBQ2IsNkJBQXNCO0lBQXRCLDhCQUFzQjtRQUF0QiwyQkFBc0I7WUFBdEIsdUJBQXNCO0lBQ3RCLGtCQUFpQixFQWVwQjtJQWxCRDtNQUtRLG9CQWZrQjtVQWVsQixtQkFma0I7Y0FlbEIsZUFma0I7TUFnQmxCLGlCQUFnQixFQUNuQjtJQVBMO01BU1Esb0JBakJrQjtVQWlCbEIsbUJBakJrQjtjQWlCbEIsZUFqQmtCO01Ba0JsQixpQkFBZ0IsRUFDbkI7SUFYTDtNQWFRLGlCQUFnQjtNQUNoQixjQUFhO01BQ2Isb0JBQU87VUFBUCxZQUFPO2NBQVAsUUFBTztNQUNQLGlCQUFnQixFQUNuQjtFQU9MO0lBQ0ksbUJBQWtCO0lBQ2xCLFdBQVU7SUFDVixvQlJBVTtJUUNWLFlBQVc7SUFDWCxpQkF2Q3NCO0lBd0N0QixhQXhDc0IsRUFvRHpCO0lBWEc7TUFDSSxnQkFBZSxFQUNsQjtFQVVMO0lBQ0ksb0JSaEJVO0lRaUJWLFlBQVc7SUFDWCxpQkF0RHNCO0lBdUR0QixhQXZEc0IsRUFxRXpCO0lBYkc7TUFDSSxnQkFBZTtNQUNmLFVBQVMsRUFDWjtFQVdMO0lBQ0ksaUJBekVzQjtJQTBFdEIsc0NBQTJFO0lBQzNFLFlBQVc7SUFDWCxxQkFBYTtJQUFiLHFCQUFhO0lBQWIsY0FBYTtJQUNiLG1CQUFrQixFQWFyQjtFQU1EO0lBQ0ksbUJBQWtCLEVBQ3JCOztBQ2pITDs7OztFQUlFO0FBRUY7RUFLSSxZQUFXLEVBa0NkO0VQb0VHO0lPM0dKO01BT1EscUJBQWE7TUFBYixxQkFBYTtNQUFiLGNBQWEsRUFnQ3BCLEVBQUE7RUE5Qkc7SUFDSSwwQlRxQ1U7SVNwQ1YsYUFBWTtJQUNaLGlCQVZtQztJQStCbkMsaUJBQWdCLEVBQ25CO0lBekJEO01BS1EsbUJBQWtCO01BQ2xCLGlCQUFnQixFQUNuQjtJUDJGTDtNT2xHQTtRQVNRLFlBZjhCO1FBZ0I5QixpQkFBZ0IsRUFldkI7UUF6QkQ7VUFZWSxhQXBCZ0I7VUFxQmhCLG1CQUFrQjtVQUNsQixxQkFBb0IsRUFDdkIsRUFBQTtJUG1GVDtNT2xHQTtRQWtCUSxhQTFCb0IsRUFpQzNCO1FBekJEO1VBb0JZLGFBNUJnQjtVQTZCaEIsZ0JBQWUsRUFDbEIsRUFBQTtFQUlUO0lBQ0ksb0JBQU87UUFBUCxZQUFPO1lBQVAsUUFBTztJQUNQLGlCQUFnQixFQUNuQjs7QUM3Q0w7RUFLSSxxQkFBYTtFQUFiLHFCQUFhO0VBQWIsY0FBYTtFQUNiLDZCQUFzQjtFQUF0Qiw4QkFBc0I7TUFBdEIsMkJBQXNCO1VBQXRCLHVCQUFzQjtFQUN0QixpQkFBZ0I7RUFDaEIsWUFBVyxFQWlCZDtFQWhCRztJQUNJLGlDVm9FVTtJVW5FViwwQlY2RFU7SVU1RFYsYUFWd0IsRUFXM0I7RUFDRDtJUitIQSxvQkZuSFk7SUVvSFoscUJGcEhvQjtJRTZKaEIsaUJBQWdCO0lRdktoQixtQlZEc0I7SVVFdEIsMEJWdURVO0lVdERWLG1CQUFrQjtJQUNsQixpQ1YyRFU7SVUxRFYsb0JBQW1CLEVBQ3RCO0VBQ0Q7SUFDSSxvQkFBWTtRQUFaLHFCQUFZO1lBQVosYUFBWSxFQUNmOztBTnpCTDs7Ozs7O0VBTUU7QUFHRjtFQVFJLHdCSkQwQjtFSUUxQixpQ0o2RGMsRUk5QmpCO0VGMkNHO0lBQ0ksWUFBVztJQUNYLGVBQWM7SUFDZCxZQUFXLEVBQ2Q7RUV2Rkw7SUFZUSxpQkFBZ0IsRUFDbkI7RUFDRjtJQUNLLGlCQUFnQjtJQUNoQixnQkFBZSxFQUtsQjtJQVBGO01BSVMsa0JKWGtCO01JWWxCLG1CSlprQixFSWFyQjtFQUVOO0lBQ0ssaUJEQ3NCO0lDQXRCLHFCQUFhO0lBQWIscUJBQWE7SUFBYixjQUFhO0lBQ2IsMEJBQW1CO1FBQW5CLHVCQUFtQjtZQUFuQixvQkFBbUI7SUFDbkIsb0JERnNCLEVDR3pCO0VBQ0Y7SUZ5R0Msb0JGL0dXO0lFZ0hYLHFCRmhIbUI7SUU2SFgsZ0NKM0p1QjtJSTJMM0IsaUJBQWdCO0lFckpoQixvQkFBTztRQUFQLFlBQU87WUFBUCxRQUFPO0lBQ1AsaUJBQWdCLEVBQ25CO0VBQ0Y7SUFDSyxrQkFBaUIsRUFDcEI7RUFDRjtJQUNLLHFCQUFhO0lBQWIscUJBQWE7SUFBYixjQUFhO0lBQ2IseUJBQXVCO1FBQXZCLHNCQUF1QjtZQUF2Qix3QkFBdUIsRUFDMUI7O0FPaERMOzs7Ozs7RUFNRTtBVHNGRTtFQUNJLFlBQVc7RUFDWCxlQUFjO0VBQ2QsWUFBVyxFQUNkOztBU3JGRDtFQUNJLGlCUnFCc0I7RVFwQnRCLHFCQUFhO0VBQWIscUJBQWE7RUFBYixjQUFhO0VBQ2IsMEJBQW1CO01BQW5CLHVCQUFtQjtVQUFuQixvQkFBbUI7RUFDbkIsb0JSa0JzQixFUWpCekI7O0FBQ0Q7RVQ2SEEsb0JGL0dXO0VFZ0hYLHFCRmhIbUI7RUU2SFgsZ0NKM0p1QjtFSTJMM0IsaUJBQWdCO0VTektoQixvQkFBTztNQUFQLFlBQU87VUFBUCxRQUFPO0VBQ1AsaUJBQWdCLEVBQ25COztBQUNEO0VBQ0ksa0JBQWlCLEVBQ3BCOztBQUNEO0VBQ0kscUJBQWE7RUFBYixxQkFBYTtFQUFiLGNBQWE7RUFDYix5QkFBdUI7TUFBdkIsc0JBQXVCO1VBQXZCLHdCQUF1QixFQUMxQjs7QUMxQkw7OztFQUdFO0FBR0Y7RUFHUSxnQkFBZTtFQUNmLHFCQUFhO0VBQWIscUJBQWE7RUFBYixjQUFhO0VBQ2IsMEJBQW1CO01BQW5CLHVCQUFtQjtVQUFuQixvQkFBbUI7RUFDbkIseUJBQXVCO01BQXZCLHNCQUF1QjtVQUF2Qix3QkFBdUI7RUFDdkIsY0FBYTtFQUNiLGFBQVk7RUFDWixPQUFNO0VBQ04sK0JBVG9DO0VBVXBDLGNBQWE7RUFDYixlWitDVSxFWTFDakI7RUFqQkQ7SUFjWSxjQUFhLEVBQ2hCOztBQ3RCVDs7O0VBR0U7QUFHRjtFQVlJLGViZ0RjO0VhL0NkLDBCYjBEYztFYXpEZCwwQmIyQ2M7RWExQ2QsaUJWVzBCO0VVVjFCLGNiUndCLEVhK0IzQjtFQXBCRztJQzVCQSxVQUFTO0lBQ1QsV0FBVTtJQUNWLDRCQUEyQjtJQUMzQix5QkFBZ0I7T0FBaEIsc0JBQWdCO1lBQWhCLGlCQUFnQjtJQUNoQixXQUFVO0lBQ1YsVUFBUztJQUNULHNCQUFxQjtJQUNyQixzQkFBcUI7SUFDckIsZ0JBQWU7SUFDZiwwQkFBaUI7T0FBakIsdUJBQWlCO1FBQWpCLHNCQUFpQjtZQUFqQixrQkFBaUI7SUFDakIsdUJBQXNCO0lBQ3RCLG9CQUFtQjtJQUNuQiw4QkFBNkI7SURrQnpCLGVidUNVO0lhdENWLFliWnFCO0lhYXJCLGFiYnFCO0lhY3JCLGFBQVk7SUFDWixhQUF3QixFQUMzQjtFQUdEO0lBQ0UsMEJiK0NZO0lhOUNaLGVid0JZLEVhdEJiO0VBQ0Q7SUFDRSwwQmIyQ1ksRWExQ2I7O0FFMUNMOztFQUVFO0FBSUY7RURUSSxVQUFTO0VBQ1QsV0FBVTtFQUNWLDRCQUEyQjtFQUMzQix5QkFBZ0I7S0FBaEIsc0JBQWdCO1VBQWhCLGlCQUFnQjtFQUNoQixXQUFVO0VBQ1YsVUFBUztFQUNULHNCQUFxQjtFQUNyQixzQkFBcUI7RUFDckIsZ0JBQWU7RUFDZiwwQkFBaUI7S0FBakIsdUJBQWlCO01BQWpCLHNCQUFpQjtVQUFqQixrQkFBaUI7RUFDakIsdUJBQXNCO0VBQ3RCLG9CQUFtQjtFQUNuQiw4QkFBNkI7RVpvSTdCLG9CRmpIVztFRWtIWCxxQkZsSG1CO0VFdUhYLGdDSm5KdUI7RUl5TDNCLGlCQUFnQjtFYXRKcEIsc0JBQXFCO0VBQ3JCLDBCZnFCYztFZXBCZCxvREFSMEQ7RUFRMUQsNENBUjBEO0VBUzFELGVmNkJjO0VlNUJkLGlCWlAwQjtFWVExQixhWlIwQjtFWVMxQixrQlpUMEI7RVlVMUIsbUJaVjBCO0VZVzFCLG9CWlgwQjtFWVkxQixtQkFBa0I7RUFDbEIsMEJBQXlCO0VBQ3pCLGlCQUFnQixFQXNLbkI7RUFwS0c7SWI2RkEsZ0JGbEhPO0lFbUhQLGlCRm5IVztJRTRKUCxpQkFBZ0I7SUFJaEIsaUJBQWdCO0lheEloQixpQlpuQnNCO0lZb0J0QixhWnBCc0I7SVlxQnRCLGtCWnJCc0I7SVlzQnRCLG1CWnRCc0I7SVl1QnRCLG9CWnZCc0IsRVl3QnpCO0VBQ0Q7SWJvRkEsbUJGaEhVO0lFaUhWLGlCRmpIYztJRThKVixpQkFBZ0I7SWFoSWhCLGlCWjNCc0I7SVk0QnRCLGFaNUJzQjtJWTZCdEIsa0JaN0JzQjtJWThCdEIsbUJaOUJzQjtJWStCdEIsb0JaL0JzQixFWW9DekI7RUE5REw7SUFnRVEsMEJBeERzRTtJQXlEdEUsZWZKVTtJZUtWLHNCQUFxQixFQUN4QjtFQW5FTDtJQXFFUSxlZlJVO0llU1Ysd0NmR1U7WWVIVixnQ2ZHVTtJZUZWLDJCQUEyRCxFQUM5RDtFQXhFTDtJQStFUSwwQkF0RXVFO0lBdUV2RSxlZm5CVSxFZW9CYjtFQWpGTDtJQXFGUSwyQmZkVTtJZWVWLGVmOUJVO0llK0JWLDBCZmpCVTtJZWtCVixvQkFBbUIsRUFDdEI7RUFDRDtJQUVJLGVmekNVO0llMENWLDhCQUE2QixFQThCaEM7SUFqQ0Q7TUFNUSw4QkFBNkI7TUFDN0IsZUFBd0MsRUFDM0M7SUFSTDtNQWlCUSw4QkFBNkI7TUFDN0IsY0FBYTtNQUNiLHlCQUFnQjtjQUFoQixpQkFBZ0IsRUFDbkI7SUFwQkw7TUEwQlEsZUFBeUMsRUFDNUM7SUEzQkw7TUErQlEsZWZqRU0sRWVrRVQ7RUFFTDtJQUNJLGFabkdzQjtJWW9HdEIsa0JacEdzQjtJWXFHdEIsbUJackdzQjtJWXNHdEIsb0JadEdzQjtJWXVHdEIsbUJBQWtCLEVBdUNyQjtJQTVDRDtNQVFRLGFaMUdrQjtNWTJHbEIsa0JaM0drQixFWTRHckI7SUFWTDtNQVlRLFlBQVc7TUFDWCxxQ0FBb0M7TUFDcEMsMkJBQW9DO01BQ3BDLFlBQVc7TUFDWCxtQkFBa0I7TUFDbEIsWUFBVztNQUNYLFFBQU87TUFDUCxrQlpySGtCO01Zc0hsQix1REF6SGtEO01BeUhsRCwrQ0F6SGtELEVBMEhyRDtJQXJCTDtNQXVCUSxjQUFhO01BQ2IseUJBQWdCO2NBQWhCLGlCQUFnQixFQUNuQjtJQXpCTDtNQWtDWSw2QmYzR0UsRWU0R0w7SUFuQ1Q7TUF5Q1ksY0FBYSxFQUNoQjtFQXRLYjtJQTJLUSxzQkFBcUI7SUFDckIsb0JBQW1CO0lBQ25CLG1CWm5Kc0I7SVkwSnRCLGlCQUE4RCxFQVdqRTtJQWhCTztNQUNJLGtCQUFpQjtNQUNqQixtQkFBa0IsRUFDckI7SUFJRDtNQUNJLGlCQUE0RSxFQUMvRTtJQUdEO01BQ0ksaUJBQTRFLEVBQy9FO0VBSVQ7SWIxREEsbUJGckhXO0lFc0hYLHFCRnRIbUI7SUVxS2YsaUJBQWdCO0lBaEJaLDBCRnJKK0I7SWVrTG5DLGlCQUFnQjtJQUNoQixrQkFBbUY7SUFDbkYsdUJBQXNCLEVBT3pCO0lBWkQ7TUFPUSwwQkFBeUI7TUFDekIsaUJaL0trQjtNWWdMbEIsa0JBQWlCO01BQ2pCLG1CQUFrQixFQUNyQjs7QUNsTlQ7Ozs7RUFJRTtBQUdGO0VkUEksZ0JGMkJPO0VFMUJQLGlCRjBCVztFRXpCWCxlRjJEYztFZ0JuQ2QsbUJBQWtCO0VBQ2xCLHNCQUFxQixFQThFeEI7RUE1RUc7SUZoQ0EsVUFBUztJQUNULFdBQVU7SUFDViw0QkFBMkI7SUFDM0IseUJBQWdCO1lBQWhCLGlCQUFnQjtJQUNoQixXQUFVO0lBQ1YsVUFBUztJQUNULHNCQUFxQjtJQUNyQixzQkFBcUI7SUFDckIsZ0JBQWU7SUFDZiwwQkFBaUI7T0FBakIsdUJBQWlCO1FBQWpCLHNCQUFpQjtZQUFqQixrQkFBaUI7SUFDakIsdUJBQXNCO0lBQ3RCLG9CQUFtQjtJQUNuQiw4QkFBNkI7SVpUN0IsZ0JGMkJPO0lFMUJQLGlCRjBCVztJRXpCWCxlRjJEYztJRWdGZCxnQkZsSE87SUVtSFAsaUJGbkhXO0lFd0hILHFDSnBKMEI7SUl3TDlCLGlCQUFnQjtJQTVLcEIsaUJBQWdCO0lBQ2hCLDhCQUE2QjtJQUM3QiwyQkFBMEI7SUFDMUIsbUJBQWtCO0lBQ2xCLCtCQUFzQjtZQUF0Qix1QkFBc0I7SUFDdEIsY0FBYTtJQUNiLG9CQUFtQjtJQUNuQixrQkFBaUI7SUFDakIsc0JGMkRjO0lFMURkLGlCQUFnQjtJQUNoQixlRndDYztJRXRDZCw4QkFBNkI7SUFDN0Isd0NGc0d3QjtJRXRHeEIsZ0NGc0d3QjtJRW5FeEIsYUMzQjBCO0lENEIxQixtQkM1QjBCO0lENkIxQixvQkM3QjBCO0lEa0MxQixpQkFBZ0I7SUFDaEIsc0JBQXFCO0lBQ3JCLGtpQkFBdUI7SUFDdkIsNkJBQTRCO0lBQzVCLDhDQUFvRjtJQUNwRixvQkFBaUY7SWN2QzdFLG1CQUFrQjtJQUNsQixrQmJEc0IsRWFnQnpCO0lkdEJEO01BRUksc0JGNkJVLEVFM0JiO0lBQ0Q7TUFDSSxzQkZvRFUsRUVuRGI7SUFDRDtNQUNJLHNCRitDVSxFRTlDYjtJQUNEO01BQ0ksc0JGNkNVLEVFNUNiO0lBQ0Q7TUFHSSxvQkFBbUI7TUFDbkIsZUZtQlU7TUVsQlYsc0JGb0cyRDtNRW5HM0QsMEJGOEJVLEVFN0JiO0lBQ0Q7TUFFSSxlRldVO01FVFYsc0JGNkYyRDtNRTVGM0Qsc0JBQXFCLEVBQ3hCO0lBa0JEO01BRUksa2lCQUF1QixFQUMxQjtJQUNEO01BRUksOGpCQUF1QixFQUMxQjtJQUNEO01BR0ksa2lCQUF1QixFQUMxQjtJY3ZERDtNQU9RLHNCaEJxQk07TWdCcEJOLFdBQXNDO01BQ3RDLHlEaEJ5Q007Y2dCekNOLGlEaEJ5Q00sRWdCeENUO0lBQ0Q7TUFDSSwwQkFBeUIsRUFNNUI7TUFQRDtRQUtRLDBCQUF5QixFQUM1QjtFQUdUO0lBQ0ksbUJibEJzQjtJYW1CdEIsdUJBQXNCO0lBQ3RCLG9DQUEyQjtZQUEzQiw0QkFBMkIsRUFDOUI7RUFDRDtJQUVJLGVBQWM7SUFDZCxnQkFBZTtJQUNmLGlCQUFnQjtJQUNoQixnQkFBZTtJQUNmLDBCaEJrQlU7SWdCakJWLG9CaEJVVTtJZ0JUVixtQkFBa0I7SUFDbEIsb0JBQW1CO0lBQ25CLFdBckR3QjtJQXNEeEIsb0NBQTJCO1lBQTNCLDRCQUEyQjtJQUMzQix5RGhCYVU7WWdCYlYsaURoQmFVO0lnQlpWLFdBQVU7SUFDVixvQkFBbUI7SUFDbkIsMkNBaERrRTtJQWdEbEUsbUNBaERrRSxFQXNEckU7SUFyQkQ7TUFrQlEsV0FBVTtNQUNWLG1CQUFrQixFQUNyQjtFQUVMO0lBQ0ksZUFBYztJQUNkLGdCQUFlO0lBQ2YsaUJBQWdCLEVBQ25CO0VBQ0Q7SWRqRkEsZ0JGMkJPO0lFMUJQLGlCRjBCVztJRXpCWCxlRjJEYztJRWdGZCxvQkZuSFk7SUVvSFoscUJGcEhvQjtJRXlIWixxQ0pwSjBCO0lJd0w5QixpQkFBZ0I7SWNsR2hCLGVBQWM7SUFDZCxnQkFBZTtJQUNmLGlCQUFnQjtJQUNoQixtQmJ4RHNCLEVhOER6QjtJQWJEO01BU1EsZWhCeEJNO01nQnlCTiwwQkF6RW9FO01BMEVwRSxzQkFBcUIsRUFDeEI7RUFFTDtJZC9GQSxnQkYyQk87SUUxQlAsaUJGMEJXO0lFekJYLGVGMkRjO0lFZ0ZkLG1CRnJIVztJRXNIWCxxQkZ0SG1CO0lFMkhYLHFDSnBKMEI7SUl3TDlCLGlCQUFnQjtJQWZoQixxQmN2RW9DO0lBQ3BDLGVBQWM7SUFDZCxlaEJyQ1U7SWdCc0NWLG1CYnBFc0I7SWFxRXRCLGtCYnJFc0I7SWFzRXRCLDhCaEJ4QlUsRWdCeUJiOztBQ3ZHTDs7RUFFRTtBQUdGO0VBQ0ksaUJBQWdCO0VBQ2hCLFNBQVEsRUFDWDs7QUNQRDs7Ozs7O0VBTUU7QUFHRjtFaEJWSSxnQkYyQk87RUUxQlAsaUJGMEJXO0VFekJYLGVGMkRjO0VrQnhDZCxhZlcwQjtFZVYxQiwwQmxCa0RjO0VrQmpEZCxvQkFBbUI7RUFDbkIsb0JBQW1CO0VBQ25CLHNCbEJxRGM7RWtCcERkLHFCQUFhO0VBQWIscUJBQWE7RUFBYixjQUFhO0VBQ2IsMEJBQW1CO01BQW5CLHVCQUFtQjtVQUFuQixvQkFBbUIsRUEyQnRCO0VBdkJHO0loQi9CQSxnQkYyQk87SUUxQlAsaUJGMEJXO0lFekJYLGVGMkRjO0lFZ0ZkLG9CRi9HVztJRWdIWCxxQkZoSG1CO0lFcUhYLGdDSm5KdUI7SUl5TDNCLGlCQUFnQjtJZ0J2SmhCLG9CQUFPO1FBQVAsWUFBTztZQUFQLFFBQU87SUFDUCxpQkFBZ0IsRUFJbkI7SUFSRDtNQU1RLG1CZkxrQixFZU1yQjtFQUVMO0loQnhDQSxnQkYyQk87SUUxQlAsaUJGMEJXO0lFekJYLGVGMkRjO0lrQm5CVixxQkFBYTtJQUFiLHFCQUFhO0lBQWIsY0FBYTtJQUNiLDBDQTNCMkM7SUEyQjNDLGtDQTNCMkM7SUE0QjNDLG9CQUFtQixFQU10QjtJQVZEO01BT1EsV0FBVTtNQUNWLG1CQUFrQixFQUNyQjs7QUNsRFQ7O0VBRUU7QUFHRjtFakJKSSxnQkYyQk87RUUxQlAsaUJGMEJXO0VFekJYLGVGMkRjO0VFZ0ZkLG1CRnJIVztFRXNIWCxxQkZ0SG1CO0VFcUtmLGlCQUFnQjtFQWhCWiwwQkZySitCO0VtQmpCdkMsa0JuQlEwQjtFbUJQMUIsbUJBQWtCO0VBQ2xCLGtCQUFpQjtFQUNqQixvQkFBbUI7RUFDbkIsaUJoQnFCMEI7RWdCcEIxQix1QkFBc0IsRUFhekI7RUFaRztJQUNJLHNCQUFxQixFQUN4QjtFQUNEO0lBQ0ksZW5CaUVVLEVtQmhFYjtFQUNEO0lBQ0ksZW5CK0RVLEVtQjlEYjtFQUNEO0lBQ0ksZW5CNkRVLEVtQjVEYjs7QUp4Qkw7O0VBRUU7QUFJRjtFRFRJLFVBQVM7RUFDVCxXQUFVO0VBQ1YsNEJBQTJCO0VBQzNCLHlCQUFnQjtLQUFoQixzQkFBZ0I7VUFBaEIsaUJBQWdCO0VBQ2hCLFdBQVU7RUFDVixVQUFTO0VBQ1Qsc0JBQXFCO0VBQ3JCLHNCQUFxQjtFQUNyQixnQkFBZTtFQUNmLDBCQUFpQjtLQUFqQix1QkFBaUI7TUFBakIsc0JBQWlCO1VBQWpCLGtCQUFpQjtFQUNqQix1QkFBc0I7RUFDdEIsb0JBQW1CO0VBQ25CLDhCQUE2QjtFWm9JN0Isb0JGakhXO0VFa0hYLHFCRmxIbUI7RUV1SFgsZ0NKbkp1QjtFSXlMM0IsaUJBQWdCO0VhdEpwQixzQkFBcUI7RUFDckIsMEJmcUJjO0VlcEJkLG9EQVIwRDtFQVExRCw0Q0FSMEQ7RUFTMUQsZWY2QmM7RWU1QmQsaUJaUDBCO0VZUTFCLGFaUjBCO0VZUzFCLGtCWlQwQjtFWVUxQixtQlpWMEI7RVlXMUIsb0JaWDBCO0VZWTFCLG1CQUFrQjtFQUNsQiwwQkFBeUI7RUFDekIsaUJBQWdCLEVBc0tuQjtFQXBLRTtJYjZGQyxnQkZsSE87SUVtSFAsaUJGbkhXO0lFNEpQLGlCQUFnQjtJQUloQixpQkFBZ0I7SWF4SWhCLGlCWm5Cc0I7SVlvQnRCLGFacEJzQjtJWXFCdEIsa0JackJzQjtJWXNCdEIsbUJadEJzQjtJWXVCdEIsb0JadkJzQixFWXdCekI7RUFDRjtJYm9GQyxtQkZoSFU7SUVpSFYsaUJGakhjO0lFOEpWLGlCQUFnQjtJYWhJaEIsaUJaM0JzQjtJWTRCdEIsYVo1QnNCO0lZNkJ0QixrQlo3QnNCO0lZOEJ0QixtQlo5QnNCO0lZK0J0QixvQlovQnNCLEVZb0N6QjtFQTlETDtJQWdFUSwwQkF4RHNFO0lBeUR0RSxlZkpVO0llS1Ysc0JBQXFCLEVBQ3hCO0VBbkVMO0lBcUVRLGVmUlU7SWVTVix3Q2ZHVTtZZUhWLGdDZkdVO0llRlYsMkJBQTJELEVBQzlEO0VBeEVMO0lBK0VRLDBCQXRFdUU7SUF1RXZFLGVmbkJVLEVlb0JiO0VBakZMO0lBcUZRLDJCZmRVO0llZVYsZWY5QlU7SWUrQlYsMEJmakJVO0lla0JWLG9CQUFtQixFQUN0QjtFQUNGO0lBRUssZWZ6Q1U7SWUwQ1YsOEJBQTZCLEVBOEJoQztJQWpDRjtNQU1TLDhCQUE2QjtNQUM3QixlQUF3QyxFQUMzQztJQVJOO01BaUJTLDhCQUE2QjtNQUM3QixjQUFhO01BQ2IseUJBQWdCO2NBQWhCLGlCQUFnQixFQUNuQjtJQXBCTjtNQTBCUyxlQUF5QyxFQUM1QztJQTNCTjtNQStCUyxlZmpFTSxFZWtFVDtFQUVOO0lBQ0ssYVpuR3NCO0lZb0d0QixrQlpwR3NCO0lZcUd0QixtQlpyR3NCO0lZc0d0QixvQlp0R3NCO0lZdUd0QixtQkFBa0IsRUF1Q3JCO0lBNUNGO01BUVMsYVoxR2tCO01ZMkdsQixrQlozR2tCLEVZNEdyQjtJQVZOO01BWVMsWUFBVztNQUNYLHFDQUFvQztNQUNwQywyQkFBb0M7TUFDcEMsWUFBVztNQUNYLG1CQUFrQjtNQUNsQixZQUFXO01BQ1gsUUFBTztNQUNQLGtCWnJIa0I7TVlzSGxCLHVEQXpIa0Q7TUF5SGxELCtDQXpIa0QsRUEwSHJEO0lBckJOO01BdUJTLGNBQWE7TUFDYix5QkFBZ0I7Y0FBaEIsaUJBQWdCLEVBQ25CO0lBekJOO01Ba0NhLDZCZjNHRSxFZTRHTDtJQW5DVjtNQXlDYSxjQUFhLEVBQ2hCO0VBdEtiO0lBMktRLHNCQUFxQjtJQUNyQixvQkFBbUI7SUFDbkIsbUJabkpzQjtJWTBKdEIsaUJBQThELEVBV2pFO0lBaEJPO01BQ0ksa0JBQWlCO01BQ2pCLG1CQUFrQixFQUNyQjtJQUlEO01BQ0ksaUJBQTRFLEVBQy9FO0lBR0Q7TUFDSSxpQkFBNEUsRUFDL0U7RUFJVjtJYjFEQyxtQkZySFc7SUVzSFgscUJGdEhtQjtJRXFLZixpQkFBZ0I7SUFoQlosMEJGckorQjtJZWtMbkMsaUJBQWdCO0lBQ2hCLGtCQUFtRjtJQUNuRix1QkFBc0IsRUFPekI7SUFaRjtNQU9TLDBCQUF5QjtNQUN6QixpQlovS2tCO01ZZ0xsQixrQkFBaUI7TUFDakIsbUJBQWtCLEVBQ3JCOztBS3BOVDs7Ozs7OztFQU9FO0FBSUY7RWxCVEksZ0JGMkJPO0VFMUJQLGlCRjBCVztFRXpCWCxlRjJEYztFb0IvQmQscUJBQWE7RUFBYixxQkFBYTtFQUFiLGNBQWE7RUFDYixvQnBCaEIwQjtFb0JpQjFCLG9CQUFtQjtFQUNuQixrQkFBaUI7RUFDakIsc0JwQjRDYztFb0IzQ2QsMEJwQm9DYyxFb0I4RWpCO0VBaEhHO0lBQ0ksZUFBYyxFQU1qQjtJQVBEO01BR1EsWUFBVztNQUNYLGNBQWE7TUFDYixVQUFTLEVBQ1o7RUFFTDtJQUVJLGdCQUFlLEVBSWxCO0lBTkQ7TUFJUSxlcEJRTSxFb0JQVDtFQUVMO0lBRVEseUJBQWtFLEVBS3JFO0lBUEw7TUFJWSxVQUFTO01BQ1QsYUFBa0QsRUFDckQ7RUFOVDtJQVNRLG1CQUE4QyxFQUNqRDtFQVZMO0lBYVksVUFBUyxFQUNaO0VBSVQ7SUFFSSxnQkFBZTtJQUNmLG9IQTlDb0Q7SUE4Q3BELDRHQTlDb0Q7SUE4Q3BELG9HQTlDb0Q7SUE4Q3BELHVJQTlDb0QsRUFzRHZEO0lBWEQ7TUFLUSxzQnBCbEJNO01vQm1CTiwwQnBCTE07TW9CTU4sdURBdkRpRDtjQXVEakQsK0NBdkRpRDtNQXdEakQsc0JBQXFCO01BQ3JCLGVBQWMsRUFDakI7RUF2RVQ7SUE2RVEscUNBQStEO0lBQy9ELGlDQUF1RDtJQUN2RCxvQ0FBMkI7WUFBM0IsNEJBQTJCO0lBQzNCLGdCQUFlLEVBSWxCO0lBcEZMO01Ba0ZZLDBCQUF5QyxFQUM1QztFQUlMO0lBQ0ksNkJBQTRCO0lBQzVCLG1DQUFrQztJQUNsQyx1QkFBc0I7SUFDdEIsZ0JBdkZzQjtJQXdGdEIsaUJBeEZzQjtJQXlGdEIseUJwQnZGc0IsRW9Cb0d6QjtJQVhHO01BQ0ksVUFBUztNQUNULGFBQWdEO01BQ2hELHVCQUFzQixFQUl6QjtNQVBEO1FBS1EsbUJBQWdDLEVBQ25DO0lBRUw7TUFDSSxtQkFBa0IsRUFDckI7RUFFTDtJQUNJLG1CcEJ0R3NCO0lvQnVHdEIsZ0JBQWU7SUFDZixvQkFBTztRQUFQLFlBQU87WUFBUCxRQUFPO0lBQ1AsaUJBQWdCLEVBQ25CO0VBQ0Q7SUFDSSxlcEI5RFU7SUVnRmQsb0JGakhXO0lFa0hYLHFCRmxIbUI7SUUrSmYsaUJBQWdCO0lrQjlEaEIsbUJBQWtCLEVBQ3JCO0VBQ0Q7SWxCY0EscUJGcEhhO0lFcUhiLHFCRnJIcUI7SUU4SmpCLGlCQUFnQjtJa0J0RGhCLG9CcEJuSG9CO0lvQndIcEIsaUJBQWdCO0lBQ2hCLHdCQUF1QixFQUMxQjtFQUNEO0lsQklBLG1CRnJIVztJRXNIWCxxQkZ0SG1CO0lFcUtmLGlCQUFnQjtJQWhCWiwwQkZySitCLEVvQm1IdEM7RUFDRDtJQUNJLG1CQUE0QyxFQUMvQztFQXJJTDtJQXVJUSxlcEJ2RlUsRW9CMkZiO0lBM0lMO01BeUlZLGVwQnpGTSxFb0IwRlQ7O0FDcEpUOztFQUVFO0FBR0Y7RW5CSkksZ0JGMkJPO0VFMUJQLGlCRjBCVztFRXpCWCxlRjJEYztFcUJoRGQscUJBQWE7RUFBYixxQkFBYTtFQUFiLGNBQWE7RUFDYixvQkFBZTtNQUFmLGdCQUFlO0VBQ2YsNkJBQXNCO0VBQXRCLDhCQUFzQjtNQUF0QiwyQkFBc0I7VUFBdEIsdUJBQXNCLEVBa0N6QjtFbkIwQ0c7SUFDSSxZQUFXO0lBQ1gsZUFBYztJQUNkLFlBQVcsRUFDZDtFbUIzRkw7SUFhUSxxQnJCRnNCLEVxQkd6QjtFbkJnR0Q7SW1COUdKO01BZ0JRLCtCQUFtQjtNQUFuQiw4QkFBbUI7VUFBbkIsd0JBQW1CO2NBQW5CLG9CQUFtQixFQTZCMUI7TUE3Q0Q7UUFrQlksb0JBQU87WUFBUCxZQUFPO2dCQUFQLFFBQU87UUFDUCxtQnJCUmtCO1FxQlNsQixxQ0FBeUQ7UUFDekQscUNBQXlELEVBSTVEO1FBekJUO1VBdUJnQixnQkFBZSxFQUNsQjtNQUlEO1FBR1EscUNBQXlEO1FBQ3pELHFDQUF5RCxFQVE1RDtRQVpMO1VBT1ksbUJyQnhCTSxFcUJ5QlQ7UUFSVDtVQVVZLGdCQUFlLEVBQ2xCO01BWFQ7UUFHUSxxQ0FBeUQ7UUFDekQscUNBQXlELEVBUTVEO1FBWkw7VUFPWSxtQnJCeEJNLEVxQnlCVDtRQVJUO1VBVVksZ0JBQWUsRUFDbEIsRUFBQTs7QUwzQ3JCOzs7O0VBSUU7QUFHRjtFZFBJLGdCRjJCTztFRTFCUCxpQkYwQlc7RUV6QlgsZUYyRGM7RWdCbkNkLG1CQUFrQjtFQUNsQixzQkFBcUIsRUE4RXhCO0VBNUVFO0lGaENDLFVBQVM7SUFDVCxXQUFVO0lBQ1YsNEJBQTJCO0lBQzNCLHlCQUFnQjtZQUFoQixpQkFBZ0I7SUFDaEIsV0FBVTtJQUNWLFVBQVM7SUFDVCxzQkFBcUI7SUFDckIsc0JBQXFCO0lBQ3JCLGdCQUFlO0lBQ2YsMEJBQWlCO09BQWpCLHVCQUFpQjtRQUFqQixzQkFBaUI7WUFBakIsa0JBQWlCO0lBQ2pCLHVCQUFzQjtJQUN0QixvQkFBbUI7SUFDbkIsOEJBQTZCO0laVDdCLGdCRjJCTztJRTFCUCxpQkYwQlc7SUV6QlgsZUYyRGM7SUVnRmQsZ0JGbEhPO0lFbUhQLGlCRm5IVztJRXdISCxxQ0pwSjBCO0lJd0w5QixpQkFBZ0I7SUE1S3BCLGlCQUFnQjtJQUNoQiw4QkFBNkI7SUFDN0IsMkJBQTBCO0lBQzFCLG1CQUFrQjtJQUNsQiwrQkFBc0I7WUFBdEIsdUJBQXNCO0lBQ3RCLGNBQWE7SUFDYixvQkFBbUI7SUFDbkIsa0JBQWlCO0lBQ2pCLHNCRjJEYztJRTFEZCxpQkFBZ0I7SUFDaEIsZUZ3Q2M7SUV0Q2QsOEJBQTZCO0lBQzdCLHdDRnNHd0I7SUV0R3hCLGdDRnNHd0I7SUVuRXhCLGFDM0IwQjtJRDRCMUIsbUJDNUIwQjtJRDZCMUIsb0JDN0IwQjtJRGtDMUIsaUJBQWdCO0lBQ2hCLHNCQUFxQjtJQUNyQixraUJBQXVCO0lBQ3ZCLDZCQUE0QjtJQUM1Qiw4Q0FBb0Y7SUFDcEYsb0JBQWlGO0ljdkM3RSxtQkFBa0I7SUFDbEIsa0JiRHNCLEVhZ0J6QjtJZHRCRDtNQUVJLHNCRjZCVSxFRTNCYjtJQUNEO01BQ0ksc0JGb0RVLEVFbkRiO0lBQ0Q7TUFDSSxzQkYrQ1UsRUU5Q2I7SUFDRDtNQUNJLHNCRjZDVSxFRTVDYjtJQUNEO01BR0ksb0JBQW1CO01BQ25CLGVGbUJVO01FbEJWLHNCRm9HMkQ7TUVuRzNELDBCRjhCVSxFRTdCYjtJQUNEO01BRUksZUZXVTtNRVRWLHNCRjZGMkQ7TUU1RjNELHNCQUFxQixFQUN4QjtJQWtCRDtNQUVJLGtpQkFBdUIsRUFDMUI7SUFDRDtNQUVJLDhqQkFBdUIsRUFDMUI7SUFDRDtNQUdJLGtpQkFBdUIsRUFDMUI7SWN2REY7TUFPUyxzQmhCcUJNO01nQnBCTixXQUFzQztNQUN0Qyx5RGhCeUNNO2NnQnpDTixpRGhCeUNNLEVnQnhDVDtJQUNGO01BQ0ssMEJBQXlCLEVBTTVCO01BUEY7UUFLUywwQkFBeUIsRUFDNUI7RUFHVjtJQUNLLG1CYmxCc0I7SWFtQnRCLHVCQUFzQjtJQUN0QixvQ0FBMkI7WUFBM0IsNEJBQTJCLEVBQzlCO0VBQ0Y7SUFFSyxlQUFjO0lBQ2QsZ0JBQWU7SUFDZixpQkFBZ0I7SUFDaEIsZ0JBQWU7SUFDZiwwQmhCa0JVO0lnQmpCVixvQmhCVVU7SWdCVFYsbUJBQWtCO0lBQ2xCLG9CQUFtQjtJQUNuQixXQXJEd0I7SUFzRHhCLG9DQUEyQjtZQUEzQiw0QkFBMkI7SUFDM0IseURoQmFVO1lnQmJWLGlEaEJhVTtJZ0JaVixXQUFVO0lBQ1Ysb0JBQW1CO0lBQ25CLDJDQWhEa0U7SUFnRGxFLG1DQWhEa0UsRUFzRHJFO0lBckJGO01Ba0JTLFdBQVU7TUFDVixtQkFBa0IsRUFDckI7RUFFTjtJQUNLLGVBQWM7SUFDZCxnQkFBZTtJQUNmLGlCQUFnQixFQUNuQjtFQUNGO0lkakZDLGdCRjJCTztJRTFCUCxpQkYwQlc7SUV6QlgsZUYyRGM7SUVnRmQsb0JGbkhZO0lFb0haLHFCRnBIb0I7SUV5SFoscUNKcEowQjtJSXdMOUIsaUJBQWdCO0ljbEdoQixlQUFjO0lBQ2QsZ0JBQWU7SUFDZixpQkFBZ0I7SUFDaEIsbUJieERzQixFYThEekI7SUFiRjtNQVNTLGVoQnhCTTtNZ0J5Qk4sMEJBekVvRTtNQTBFcEUsc0JBQXFCLEVBQ3hCO0VBRU47SWQvRkMsZ0JGMkJPO0lFMUJQLGlCRjBCVztJRXpCWCxlRjJEYztJRWdGZCxtQkZySFc7SUVzSFgscUJGdEhtQjtJRTJIWCxxQ0pwSjBCO0lJd0w5QixpQkFBZ0I7SUFmaEIscUJjdkVvQztJQUNwQyxlQUFjO0lBQ2QsZWhCckNVO0lnQnNDVixtQmJwRXNCO0lhcUV0QixrQmJyRXNCO0lhc0V0Qiw4QmhCeEJVLEVnQnlCYjs7QU14R0w7Ozs7Ozs7OztFQVNFO0FwQm1GRTtFQUNJLFlBQVc7RUFDWCxlQUFjO0VBQ2QsWUFBVyxFQUNkOztBQUlEO0VBQ0ksaUJBQWdCO0VBQ2hCLGdCQUFlLEVBRWxCOztBb0JsRkQ7RUFLUSxtQm5CTWtCLEVtQkxyQjtFQU5MO0lwQitFSSxpQkFBZ0I7SUFDaEIsZ0JBQWUsRUFFbEI7O0FvQjFFRDtFQUNJLG9CbkJFc0IsRW1CT3pCO0VBVkQ7SUFJWSxpQkFBZ0IsRUFDbkI7RUFMVDtJQVFRLGdCbkJMa0IsRW1CTXJCOztBQUVMO0VBRUksb0JuQlZzQixFbUJ3Q3pCO0VwQjJCRDtJQUNJLGlCQUFnQjtJQUNoQixnQkFBZSxFQUVsQjtFb0I1REc7SUFFSSxtQkFBa0I7SUFDbEIsZUFBYyxFQWtCakI7SXBCMkJMO01BQ0ksWUFBVztNQUNYLGVBQWM7TUFDZCxZQUFXLEVBQ2Q7SW9CcERHO01wQmtHSixnQkZsSE87TUVtSFAsaUJGbkhXO01FNEpQLGlCQUFnQjtNb0J0SVIsaUJBQWdCO01BQ2hCLHVCQUFzQjtNQUN0QixxQkFBYTtNQUFiLHFCQUFhO01BQWIsY0FBYTtNQUNiLDBCQUFtQjtVQUFuQix1QkFBbUI7Y0FBbkIsb0JBQW1CO01BQ25CLGtCbkJyQmMsRW1Cc0JqQjtJQVhMO01BYVEsWUFBVztNQUNYLHVCQUFzQjtNQUN0QixtQm5CMUJjLEVtQjJCakI7SUFoQkw7TUFrQlEsWUFBVztNQUNYLGtCbkI5QmMsRW1CK0JqQjtFQUVMO0lBQ0ksWUFBVyxFQUtkO0lBTkQ7TUFHUSxnQm5CcENjO01tQnFDZCxZQUFXLEVBQ2Q7O0FBR1Q7RXBCb0VBLG9CRm5IWTtFRW9IWixxQkZwSG9CO0VFNkpoQixpQkFBZ0I7RW9CNUdoQixlQUFjO0VBQ2QsbUJuQjVDc0I7RW1CNkN0QixVQUFTO0VBQ1QsZXRCZlUsRXNCbUJiO0VBVEQ7SXBCb0hJLGlCQUFnQixFb0I1R2Y7O0FBRUw7RUFDSSxnQm5CcERzQixFbUJxRHpCOztBQUNEO0VBQ0ksb0JuQnZEc0IsRW1Cd0R6Qjs7QUFDRDtFQUNJLGFBQVksRUFDZjs7QUFDRDtFQUNJLFlBQVc7RUFDWCxlQUFjO0VwQitDbEIsb0JGbkhZO0VFb0haLHFCRnBIb0I7RUU2SmhCLGlCQUFnQjtFb0J2RmhCLGV0QmxDVTtFc0JtQ1YsZUFBc0I7RUFDdEIsbUJBQWtCO0VBQ2xCLG1CQUFrQixFQXFEckI7RUFsRE87SUFDSSxxQ0FBcUM7WUFBckMsNkJBQXFDO0lBQ3JDLHFCbkJ4RWMsRW1CeUVqQjtFQUNEO0lBQ0ksbUNBQWtDO1lBQWxDLDJCQUFrQztJQUNsQyxtQm5CNUVjLEVtQjZFakI7RUFqQlQ7SUFvQlEsWUFBVztJQUNYLGFBQVk7SUFDWixtQkFBa0I7SUFDbEIsbUJBQWtCO0lBQ2xCLFFBQU87SUFDUCxldEJuRE07SXNCb0ROLG1CQUFrQjtJQUNsQiwwQnRCeERNO0lzQnlETixtQkFBa0IsRUFDckI7RUFDRDtJQUNJLG1CbkIzRmtCLEVtQitGckI7SUFMRDtNQUdRLGFBQVksRUFDZjtFQUVMO0lBQ0ksbUJuQmpHa0I7SW1Ca0dsQixldEJyRU0sRXNCMEVUO0lBUEQ7TUFJUSxhQUFZO01BQ1osVW5CckdjLEVtQnNHakI7RUFFTDtJQUNJLDBCQUFrRSxFQU9yRTtJQVJEO01BR1EsOEJBQTZCO01BQzdCLGlCQUFnQjtNcEI0RDlCLFVBQVM7TUFDVCxTQUFRO01BT0osa0NGN0hZO01FOEhaLG9DQVZrRTtNQVdsRSxxQ0FYa0U7TW9CekR4RCxvQkFBbUIsRUFDdEI7RUFFTDtJQUNJLDBCQUFnRSxFQUtuRTtJQU5EO01BR1EsMEJ0QmhFRTtNc0JpRUYsZXRCbkZFLEVzQm9GTDs7QUN0SmI7Ozs7RUFJRTtBQUdGO0VyQlBJLGdCRjJCTztFRTFCUCxpQkYwQlc7RUV6QlgsZUYyRGM7RXVCL0NkLHFCQUFhO0VBQWIscUJBQWE7RUFBYixjQUFhO0VBQ2IsdUJBQXNCO0VBQ3RCLGlCcEJnQjBCLEVvQjZGN0I7RUF0SEQ7SUFtQlEsMkJBQTBCLEVBQzdCO0lBcEJMO01BZ0JZLHlCQUF3QjtNQUN4QixVQUFTLEVBQ1o7RUFsQlQ7SUFzQlEsZ3BCQUErb0I7SUFDL29CLDZCQUE0QjtJQUM1QixpQ0FBdUM7SUFDdkMsbUJwQkFzQjtJb0JDdEIsb0JwQkRzQjtJb0JVdEIsMkJBQTBCLEVBQzdCO0lBcENMO01BNEJZLHlCQUF3QjtNQUN4QixVQUFTLEVBQ1o7SUE5QlQ7TUFnQ1kseUJBQXdCO01BQ3hCLFVBQVMsRUFDWjtFQUdMO0lBQ0ksNEJBQW9CO0lBQXBCLDRCQUFvQjtJQUFwQixxQkFBb0IsRUFDdkI7RUFDRDtJQUVRLDBCQUF5QixFQUM1QjtFQUVMO0lyQnlGQSxxQkZwSGE7SUVxSGIscUJGckhxQjtJRTBIYixxQ0pwSjBCO0lJOEw5QixpQkFBZ0I7SUFyQmhCLHVCcUJuSHVDO0lBQ3ZDLGV2QlNVO0l1QlJWLGdCcEJ2QnNCO0lvQndCdEIsb0JBQW1CO0lBQ25CLGtCQUFpQjtJQUNqQixzQnZCb0JVO0l1Qm5CViwwQnZCaUJVO0l1QmhCVix5QkFBdUI7UUFBdkIsc0JBQXVCO1lBQXZCLHdCQUF1QjtJQUN2QixxQkFBYTtJQUFiLHFCQUFhO0lBQWIsY0FBYTtJQUNiLDZCQUFzQjtJQUF0Qiw4QkFBc0I7UUFBdEIsMkJBQXNCO1lBQXRCLHVCQUFzQixFQTBCekI7SUFwQ0Q7TUFlUSxzQkFBcUIsRUFDeEI7SUFoQkw7TUFrQlEscUJBQW9CLEVBQ3ZCO0lBQ0Q7TUFDSSxXQUFVLEVBQ2I7STFCNGxETDtNMEJ6bERZLDhCQUE2QjtNQUM3QixnQ0FBK0IsRUFDbEM7STFCMGxEVDtNMEJ0bERZLFVBQVM7TUFDVCxTQUFRLEVBQ1g7RUFJVDtJVDVGQSxVQUFTO0lBQ1QsV0FBVTtJQUNWLDRCQUEyQjtJQUMzQix5QkFBZ0I7T0FBaEIsc0JBQWdCO1lBQWhCLGlCQUFnQjtJQUNoQixXQUFVO0lBQ1YsVUFBUztJQUNULHNCQUFxQjtJQUNyQixzQkFBcUI7SUFDckIsZ0JBQWU7SUFDZiwwQkFBaUI7T0FBakIsdUJBQWlCO1FBQWpCLHNCQUFpQjtZQUFqQixrQkFBaUI7SUFDakIsdUJBQXNCO0lBQ3RCLG9CQUFtQjtJQUNuQiw4QkFBNkI7SVNrRnpCLG9CQUFPO1FBQVAsWUFBTztZQUFQLFFBQU87SUFDUCxZQUFXO0lBQ1gsZUFBYztJQUNkLGdCcEI5RHNCLEVvQjBGekI7SUEzQkc7TUFDSSxnQkFBZSxFQUtsQjtNQU5EO1FBR1EsWUFBVztRQUNYLG1CQUFrQixFQUNyQjtJQUVMO01BQ0ksaUN2QnpCTSxFdUI4QlQ7TUFORDtRckJrR04sVUFBUztRQUNULFNBQVE7UUFPSiwrQnFCdkcyQztRckJ3RzNDLHFDQVZrRTtRQVdsRSxzQ0FYa0U7UXFCN0Z4RCxXQUFVLEVBQ2I7SUFFTDtNckIyRk4sVUFBUztNQUNULFNBQVE7TUFlSixxQ0FqQmtFO01Ba0JsRSxzQ0FsQmtFO01BbUJsRSw0QnFCM0cyQztNQUNqQyxVQUFTLEVBQ1o7SUFFTDtNQUNJLG9qQkFBbWpCO01BQ25qQiw2QkFBNEI7TUFDNUIsNEJBQTJCO01BQzNCLG1CQUFrQjtNQUNsQixZcEJ4RmtCLEVvQnlGckI7O0FDMUhUOztFQUVFO0FBR0Y7RXRCSkksZ0JGMkJPO0VFMUJQLGlCRjBCVztFRXpCWCxlRjJEYztFRWdGZCxtQkZySFc7RUVzSFgscUJGdEhtQjtFRXFLZixpQkFBZ0I7RUFoQlosMEJGckorQixFd0JSMUM7RUFURztJQUNJLGV4QjBFVSxFd0J6RWI7RUFDRDtJQUNJLGV4QndFVSxFd0J2RWI7RUFDRDtJQUNJLGV4QnNFVSxFd0JyRWI7O0FUZkw7O0VBRUU7QUFJRjtFRFRJLFVBQVM7RUFDVCxXQUFVO0VBQ1YsNEJBQTJCO0VBQzNCLHlCQUFnQjtLQUFoQixzQkFBZ0I7VUFBaEIsaUJBQWdCO0VBQ2hCLFdBQVU7RUFDVixVQUFTO0VBQ1Qsc0JBQXFCO0VBQ3JCLHNCQUFxQjtFQUNyQixnQkFBZTtFQUNmLDBCQUFpQjtLQUFqQix1QkFBaUI7TUFBakIsc0JBQWlCO1VBQWpCLGtCQUFpQjtFQUNqQix1QkFBc0I7RUFDdEIsb0JBQW1CO0VBQ25CLDhCQUE2QjtFWm9JN0Isb0JGakhXO0VFa0hYLHFCRmxIbUI7RUV1SFgsZ0NKbkp1QjtFSXlMM0IsaUJBQWdCO0VhdEpwQixzQkFBcUI7RUFDckIsMEJmcUJjO0VlcEJkLG9EQVIwRDtFQVExRCw0Q0FSMEQ7RUFTMUQsZWY2QmM7RWU1QmQsaUJaUDBCO0VZUTFCLGFaUjBCO0VZUzFCLGtCWlQwQjtFWVUxQixtQlpWMEI7RVlXMUIsb0JaWDBCO0VZWTFCLG1CQUFrQjtFQUNsQiwwQkFBeUI7RUFDekIsaUJBQWdCLEVBc0tuQjtFQXBLQztJYjZGRSxnQkZsSE87SUVtSFAsaUJGbkhXO0lFNEpQLGlCQUFnQjtJQUloQixpQkFBZ0I7SWF4SWhCLGlCWm5Cc0I7SVlvQnRCLGFacEJzQjtJWXFCdEIsa0JackJzQjtJWXNCdEIsbUJadEJzQjtJWXVCdEIsb0JadkJzQixFWXdCekI7RUFDSDtJYm9GRSxtQkZoSFU7SUVpSFYsaUJGakhjO0lFOEpWLGlCQUFnQjtJYWhJaEIsaUJaM0JzQjtJWTRCdEIsYVo1QnNCO0lZNkJ0QixrQlo3QnNCO0lZOEJ0QixtQlo5QnNCO0lZK0J0QixvQlovQnNCLEVZb0N6QjtFQTlETDtJQWdFUSwwQkF4RHNFO0lBeUR0RSxlZkpVO0llS1Ysc0JBQXFCLEVBQ3hCO0VBbkVMO0lBcUVRLGVmUlU7SWVTVix3Q2ZHVTtZZUhWLGdDZkdVO0llRlYsMkJBQTJELEVBQzlEO0VBeEVMO0lBK0VRLDBCQXRFdUU7SUF1RXZFLGVmbkJVLEVlb0JiO0VBakZMO0lBcUZRLDJCZmRVO0llZVYsZWY5QlU7SWUrQlYsMEJmakJVO0lla0JWLG9CQUFtQixFQUN0QjtFQUNIO0lBRU0sZWZ6Q1U7SWUwQ1YsOEJBQTZCLEVBOEJoQztJQWpDSDtNQU1VLDhCQUE2QjtNQUM3QixlQUF3QyxFQUMzQztJQVJQO01BaUJVLDhCQUE2QjtNQUM3QixjQUFhO01BQ2IseUJBQWdCO2NBQWhCLGlCQUFnQixFQUNuQjtJQXBCUDtNQTBCVSxlQUF5QyxFQUM1QztJQTNCUDtNQStCVSxlZmpFTSxFZWtFVDtFQUVQO0lBQ00sYVpuR3NCO0lZb0d0QixrQlpwR3NCO0lZcUd0QixtQlpyR3NCO0lZc0d0QixvQlp0R3NCO0lZdUd0QixtQkFBa0IsRUF1Q3JCO0lBNUNIO01BUVUsYVoxR2tCO01ZMkdsQixrQlozR2tCLEVZNEdyQjtJQVZQO01BWVUsWUFBVztNQUNYLHFDQUFvQztNQUNwQywyQkFBb0M7TUFDcEMsWUFBVztNQUNYLG1CQUFrQjtNQUNsQixZQUFXO01BQ1gsUUFBTztNQUNQLGtCWnJIa0I7TVlzSGxCLHVEQXpIa0Q7TUF5SGxELCtDQXpIa0QsRUEwSHJEO0lBckJQO01BdUJVLGNBQWE7TUFDYix5QkFBZ0I7Y0FBaEIsaUJBQWdCLEVBQ25CO0lBekJQO01Ba0NjLDZCZjNHRSxFZTRHTDtJQW5DWDtNQXlDYyxjQUFhLEVBQ2hCO0VBdEtiO0lBMktRLHNCQUFxQjtJQUNyQixvQkFBbUI7SUFDbkIsbUJabkpzQjtJWTBKdEIsaUJBQThELEVBV2pFO0lBaEJPO01BQ0ksa0JBQWlCO01BQ2pCLG1CQUFrQixFQUNyQjtJQUlEO01BQ0ksaUJBQTRFLEVBQy9FO0lBR0Q7TUFDSSxpQkFBNEUsRUFDL0U7RUFJWDtJYjFERSxtQkZySFc7SUVzSFgscUJGdEhtQjtJRXFLZixpQkFBZ0I7SUFoQlosMEJGckorQjtJZWtMbkMsaUJBQWdCO0lBQ2hCLGtCQUFtRjtJQUNuRix1QkFBc0IsRUFPekI7SUFaSDtNQU9VLDBCQUF5QjtNQUN6QixpQlovS2tCO01ZZ0xsQixrQkFBaUI7TUFDakIsbUJBQWtCLEVBQ3JCOztBQ2xOVDs7OztFQUlFO0FBR0Y7RWRQSSxnQkYyQk87RUUxQlAsaUJGMEJXO0VFekJYLGVGMkRjO0VnQm5DZCxtQkFBa0I7RUFDbEIsc0JBQXFCLEVBOEV4QjtFQTVFQztJRmhDRSxVQUFTO0lBQ1QsV0FBVTtJQUNWLDRCQUEyQjtJQUMzQix5QkFBZ0I7WUFBaEIsaUJBQWdCO0lBQ2hCLFdBQVU7SUFDVixVQUFTO0lBQ1Qsc0JBQXFCO0lBQ3JCLHNCQUFxQjtJQUNyQixnQkFBZTtJQUNmLDBCQUFpQjtPQUFqQix1QkFBaUI7UUFBakIsc0JBQWlCO1lBQWpCLGtCQUFpQjtJQUNqQix1QkFBc0I7SUFDdEIsb0JBQW1CO0lBQ25CLDhCQUE2QjtJWlQ3QixnQkYyQk87SUUxQlAsaUJGMEJXO0lFekJYLGVGMkRjO0lFZ0ZkLGdCRmxITztJRW1IUCxpQkZuSFc7SUV3SEgscUNKcEowQjtJSXdMOUIsaUJBQWdCO0lBNUtwQixpQkFBZ0I7SUFDaEIsOEJBQTZCO0lBQzdCLDJCQUEwQjtJQUMxQixtQkFBa0I7SUFDbEIsK0JBQXNCO1lBQXRCLHVCQUFzQjtJQUN0QixjQUFhO0lBQ2Isb0JBQW1CO0lBQ25CLGtCQUFpQjtJQUNqQixzQkYyRGM7SUUxRGQsaUJBQWdCO0lBQ2hCLGVGd0NjO0lFdENkLDhCQUE2QjtJQUM3Qix3Q0ZzR3dCO0lFdEd4QixnQ0ZzR3dCO0lFbkV4QixhQzNCMEI7SUQ0QjFCLG1CQzVCMEI7SUQ2QjFCLG9CQzdCMEI7SURrQzFCLGlCQUFnQjtJQUNoQixzQkFBcUI7SUFDckIsa2lCQUF1QjtJQUN2Qiw2QkFBNEI7SUFDNUIsOENBQW9GO0lBQ3BGLG9CQUFpRjtJY3ZDN0UsbUJBQWtCO0lBQ2xCLGtCYkRzQixFYWdCekI7SWR0QkQ7TUFFSSxzQkY2QlUsRUUzQmI7SUFDRDtNQUNJLHNCRm9EVSxFRW5EYjtJQUNEO01BQ0ksc0JGK0NVLEVFOUNiO0lBQ0Q7TUFDSSxzQkY2Q1UsRUU1Q2I7SUFDRDtNQUdJLG9CQUFtQjtNQUNuQixlRm1CVTtNRWxCVixzQkZvRzJEO01FbkczRCwwQkY4QlUsRUU3QmI7SUFDRDtNQUVJLGVGV1U7TUVUVixzQkY2RjJEO01FNUYzRCxzQkFBcUIsRUFDeEI7SUFrQkQ7TUFFSSxraUJBQXVCLEVBQzFCO0lBQ0Q7TUFFSSw4akJBQXVCLEVBQzFCO0lBQ0Q7TUFHSSxraUJBQXVCLEVBQzFCO0ljdkRIO01BT1Usc0JoQnFCTTtNZ0JwQk4sV0FBc0M7TUFDdEMseURoQnlDTTtjZ0J6Q04saURoQnlDTSxFZ0J4Q1Q7SUFDSDtNQUNNLDBCQUF5QixFQU01QjtNQVBIO1FBS1UsMEJBQXlCLEVBQzVCO0VBR1g7SUFDTSxtQmJsQnNCO0lhbUJ0Qix1QkFBc0I7SUFDdEIsb0NBQTJCO1lBQTNCLDRCQUEyQixFQUM5QjtFQUNIO0lBRU0sZUFBYztJQUNkLGdCQUFlO0lBQ2YsaUJBQWdCO0lBQ2hCLGdCQUFlO0lBQ2YsMEJoQmtCVTtJZ0JqQlYsb0JoQlVVO0lnQlRWLG1CQUFrQjtJQUNsQixvQkFBbUI7SUFDbkIsV0FyRHdCO0lBc0R4QixvQ0FBMkI7WUFBM0IsNEJBQTJCO0lBQzNCLHlEaEJhVTtZZ0JiVixpRGhCYVU7SWdCWlYsV0FBVTtJQUNWLG9CQUFtQjtJQUNuQiwyQ0FoRGtFO0lBZ0RsRSxtQ0FoRGtFLEVBc0RyRTtJQXJCSDtNQWtCVSxXQUFVO01BQ1YsbUJBQWtCLEVBQ3JCO0VBRVA7SUFDTSxlQUFjO0lBQ2QsZ0JBQWU7SUFDZixpQkFBZ0IsRUFDbkI7RUFDSDtJZGpGRSxnQkYyQk87SUUxQlAsaUJGMEJXO0lFekJYLGVGMkRjO0lFZ0ZkLG9CRm5IWTtJRW9IWixxQkZwSG9CO0lFeUhaLHFDSnBKMEI7SUl3TDlCLGlCQUFnQjtJY2xHaEIsZUFBYztJQUNkLGdCQUFlO0lBQ2YsaUJBQWdCO0lBQ2hCLG1CYnhEc0IsRWE4RHpCO0lBYkg7TUFTVSxlaEJ4Qk07TWdCeUJOLDBCQXpFb0U7TUEwRXBFLHNCQUFxQixFQUN4QjtFQUVQO0lkL0ZFLGdCRjJCTztJRTFCUCxpQkYwQlc7SUV6QlgsZUYyRGM7SUVnRmQsbUJGckhXO0lFc0hYLHFCRnRIbUI7SUUySFgscUNKcEowQjtJSXdMOUIsaUJBQWdCO0lBZmhCLHFCY3ZFb0M7SUFDcEMsZUFBYztJQUNkLGVoQnJDVTtJZ0JzQ1YsbUJicEVzQjtJYXFFdEIsa0JickVzQjtJYXNFdEIsOEJoQnhCVSxFZ0J5QmI7O0FTdEdMOzs7OztFQUtFO0FBR0Y7RXZCVEksZ0JGMkJPO0VFMUJQLGlCRjBCVztFRXpCWCxlRjJEYztFeUJ6Q2QsaUJ0QlkwQjtFc0JYMUIsMEJ6Qm1EYztFeUJsRGQsc0J6QndEYztFeUJ2RGQsb0JBQW1CO0VBQ25CLG9CQUFtQjtFQVluQixxQkFBYTtFQUFiLHFCQUFhO0VBQWIsY0FBYTtFQUNiLG9CQUFlO01BQWYsZ0JBQWUsRUFrR2xCO0VBOUhEO0lBbUJRLHNCQUFxQjtJQUNyQix1QkFBc0I7SUFDdEIsZUFBYztJQUVkLGF0QkFzQjtJc0JDdEIsK0J6QjZDVSxFeUI1Q2I7RUFJRDtJQUNJLGlCdEJQc0I7SXNCU3RCLGtCQUFpQjtJQUNqQixzQ0EzQjRDO0lBMkI1Qyw4QkEzQjRDO0lBNEI1QyxZQUFXLEVBd0NkO0lBdkNHO01BQ0ksNkJBQVE7VUFBUixrQkFBUTtjQUFSLFNBQVE7TUFDUixxQkFBYTtNQUFiLHFCQUFhO01BQWIsY0FBYTtNQUNiLDBCQUFtQjtVQUFuQix1QkFBbUI7Y0FBbkIsb0JBQW1CO01BQ25CLDhCekI4Qk0sRXlCMUJUO012QjhETDtRdUJ0RUk7VUFNUSxpQkFBZ0IsRUFFdkIsRUFBQTtJQUNEO01BQ0kscUJBQWE7TUFBYixxQkFBYTtNQUFiLGNBQWEsRUFDaEI7SUFDRDtNQUNJLDBCekJjTTtNeUJiTiw4QnpCb0JNLEV5Qm5CVDtJQUNEO01BQ0ksOEJ6QmlCTTtNeUJoQk4scUJBQWE7TUFBYixxQkFBYTtNQUFiLGNBQWE7TUFDYiwwQkFBbUI7VUFBbkIsdUJBQW1CO2NBQW5CLG9CQUFtQixFQUN0QjtJdkJrREw7TXVCaERRO1FBQ0ksWUFBVyxFQUNkO01BQ0Q7UUFDSSxZQUFXO1FBQ1gsNkJBQVE7WUFBUixrQkFBUTtnQkFBUixTQUFRO1FBQ1Isa0JBQWlCLEVBQ3BCO01BQ0Q7UUFDSSxlQUFjO1FBQ2Qsa0JBQWlCLEVBQ3BCLEVBQUE7SUF2Q1Q7TUEwQ1EsY0FBYTtNQUNiLGFBQVksRUFDZjtFQUVMO0lBQ0ksZUFBYyxFQUlqQjtJdkJ5QkQ7TXVCOUJBO1FBR1EsbUJ0QnZEa0IsRXNCeUR6QixFQUFBO0VBQ0Q7SUFDSSxjQUFhLEVBS2hCO0l2QmtCRDtNdUJ4QkE7UUFHUSxlQUFjO1FBQ2QsK0J6QmhCTSxFeUJrQmIsRUFBQTtFQUNEO0lBRVEsMEJ6QjVCTSxFeUI2QlQ7RUFHTDtJQUNJLGtCdEJ4RXNCO0lzQnlFdEIsaUJBQWdCO0lBQ2hCLGlCQUFnQjtJQUNoQixvQkFBZTtRQUFmLGdCQUFlLEVBS2xCO0l2QkVEO011QlhBO1FBTVEsNEJBQW9CO1FBQXBCLDRCQUFvQjtRQUFwQixxQkFBb0I7UUFDcEIsMEJBQW1CO1lBQW5CLHVCQUFtQjtnQkFBbkIsb0JBQW1CLEVBRTFCLEVBQUE7RUFDRDtJdkI0QkEsbUJGckhXO0lFc0hYLHFCRnRIbUI7SUUySFgscUNKcEowQjtJSXdMOUIsaUJBQWdCO0lBZmhCLHFCdUJ0RG9DO0lBQ3BDLHFCQUFvQjtJQUNwQixxQkFBYTtJQUFiLHFCQUFhO0lBQWIsY0FBYTtJQUNiLDBCQUFtQjtRQUFuQix1QkFBbUI7WUFBbkIsb0JBQW1CO0lBQ25CLG1CdEJ0RnNCLEVzQmtHekI7SXZCaEJEO011QkRBO1FBT1EsNEJBQW9CO1FBQXBCLDRCQUFvQjtRQUFwQixxQkFBb0IsRUFVM0IsRUFBQTtJQWpCRDtNQVVRLGFBQVMsRUFBSztJQVZ0QjtNQWNZLGNBQWEsRUFDaEI7RUFHVDtJdkJVQSxtQkZySFc7SUVzSFgscUJGdEhtQjtJRTJIWCxxQ0pwSjBCO0lJNEw5QixpQkFBZ0I7SUFkWiwwQkZySitCLEV5QjZHdEM7O0FWcklMOztFQUVFO0FBSUY7RURUSSxVQUFTO0VBQ1QsV0FBVTtFQUNWLDRCQUEyQjtFQUMzQix5QkFBZ0I7S0FBaEIsc0JBQWdCO1VBQWhCLGlCQUFnQjtFQUNoQixXQUFVO0VBQ1YsVUFBUztFQUNULHNCQUFxQjtFQUNyQixzQkFBcUI7RUFDckIsZ0JBQWU7RUFDZiwwQkFBaUI7S0FBakIsdUJBQWlCO01BQWpCLHNCQUFpQjtVQUFqQixrQkFBaUI7RUFDakIsdUJBQXNCO0VBQ3RCLG9CQUFtQjtFQUNuQiw4QkFBNkI7RVpvSTdCLG9CRmpIVztFRWtIWCxxQkZsSG1CO0VFdUhYLGdDSm5KdUI7RUl5TDNCLGlCQUFnQjtFYXRKcEIsc0JBQXFCO0VBQ3JCLDBCZnFCYztFZXBCZCxvREFSMEQ7RUFRMUQsNENBUjBEO0VBUzFELGVmNkJjO0VlNUJkLGlCWlAwQjtFWVExQixhWlIwQjtFWVMxQixrQlpUMEI7RVlVMUIsbUJaVjBCO0VZVzFCLG9CWlgwQjtFWVkxQixtQkFBa0I7RUFDbEIsMEJBQXlCO0VBQ3pCLGlCQUFnQixFQXNLbkI7RUFwS0E7SWI2RkcsZ0JGbEhPO0lFbUhQLGlCRm5IVztJRTRKUCxpQkFBZ0I7SUFJaEIsaUJBQWdCO0lheEloQixpQlpuQnNCO0lZb0J0QixhWnBCc0I7SVlxQnRCLGtCWnJCc0I7SVlzQnRCLG1CWnRCc0I7SVl1QnRCLG9CWnZCc0IsRVl3QnpCO0VBQ0o7SWJvRkcsbUJGaEhVO0lFaUhWLGlCRmpIYztJRThKVixpQkFBZ0I7SWFoSWhCLGlCWjNCc0I7SVk0QnRCLGFaNUJzQjtJWTZCdEIsa0JaN0JzQjtJWThCdEIsbUJaOUJzQjtJWStCdEIsb0JaL0JzQixFWW9DekI7RUE5REw7SUFnRVEsMEJBeERzRTtJQXlEdEUsZWZKVTtJZUtWLHNCQUFxQixFQUN4QjtFQW5FTDtJQXFFUSxlZlJVO0llU1Ysd0NmR1U7WWVIVixnQ2ZHVTtJZUZWLDJCQUEyRCxFQUM5RDtFQXhFTDtJQStFUSwwQkF0RXVFO0lBdUV2RSxlZm5CVSxFZW9CYjtFQWpGTDtJQXFGUSwyQmZkVTtJZWVWLGVmOUJVO0llK0JWLDBCZmpCVTtJZWtCVixvQkFBbUIsRUFDdEI7RUFDSjtJQUVPLGVmekNVO0llMENWLDhCQUE2QixFQThCaEM7SUFqQ0o7TUFNVyw4QkFBNkI7TUFDN0IsZUFBd0MsRUFDM0M7SUFSUjtNQWlCVyw4QkFBNkI7TUFDN0IsY0FBYTtNQUNiLHlCQUFnQjtjQUFoQixpQkFBZ0IsRUFDbkI7SUFwQlI7TUEwQlcsZUFBeUMsRUFDNUM7SUEzQlI7TUErQlcsZWZqRU0sRWVrRVQ7RUFFUjtJQUNPLGFabkdzQjtJWW9HdEIsa0JacEdzQjtJWXFHdEIsbUJackdzQjtJWXNHdEIsb0JadEdzQjtJWXVHdEIsbUJBQWtCLEVBdUNyQjtJQTVDSjtNQVFXLGFaMUdrQjtNWTJHbEIsa0JaM0drQixFWTRHckI7SUFWUjtNQVlXLFlBQVc7TUFDWCxxQ0FBb0M7TUFDcEMsMkJBQW9DO01BQ3BDLFlBQVc7TUFDWCxtQkFBa0I7TUFDbEIsWUFBVztNQUNYLFFBQU87TUFDUCxrQlpySGtCO01Zc0hsQix1REF6SGtEO01BeUhsRCwrQ0F6SGtELEVBMEhyRDtJQXJCUjtNQXVCVyxjQUFhO01BQ2IseUJBQWdCO2NBQWhCLGlCQUFnQixFQUNuQjtJQXpCUjtNQWtDZSw2QmYzR0UsRWU0R0w7SUFuQ1o7TUF5Q2UsY0FBYSxFQUNoQjtFQXRLYjtJQTJLUSxzQkFBcUI7SUFDckIsb0JBQW1CO0lBQ25CLG1CWm5Kc0I7SVkwSnRCLGlCQUE4RCxFQVdqRTtJQWhCTztNQUNJLGtCQUFpQjtNQUNqQixtQkFBa0IsRUFDckI7SUFJRDtNQUNJLGlCQUE0RSxFQUMvRTtJQUdEO01BQ0ksaUJBQTRFLEVBQy9FO0VBSVo7SWIxREcsbUJGckhXO0lFc0hYLHFCRnRIbUI7SUVxS2YsaUJBQWdCO0lBaEJaLDBCRnJKK0I7SWVrTG5DLGlCQUFnQjtJQUNoQixrQkFBbUY7SUFDbkYsdUJBQXNCLEVBT3pCO0lBWko7TUFPVywwQkFBeUI7TUFDekIsaUJaL0trQjtNWWdMbEIsa0JBQWlCO01BQ2pCLG1CQUFrQixFQUNyQjs7QVduTlQ7RUFDSSxnQ0FBK0I7RUFDL0IsZ0dBQytDO0VBQy9DLG9CQUFtQjtFQUNuQixtQkFBa0IsRUFBQTs7QUF5R3RCO0VBSUksb0JBSHVCO0VBSXZCLGdDQUErQjtFQUMvQixlQUFjO0VBQ2QsbUJBQWtCO0VBQ2xCLG9CQUFtQjtFQUNuQixtQkFBa0I7RUFDbEIsc0JBQXFCO0VBQ3JCLHlCQUF3QjtFQUN4QixxQkFBb0I7RUFDcEIsbUNBQWtDO0VBQ2xDLG9DQUFtQztFQUNuQyxtQ0FBa0MsRUFtQnJDO0VBbEJHO0lBQ0ksb0JBZjJCLEVBZ0I5QjtFQUNEO0lBQ0ksZ0JBakJzQixFQWtCekI7RUFyQkw7SUF1QlEsZ0JBQWU7SUFDZixtQkFBa0IsRUFDckI7RUFHRztJQUVRLGFBaklQLEVBQU87RUErSFI7SUFFUSxhQS9ITCxFQUFPO0VBNkhWO0lBRVEsYUE3SEQsRUFBTztFQTJIZDtJQUVRLGFBM0hILEVBQU87RUF5SFo7SUFFUSxhQXpISixFQUFPO0VBdUhYO0lBRVEsYUF2SEgsRUFBTztFQXFIWjtJQUVRLGFBckhILEVBQU87RUFtSFo7SUFFUSxhQW5ITCxFQUFPO0VBaUhWO0lBRVEsYUFqSEwsRUFBTztFQStHVjtJQUVRLGFBL0dGLEVBQU87RUE2R2I7SUFFUSxhQTdHSixFQUFPO0VBMkdYO0lBRVEsYUEzR04sRUFBTztFQXlHVDtJQUVRLGFBekdHLEVBQU87RUF1R2xCO0lBRVEsYUF2R0UsRUFBTztFQXFHakI7SUFFUSxhQXJHSSxFQUFPO0VBbUduQjtJQUVRLGFBbkdOLEVBQU87RUFpR1Q7SUFFUSxhQWpHSixFQUFPO0VBK0ZYO0lBRVEsYUEvRkYsRUFBTztFQTZGYjtJQUVRLGFBN0ZKLEVBQU87RUEyRlg7SUFFUSxhQTNGRSxFQUFPO0VBeUZqQjtJQUVRLGFBekZOLEVBQU87RUF1RlQ7SUFFUSxhQXZGTixFQUFPO0VBcUZUO0lBRVEsYUFyRkosRUFBTztFQW1GWDtJQUVRLGFBbkZOLEVBQU87RUFpRlQ7SUFFUSxhQWpGTixFQUFPO0VBK0VUO0lBRVEsYUEvRUUsRUFBTztFQTZFakI7SUFFUSxhQTdFTixFQUFPO0VBMkVUO0lBRVEsYUEzRUYsRUFBTztFQXlFYjtJQUVRLGFBekVGLEVBQU87RUF1RWI7SUFFUSxhQXZFTixFQUFPO0VBcUVUO0lBRVEsYUFyRUgsRUFBTztFQW1FWjtJQUVRLGFBbkVILEVBQU87RUFpRVo7SUFFUSxhQWpFSixFQUFPO0VBK0RYO0lBRVEsYUEvRE4sRUFBTztFQTZEVDtJQUVRLGFBN0ROLEVBQU87RUEyRFQ7SUFFUSxhQTNEUCxFQUFPO0VBeURSO0lBRVEsYUF6REcsRUFBTztFQXVEbEI7SUFFUSxhQXZERSxFQUFPO0VBcURqQjtJQUVRLGFBckRILEVBQU87O0FDcEZwQjs7RUFFRTtBQUlGO0V6QlJJLGdCRjJCTztFRTFCUCxpQkYwQlc7RUV6QlgsZUYyRGM7RUVnRmQsb0JGbkhZO0VFb0haLHFCRnBIb0I7RUU2SmhCLGlCQUFnQjtFeUJ0S3RCLHNCQUFxQjtFQUNyQixpQkFBZ0I7RUFDaEIsZ0JBQWU7RUFDZixpQkFBZ0IsRUE0RWpCO0VBM0VDO0lBQ0UsZTNCbUNjO0kyQmxDZCw4QkFBNkI7SUFDN0IsbUJ4QlEwQjtJd0JQMUIsb0J4Qk8wQjtJd0JOMUIsbUJBQWtCLEVBNkNuQjtJQWxERDtNQU9NLFlBQVc7TUFDWCxxQ0FBb0M7TUFDcEMsMEJBQW9DO01BQ3BDLFlBQVc7TUFDWCxtQkFBa0I7TUFDbEIsYUFBWTtNQUNaLFFBQU87TUFDUCxpQnhCSHNCLEV3Qkl6QjtJQWZIO01Ba0JJLGVBQTRDO01BQzVDLHNCQUFxQixFQUl0QjtNQXZCSDtRQXFCUSw2QkFBMEQsRUFDN0Q7SUF0Qkw7TUEyQkksOEJBQTZCO01BQzdCLGNBQWE7TUFDYix5QkFBZ0I7Y0FBaEIsaUJBQWdCLEVBSWpCO01BakNIO1FBK0JRLGlDQUFnQyxFQUNuQztJQWhDTDtNQW9DSSxlM0JLWTtNMkJKWixzQkFBcUI7TUFDckIsZ0JBQWUsRUFJaEI7TUExQ0g7UUF3Q1EsaUNBQWdDLEVBQ25DO0lBekNMO01BOENJLGUzQk5ZO00yQk9aLHNCQUFxQjtNQUNyQixnQkFBZSxFQUNoQjtFQUdIO0lBQ0Usc0JBQXFCLEVBS3RCO0lBTkQ7TXpCNkxFLGtDQUFnQztNQUloQywwQkFBd0IsRXlCNUx2QjtFQUVIO0l6QjZERSxtQkZySFc7SUVzSFgscUJGdEhtQjtJRXFLZixpQkFBZ0I7SUFoQlosMEJGckorQjtJMkIwRHZDLGUzQnJCYztJMkJzQmQsb0JBQW1CO0lBQ25CLG1CeEJwRDBCO0l3QnFEMUIsb0J4QnJEMEIsRXdCNEQzQjtJQVpEO01BUUksOEJBQTZCO01BQzdCLGUzQjVCWTtNMkI2QlosZ0JBQWUsRUFDaEI7RUFFSDtJQUNFLGUzQmhDYyxFMkJpQ2Y7O0FDaEdIOzs7OztFQUtFO0FBR0Y7RTFCUEksZ0JGMkJPO0VFMUJQLGlCRjBCVztFRXpCWCxlRjJEYztFNEIxQ2QsWUFBVztFQUNYLGdCQUFlO0VBQ2YsMEJBQXlCO0VBQ3pCLG9CNUJQMEI7RTRCUTFCLDhCNUJ1RGMsRTRCYmpCO0UxQmtDRztJQUNJLGlCQUFnQjtJQUNoQixnQkFBZSxFQUVsQjtFMEJoR0w7SUFrQlEsb0RBWnFEO0lBWXJELDRDQVpxRCxFQW9CeEQ7SUExQkw7TUFvQlksMEJBQW1ELEVBQ3REO0lBckJUO01Bd0JZLDBCQUFrRCxFQUNyRDtFQXpCVDtJMUJzSUksb0JGbkhZO0lFb0haLHFCRnBIb0I7SUU2SmhCLGlCQUFnQjtJMEJuSmhCLGU1QjBCVSxFNEJoQmI7SUF2Q0w7TUFnQ2dCLDBCQUF5QixFQUM1QjtJQWpDYjs7TUFxQ1ksYUFBWSxFQUNmO0VBdENUOztJQTBDUSxpQkFBZ0I7SUFDaEIsMEJBQStFO0lBSS9FLG9CQUFtQjtJQUNuQixvQkFBbUI7SUFDbkIsc0I1QnNCVSxFNEJyQmI7SUFsREw7O01BNkNZLG1CekJwQmtCLEV5QnFCckI7RUE5Q1Q7SUFvRFEsZTVCRlUsRTRCTWI7SUF4REw7TUFzRFksZTVCSk0sRTRCS1Q7O0FDL0RUOzs7OztFQUtFO0FBSUY7RTNCUkksZ0JGMkJPO0VFMUJQLGlCRjBCVztFRXpCWCxlRjJEYztFNkIxQ2QscUJBQWE7RUFBYixxQkFBYTtFQUFiLGNBQWE7RUFDYixvQkFBZTtNQUFmLGdCQUFlO0VBQ2YsZ0JBQWU7RUFDZixvQjdCTnlCO0U2Qk96QixpQkFBZ0I7RUFDaEIsaUM3QnNEYyxFNkJaakI7RUFyQ0c7SUFDSSxlQUFjO0lBQ2QsbUIxQkNzQjtJRDZHMUIsb0JGakhXO0lFa0hYLHFCRmxIbUI7SUV1SFgsZ0NKbkp1QjtJSXlMM0IsaUJBQWdCO0lBakJoQiwwQjJCeEl1QztJQUN2QyxlN0J3QlU7STZCdkJWLHFDQUEyRDtJQUMzRCx1Q0FuQnlEO0lBbUJ6RCwrQkFuQnlEO0lBb0J6RCxnQkFBZSxFQWtCbEI7SUF6QkQ7TUFTUSxpQzdCbUJNO002QmxCTixlN0I2RXFDLEU2QjVFeEM7SUFYTDtNQWNRLGU3QmtCTTtNNkJqQk4saUM3QmFNLEU2QlpUO0lBaEJMO01BbUJRLGU3QmNNO002QmJOLG9CQUFtQixFQUl0QjtNQXhCTDtRQXNCWSxpQ0FBZ0MsRUFDbkM7RUFHVDtJQUVRLGNBQWEsRUFDaEI7RUFITDtJQU1RLGVBQWMsRUFDakI7O0FkOURUOztFQUVFO0FBSUY7RURUSSxVQUFTO0VBQ1QsV0FBVTtFQUNWLDRCQUEyQjtFQUMzQix5QkFBZ0I7S0FBaEIsc0JBQWdCO1VBQWhCLGlCQUFnQjtFQUNoQixXQUFVO0VBQ1YsVUFBUztFQUNULHNCQUFxQjtFQUNyQixzQkFBcUI7RUFDckIsZ0JBQWU7RUFDZiwwQkFBaUI7S0FBakIsdUJBQWlCO01BQWpCLHNCQUFpQjtVQUFqQixrQkFBaUI7RUFDakIsdUJBQXNCO0VBQ3RCLG9CQUFtQjtFQUNuQiw4QkFBNkI7RVpvSTdCLG9CRmpIVztFRWtIWCxxQkZsSG1CO0VFdUhYLGdDSm5KdUI7RUl5TDNCLGlCQUFnQjtFYXRKcEIsc0JBQXFCO0VBQ3JCLDBCZnFCYztFZXBCZCxvREFSMEQ7RUFRMUQsNENBUjBEO0VBUzFELGVmNkJjO0VlNUJkLGlCWlAwQjtFWVExQixhWlIwQjtFWVMxQixrQlpUMEI7RVlVMUIsbUJaVjBCO0VZVzFCLG9CWlgwQjtFWVkxQixtQkFBa0I7RUFDbEIsMEJBQXlCO0VBQ3pCLGlCQUFnQixFQXNLbkI7RUFwS0Q7SWI2RkksZ0JGbEhPO0lFbUhQLGlCRm5IVztJRTRKUCxpQkFBZ0I7SUFJaEIsaUJBQWdCO0lheEloQixpQlpuQnNCO0lZb0J0QixhWnBCc0I7SVlxQnRCLGtCWnJCc0I7SVlzQnRCLG1CWnRCc0I7SVl1QnRCLG9CWnZCc0IsRVl3QnpCO0VBQ0w7SWJvRkksbUJGaEhVO0lFaUhWLGlCRmpIYztJRThKVixpQkFBZ0I7SWFoSWhCLGlCWjNCc0I7SVk0QnRCLGFaNUJzQjtJWTZCdEIsa0JaN0JzQjtJWThCdEIsbUJaOUJzQjtJWStCdEIsb0JaL0JzQixFWW9DekI7RUE5REw7SUFnRVEsMEJBeERzRTtJQXlEdEUsZWZKVTtJZUtWLHNCQUFxQixFQUN4QjtFQW5FTDtJQXFFUSxlZlJVO0llU1Ysd0NmR1U7WWVIVixnQ2ZHVTtJZUZWLDJCQUEyRCxFQUM5RDtFQXhFTDtJQStFUSwwQkF0RXVFO0lBdUV2RSxlZm5CVSxFZW9CYjtFQWpGTDtJQXFGUSwyQmZkVTtJZWVWLGVmOUJVO0llK0JWLDBCZmpCVTtJZWtCVixvQkFBbUIsRUFDdEI7RUFDTDtJQUVRLGVmekNVO0llMENWLDhCQUE2QixFQThCaEM7SUFqQ0w7TUFNWSw4QkFBNkI7TUFDN0IsZUFBd0MsRUFDM0M7SUFSVDtNQWlCWSw4QkFBNkI7TUFDN0IsY0FBYTtNQUNiLHlCQUFnQjtjQUFoQixpQkFBZ0IsRUFDbkI7SUFwQlQ7TUEwQlksZUFBeUMsRUFDNUM7SUEzQlQ7TUErQlksZWZqRU0sRWVrRVQ7RUFFVDtJQUNRLGFabkdzQjtJWW9HdEIsa0JacEdzQjtJWXFHdEIsbUJackdzQjtJWXNHdEIsb0JadEdzQjtJWXVHdEIsbUJBQWtCLEVBdUNyQjtJQTVDTDtNQVFZLGFaMUdrQjtNWTJHbEIsa0JaM0drQixFWTRHckI7SUFWVDtNQVlZLFlBQVc7TUFDWCxxQ0FBb0M7TUFDcEMsMkJBQW9DO01BQ3BDLFlBQVc7TUFDWCxtQkFBa0I7TUFDbEIsWUFBVztNQUNYLFFBQU87TUFDUCxrQlpySGtCO01Zc0hsQix1REF6SGtEO01BeUhsRCwrQ0F6SGtELEVBMEhyRDtJQXJCVDtNQXVCWSxjQUFhO01BQ2IseUJBQWdCO2NBQWhCLGlCQUFnQixFQUNuQjtJQXpCVDtNQWtDZ0IsNkJmM0dFLEVlNEdMO0lBbkNiO01BeUNnQixjQUFhLEVBQ2hCO0VBdEtiO0lBMktRLHNCQUFxQjtJQUNyQixvQkFBbUI7SUFDbkIsbUJabkpzQjtJWTBKdEIsaUJBQThELEVBV2pFO0lBaEJPO01BQ0ksa0JBQWlCO01BQ2pCLG1CQUFrQixFQUNyQjtJQUlEO01BQ0ksaUJBQTRFLEVBQy9FO0lBR0Q7TUFDSSxpQkFBNEUsRUFDL0U7RUFJYjtJYjFESSxtQkZySFc7SUVzSFgscUJGdEhtQjtJRXFLZixpQkFBZ0I7SUFoQlosMEJGckorQjtJZWtMbkMsaUJBQWdCO0lBQ2hCLGtCQUFtRjtJQUNuRix1QkFBc0IsRUFPekI7SUFaTDtNQU9ZLDBCQUF5QjtNQUN6QixpQlovS2tCO01ZZ0xsQixrQkFBaUI7TUFDakIsbUJBQWtCLEVBQ3JCOztBZW5OVDs7Ozs7Ozs7RUFRRTtBQU9GO0VBQ0UsYUFBWTtFQUNaLGtCQUF3QixFQWlDekI7RUFoQ0M7SUFDRSwwQjlCcURjLEU4QmpEZjtJQUxEO01BR0ksYUFBWSxFQUNiO0VBRUg7SUFDRSxpQzlCc0RjO0k4QnJEZCxtQjNCTzBCO0kyQk4xQixrQjNCTTBCO0kyQkwxQixvQkFBd0MsRUFDekM7RUFDRDtJNUJnSEUscUJGOUdZO0lFK0daLHFCRi9Hb0I7SUVvSFosZ0NKbkp1QjtJSXlMM0IsaUJBQWdCLEU0QjFKckI7RUFDRDtJQUNFLGMzQkQwQixFMkJFM0I7RUFDRDtJQUNFLGVBQWM7SUFDZCxlQUFjO0lBQ2QsOEI5QndDYztJOEJ2Q2QsYzNCUDBCO0kyQlExQixrQkFBc0MsRUFDdkM7O0FDekNIOzs7Ozs7O0VBT0U7QUFHRjtFN0JWSSxnQkYyQk87RUUxQlAsaUJGMEJXO0VFekJYLGVGMkRjO0UrQnZDZCxtQkFBa0I7RUFDbEIsWUFBVztFQUNYLGdCQUFlO0VBQ2YsaUMvQnFEYztFK0JwRGQsb0IvQlgwQjtFK0JZMUIsZUFBYyxFQXFHakI7RTdCN0JHO0lBQ0ksaUJBQWdCO0lBQ2hCLGdCQUFlLEVBRWxCO0U2QjdGTDtJQW1CUSxpQkFBZ0IsRUFDbkI7RUFDRDtJQUNJLGlCQUFnQjtJQUNoQiw4Qi9CNkNVO0krQjVDVixpQkFBZ0IsRUFDbkI7RUFDRDtJQUVJLDBDQUErQztJQUEvQyxrQ0FBK0M7SUFDL0MsaUJBQWdCO0lBQ2hCLFdBQVU7SUFDVixpQkFBZ0I7SUFDaEIsZUFBYyxFQU9qQjtJQWJEO01BU1EsY0FBYTtNQUNiLFdBQVU7TUFDVixpQkFBZ0IsRUFDbkI7RUFFTDtJQUNJLDhCL0IyQlU7SStCMUJWLGlCQUFnQjtJQUNoQixpQkFBZ0IsRUFDbkI7RUFDRDtJQUNJLGdCNUJ4QnNCO0k0QnlCdEIscUJBQWE7SUFBYixxQkFBYTtJQUFiLGNBQWE7SUFDYiwwQkFBbUI7UUFBbkIsdUJBQW1CO1lBQW5CLG9CQUFtQjtJQUNuQixtQkFBa0I7SUFDbEIsb0RBMUNvRDtJQTBDcEQsNENBMUNvRCxFQTBEdkQ7SUFyQkQ7TUFPUSwwQkFBbUQsRUFDdEQ7SUFDRDtNN0I2RUosb0JGbkhZO01Fb0haLHFCRnBIb0I7TUU2SmhCLGlCQUFnQjtNQU1oQixpQkFBZ0I7TTZCMUhaLGUvQkxNLEUrQlNUO01BUEQ7UUFLUSw4QkFBNkIsRUFDaEM7SUFmVDtNQW1CUSwwQkFBa0QsRUFDckQ7RUFHTDtJQUNJLG9CQUFPO1FBQVAsWUFBTztZQUFQLFFBQU87SUFDUCxnQkFBZ0M7SUFFaEMsbUJBTHFFLEVBd0J4RTtJQWxCRztNQUNJLG9CQUFVO1VBQVYsZUFBVTtjQUFWLFdBQVU7TUFDVixXQUFVLEVBVWI7TUFOVztRQUNJLG1CQUFzQyxFQUN6QztNQUZEO1FBQ0ksbUJBQXNDLEVBQ3pDO01BRkQ7UUFDSSxvQkFBc0MsRUFDekM7TUFGRDtRQUNJLG9CQUFzQyxFQUN6QztNQUZEO1FBQ0ksb0JBQXNDLEVBQ3pDO01BRkQ7UUFDSSxvQkFBc0MsRUFDekM7TUFGRDtRQUNJLG9CQUFzQyxFQUN6QztNQUZEO1FBQ0ksb0JBQXNDLEVBQ3pDO0lBS2I7TUFDSSxlQUFjO01BQ2Qsa0JBQWlCO01BQ2pCLGtCQUFpQixFQUNwQjtFQUdMO0lqQjFHQSxVQUFTO0lBQ1QsV0FBVTtJQUNWLDRCQUEyQjtJQUMzQix5QkFBZ0I7T0FBaEIsc0JBQWdCO1lBQWhCLGlCQUFnQjtJQUNoQixXQUFVO0lBQ1YsVUFBUztJQUNULHNCQUFxQjtJQUNyQixzQkFBcUI7SUFDckIsZ0JBQWU7SUFDZiwwQkFBaUI7T0FBakIsdUJBQWlCO1FBQWpCLHNCQUFpQjtZQUFqQixrQkFBaUI7SUFDakIsdUJBQXNCO0lBQ3RCLG9CQUFtQjtJQUNuQiw4QkFBNkI7SWlCZ0d6QixtQkFBa0I7SUFDbEIsd0JBQTRDO0lBQzVDLG1CQUErQjtJQUMvQixZQTVGd0I7SUE2RnhCLGFBN0Z3QjtJQThGeEIsbUI1QjlFc0I7STRCK0V0Qiw0aUJBQXdFO0lBQ3hFLHlCQUF3QjtJQUN4QixrQ0FBeUI7WUFBekIsMEJBQXlCO0lBQ3pCLHVCQUFzQjtJQUN0QixvREFBaUQ7SUFBakQsNENBQWlEO0lBQWpELG9DQUFpRDtJQUFqRCxxRUFBaUQsRUFLcEQ7SUFqQkQ7TUFlUSw2QkFBb0I7Y0FBcEIscUJBQW9CLEVBQ3ZCO0VBN0dUO0lBZ0hRLGUvQmpFVSxFK0JxRWI7SUFwSEw7TUFrSFksZS9CbkVNLEUrQm9FVDs7QUM3SFQ7Ozs7RUFJRTtBQUdGO0U5QlBJLGdCRjJCTztFRTFCUCxpQkYwQlc7RUV6QlgsZUYyRGM7RWdDM0NkLGVBQWMsRUE0QmpCO0VBM0JHO0lBQ0ksaUJBQWdCO0lBQ2hCLDBCQVowRDtJQWExRCxpQkFBZ0I7SUFDaEIsYzdCU3NCO0k2QlJ0QixxQkFBYTtJQUFiLHFCQUFhO0lBQWIsY0FBYTtJQUNiLG1CQUFrQjtJQUNsQix1QkFoQmlDO0lBaUJqQyxvREFiMEQ7SUFhMUQsNENBYjBELEVBb0I3RDtJQWZEO01BVVEsOEJBcEJzRCxFQXFCekQ7SUFYTDtNQWFRLDBCQXJCaUUsRUFzQnBFO0VBRUw7SUFDSSxvQkFBTztRQUFQLFlBQU87WUFBUCxRQUFPO0lBQ1Asa0JBQWlCO0lBQ2pCLG1CQUFrQjtJQUNsQixzQkFBcUI7SUFDckIsaUI3QlJzQjtJNkJTdEIsaUJoQy9CYztJZ0NnQ2QsVzdCVnNCO0k2Qld0QixxQkFBK0M7SUFDL0MsYTdCWnNCLEU2QmF6Qjs7QUM5Q0w7OztFQUdFO0FBR0Y7RS9Cd0lJLG9CRm5IWTtFRW9IWixxQkZwSG9CO0VFNkpoQixpQkFBZ0I7RStCcEtwQixtQkFBa0I7RUFFbEIsc0JBQXFCO0VBQ3JCLFlBVDJCO0VBVTNCLGFBVjJCO0VBVzNCLFNBQVEsRUEyRVg7RUE5RkQ7SUFzQlEsYUFBWTtJQUNaLFlBZnVCO0lBZ0J2QixhQWhCdUI7SUFpQnZCLG1CQUFrQjtJQUNsQixtQkFBa0I7SUFDbEIsUUFBTztJQUNQLGVqQ2lDVTtJaUNoQ1YsbUJBQWtCO0lBQ2xCLDBCakM0QlU7SWlDM0JWLG1CQUFrQixFQUNyQjtFQUdEO0kvQnFHQSxxQkZwSGE7SUVxSGIscUJGckhxQjtJRThKakIsaUJBQWdCO0krQjdJaEIsb0JqQ3FCVTtJaUNwQlYsY2pDN0JvQjtJaUM4QnBCLGVBQWM7SUFDZCxtQkFBa0I7SUFDbEIsZWpDb0JVO0lpQ25CVixVQUE4QjtJQUM5QixhakNsQ29CO0lpQ21DcEIsaUJBbEN3QjtJQW1DeEIsbUJBQWtCO0lBQ2xCLFdBQVU7SUFDViwyQ0F0Q3VEO0lBc0N2RCxtQ0F0Q3VEO0lBdUN2RCxpQkFBZ0I7SUFDaEIsV0FBVSxFQXFDYjtJQW5ERDtNQWdCUSxTQUFRO01BQ1IsVUFBUztNQUNULG9CQUFtQjtNQUNuQiwrQkFoRG1DO01BaURuQywwREFBc0Y7TUFDdEYsbUJBQWtCO01BQ2xCLFlBQVc7TUFDWCxXQXBEbUM7TUFxRG5DLFlBckRtQyxFQXNEdEM7SUFDRDtNQUNJLFdqQ3JEZ0I7TWlDc0RoQixXQUErQixFQU1sQztNQVJEO1FBSVEsVUFBaUM7UUFDakMsWUFBb0M7UUFDcEMsa0NBQXlCO2dCQUF6QiwwQkFBeUIsRUFDNUI7SUFFTDtNQUNJLFdqQzlEZ0I7TWlDK0RoQixZQUFnQyxFQU1uQztNQVJEO1FBSVEsVUFBaUM7UUFDakMsYUFBcUM7UUFDckMsaUNBQXdCO2dCQUF4Qix5QkFBd0IsRUFDM0I7SUFFTDtNQUNJLFlBMUVtQyxFQStFdEM7TUFORDtRQUdRLFdBNUUrQjtRQTZFL0IsV0E3RStCLEVBOEVsQztFQXBGYjtJQXlGWSxvQkFBbUI7SUFDbkIsV0FBVTtJQUNWLGtCQUFpQixFQUNwQjs7QUNsR1Q7Ozs7RUFJRTtBQUdGO0VoQ05JLGdCRjJCTztFRTFCUCxpQkYwQlc7RUV6QlgsZUYyRGM7RWtDcERkLHFCQUFhO0VBQWIscUJBQWE7RUFBYixjQUFhO0VBQ2Isb0JBQWU7TUFBZixnQkFBZTtFQUNmLGdCQUFlO0VBQ2YsaUJBQWdCO0VBQ2hCLGlCQUFnQixFQW1CbkI7RUFqQkc7SUFDSSw2QkFBc0I7SUFBdEIsOEJBQXNCO1FBQXRCLDJCQUFzQjtZQUF0Qix1QkFBc0IsRUFDekI7RUFNRDtJQUNJLGVBQWM7SUFDZCxhL0JPc0IsRStCRnpCO0lBUEQ7TUFLUSxlbENpQ00sRWtDaENUOztBTDlCVDs7Ozs7RUFLRTtBQUlGO0UzQlJJLGdCRjJCTztFRTFCUCxpQkYwQlc7RUV6QlgsZUYyRGM7RTZCMUNkLHFCQUFhO0VBQWIscUJBQWE7RUFBYixjQUFhO0VBQ2Isb0JBQWU7TUFBZixnQkFBZTtFQUNmLGdCQUFlO0VBQ2Ysb0I3Qk55QjtFNkJPekIsaUJBQWdCO0VBQ2hCLGlDN0JzRGMsRTZCWmpCO0VBckNFO0lBQ0ssZUFBYztJQUNkLG1CMUJDc0I7SUQ2RzFCLG9CRmpIVztJRWtIWCxxQkZsSG1CO0lFdUhYLGdDSm5KdUI7SUl5TDNCLGlCQUFnQjtJQWpCaEIsMEIyQnhJdUM7SUFDdkMsZTdCd0JVO0k2QnZCVixxQ0FBMkQ7SUFDM0QsdUNBbkJ5RDtJQW1CekQsK0JBbkJ5RDtJQW9CekQsZ0JBQWUsRUFrQmxCO0lBekJGO01BU1MsaUM3Qm1CTTtNNkJsQk4sZTdCNkVxQyxFNkI1RXhDO0lBWE47TUFjUyxlN0JrQk07TTZCakJOLGlDN0JhTSxFNkJaVDtJQWhCTjtNQW1CUyxlN0JjTTtNNkJiTixvQkFBbUIsRUFJdEI7TUF4Qk47UUFzQmEsaUNBQWdDLEVBQ25DO0VBR1Y7SUFFUyxjQUFhLEVBQ2hCO0VBSE47SUFNUyxlQUFjLEVBQ2pCOztBTS9EVDs7OztFQUlFO0FBR0Y7RWpDTkksZ0JGMkJPO0VFMUJQLGlCRjBCVztFRXpCWCxlRjJEYztFbUMzQ2QsbUJBQWtCO0VBQ2xCLHNCQUFxQjtFQUNyQixhaENZMEI7RWdDWDFCLFlBQWtDLEVBOERyQztFQTdERztJQUNJLGFBQStCO0lBQy9CLFlBQThCO0lBQzlCLG1CQUFrQjtJQUNsQixtQkFBa0I7SUFDbEIsU0FBUTtJQUNSLFVBQVM7SUFDVCx3QkFBdUI7SUFDdkIsd0NBZnNEO0lBZXRELGdDQWZzRDtJQWdCdEQscUJBQW9CLEVBQ3ZCO0VBMUJMO0lBNEJRLDBCbkM0Q1U7SW1DM0NWLG9CQUFrQztJQUNsQyxZQUFXO0lBQ1gsYUFBWTtJQUNaLDBCQUF5QjtJQUN6Qix1QkFBc0IsRUFpQnpCO0lBbERMO01Bb0NnQixjQUFhLEVBQ2hCO0lBckNiO01BdUNnQixzQkFBcUIsRUFDeEI7SUF4Q2I7TUE2Q1ksc0JuQzJCTSxFbUN2QlQ7TUFqRFQ7UUErQ2dCLDBCbkN3QkUsRW1DdkJMO0VBR1Q7SUFDSSxhaEMxQnNCO0lnQzJCdEIsWUFBeUMsRUFRNUM7SUFWRDtNQUlRLG9CQUF5QyxFQUM1QztJQUxMO01BT1EsYUFBc0M7TUFDdEMsWUFBcUMsRUFDeEM7RUFFTDtJQUNJLGFoQ3JDc0I7SWdDc0N0QixhQUF5QyxFQVE1QztJQVZEO01BSVEsb0JBQXlDLEVBQzVDO0lBTEw7TUFPUSxhQUFzQztNQUN0QyxZQUFxQyxFQUN4Qzs7QUM5RVQ7Ozs7OztFQU1FO0FBR0Y7RUFlSSxtQkFBa0I7RUFDbEIsWUFKK0Q7RUFLL0QsYUFkd0I7RUFleEIscUJBQWE7RUFBYixxQkFBYTtFQUFiLGNBQWE7RUFDYiwwQkFBOEI7TUFBOUIsdUJBQThCO1VBQTlCLCtCQUE4QjtFQUM5QixlQUFjLEVBZ0ZqQjtFQXBHRDtJQXdCUSxjQUFhLEVBQ2hCO0VBSUc7SUFFSSxtQkFBa0I7SUFDbEIsaUJBN0JnQixFQThDbkI7SUFwQkQ7TUFLUSxtQkFBa0I7TUFDbEIsNENwQzRCRTtNb0MzQkYsT0FBTTtNQUNOLFNBQVE7TUFDUixVQUFTO01BQ1QsUUFBTztNQUNQLFdBQVU7TUFDVixZQUFXLEVBQ2Q7SUFiTDtNQWVRLG1CQUFrQjtNQUNsQixXQUFVO01BQ1YseUJBQThCO01BQzlCLHdCQUE4QixFQUNqQztFQWhEYjtJQXNEUSxZQUFXO0lBQ1gsbUJBQWtCO0lBQ2xCLFdBcER1QjtJQXFEdkIsYUFBWTtJQUNaLDBCcENUVSxFb0NVYjtFQTNETDtJQStEWSxZQUFXO0lBQ1gsbUJBQWtCO0lBQ2xCLFdBN0RtQjtJQThEbkIsYUFBWTtJQUNaLDBCcENsQk0sRW9DbUJUO0VBcEVUO0lBc0VZLFVBQXdELEVBQzNEO0VBdkVUO0lBeUVZLFdBQXlELEVBQzVEO0VBMUVUO0lBK0VRLCtDQUErRDtZQUEvRCx1Q0FBK0Q7SUFDL0QsNkJBMUUyQjtZQTBFM0IscUJBMUUyQixFQTJFOUI7RUFqRkw7SUFxRlksK0NBQStEO1lBQS9ELHVDQUErRDtJQUMvRCwrQkFBb0Q7WUFBcEQsdUJBQW9ELEVBQ3ZEO0VBdkZUO0lBMEZZLCtDQUErRDtZQUEvRCx1Q0FBK0Q7SUFDL0QsK0JBQW9EO1lBQXBELHVCQUFvRCxFQUN2RDtFQTVGVDtJQWdHUSwrQ0FBK0Q7WUFBL0QsdUNBQStEO0lBQy9ELCtCQUFvRDtZQUFwRCx1QkFBb0QsRUFDdkQ7O0FBSUw7RUFDSTs7O0lBR0ksK0JBQXFCO1lBQXJCLHVCQUFxQixFQUFBO0VBRXpCO0lBQ0ksNkJBQW9CO1lBQXBCLHFCQUFvQixFQUFBLEVBQUE7O0FBUDVCO0VBQ0k7OztJQUdJLCtCQUFxQjtZQUFyQix1QkFBcUIsRUFBQTtFQUV6QjtJQUNJLDZCQUFvQjtZQUFwQixxQkFBb0IsRUFBQSxFQUFBOztBQ3RINUI7O0VBRUU7QUFHRjtFQWdCSSxzQkFBcUI7RUFDckIsdUJBQXNCO0VBQ3RCLDZCQUE0QjtFQUM1Qix1QkFBc0I7RUFDdEIseUJBQXdCLEVBK0IzQjtFQTFCTztJQUNJLFlBdkJJO0lBd0JKLGFBeEJJLEVBeUJQO0VBSEQ7SUFDSSxZQXRCRztJQXVCSCxhQXZCRyxFQXdCTjtFQUhEO0lBQ0ksWUFyQkc7SUFzQkgsYUF0QkcsRUF1Qk47RUFIRDtJQUNJLFlBcEJHO0lBcUJILGFBckJHLEVBc0JOO0VBSEQ7SUFDSSxZQW5CSTtJQW9CSixhQXBCSSxFQXFCUDtFQUhEO0lBQ0ksYUFsQk07SUFtQk4sY0FuQk0sRUFvQlQ7RUFHTDtJQUNJLG1CQUFrQixFQUtyQjtJQU5EO01BSVEsbUJBQWtCLEVBQ3JCO0VBRUw7SUFDSSxtQkFBa0IsRUFDckI7RUFFRDtJQUNJLDBCckM4QlUsRXFDN0JiO0VBQ0Q7SUFDSSx3aUJBQTBELEVBQzdEO0VBQ0Q7SUFDSSxnMkJBQTBELEVBQzdEOztBWHZETDtFQUNJLGdDQUErQjtFQUMvQixnR0FDK0M7RUFDL0Msb0JBQW1CO0VBQ25CLG1CQUFrQixFQUFBOztBQXlHdEI7RUFJSSxvQkFIdUI7RUFJdkIsZ0NBQStCO0VBQy9CLGVBQWM7RUFDZCxtQkFBa0I7RUFDbEIsb0JBQW1CO0VBQ25CLG1CQUFrQjtFQUNsQixzQkFBcUI7RUFDckIseUJBQXdCO0VBQ3hCLHFCQUFvQjtFQUNwQixtQ0FBa0M7RUFDbEMsb0NBQW1DO0VBQ25DLG1DQUFrQyxFQW1CckM7RUFsQkU7SUFDSyxvQkFmMkIsRUFnQjlCO0VBQ0Y7SUFDSyxnQkFqQnNCLEVBa0J6QjtFQXJCTDtJQXVCUSxnQkFBZTtJQUNmLG1CQUFrQixFQUNyQjtFQUdHO0lBRVEsYUFqSVAsRUFBTztFQStIUjtJQUVRLGFBL0hMLEVBQU87RUE2SFY7SUFFUSxhQTdIRCxFQUFPO0VBMkhkO0lBRVEsYUEzSEgsRUFBTztFQXlIWjtJQUVRLGFBekhKLEVBQU87RUF1SFg7SUFFUSxhQXZISCxFQUFPO0VBcUhaO0lBRVEsYUFySEgsRUFBTztFQW1IWjtJQUVRLGFBbkhMLEVBQU87RUFpSFY7SUFFUSxhQWpITCxFQUFPO0VBK0dWO0lBRVEsYUEvR0YsRUFBTztFQTZHYjtJQUVRLGFBN0dKLEVBQU87RUEyR1g7SUFFUSxhQTNHTixFQUFPO0VBeUdUO0lBRVEsYUF6R0csRUFBTztFQXVHbEI7SUFFUSxhQXZHRSxFQUFPO0VBcUdqQjtJQUVRLGFBckdJLEVBQU87RUFtR25CO0lBRVEsYUFuR04sRUFBTztFQWlHVDtJQUVRLGFBakdKLEVBQU87RUErRlg7SUFFUSxhQS9GRixFQUFPO0VBNkZiO0lBRVEsYUE3RkosRUFBTztFQTJGWDtJQUVRLGFBM0ZFLEVBQU87RUF5RmpCO0lBRVEsYUF6Rk4sRUFBTztFQXVGVDtJQUVRLGFBdkZOLEVBQU87RUFxRlQ7SUFFUSxhQXJGSixFQUFPO0VBbUZYO0lBRVEsYUFuRk4sRUFBTztFQWlGVDtJQUVRLGFBakZOLEVBQU87RUErRVQ7SUFFUSxhQS9FRSxFQUFPO0VBNkVqQjtJQUVRLGFBN0VOLEVBQU87RUEyRVQ7SUFFUSxhQTNFRixFQUFPO0VBeUViO0lBRVEsYUF6RUYsRUFBTztFQXVFYjtJQUVRLGFBdkVOLEVBQU87RUFxRVQ7SUFFUSxhQXJFSCxFQUFPO0VBbUVaO0lBRVEsYUFuRUgsRUFBTztFQWlFWjtJQUVRLGFBakVKLEVBQU87RUErRFg7SUFFUSxhQS9ETixFQUFPO0VBNkRUO0lBRVEsYUE3RE4sRUFBTztFQTJEVDtJQUVRLGFBM0RQLEVBQU87RUF5RFI7SUFFUSxhQXpERyxFQUFPO0VBdURsQjtJQUVRLGFBdkRFLEVBQU87RUFxRGpCO0lBRVEsYUFyREgsRUFBTzs7QVl0RnBCO0VBQ0ksZ0NBQStCLEVBQ2xDOztBQUNEO0VBQ0ksNkJBQTRCLEVBQy9COztBQUNEO0VBQ0ksOEJBQTZCLEVBQ2hDOztBQUNEO0VBQ0ksOEJBQTZCLEVBQ2hDOztBQUNEO0VBQ0ksNkJBQTRCLEVBQy9COztBQUNEO0VBQ0ksdUJBQXNCLEVBQ3pCOztBQUNEO0VBQ0ksd0JBQXVCLEVBQzFCOztBQUNEO0VBQ0ksOEJBQTZCLEVBQ2hDOztBQ2hCTztFckNzSUosbUJGckhXO0VFc0hYLHFCRnRIbUI7RUVxS2YsaUJBQWdCO0VBaEJaLDBCRnJKK0IsRXVDZmxDOztBQUZEO0VyQ3NJSixxQkZwSGE7RUVxSGIscUJGckhxQjtFRThKakIsaUJBQWdCLEVxQzlLZjs7QUFGRDtFckNzSUosb0JGbkhZO0VFb0haLHFCRnBIb0I7RUU2SmhCLGlCQUFnQixFcUM5S2Y7O0FBRUQ7O0VyQ2tJSixnQkZsSE87RUVtSFAsaUJGbkhXO0VFNEpQLGlCQUFnQixFcUN6S2Y7O0FBWEQ7RXJDMElKLG9CRmpIVztFRWtIWCxxQkZsSG1CO0VFK0pmLGlCQUFnQixFcUN0TGY7O0FBRkQ7RXJDMElKLG1CRmhIVTtFRWlIVixpQkZqSGM7RUU4SlYsaUJBQWdCLEVxQ3RMZjs7QUFGRDtFckMwSUosb0JGL0dXO0VFZ0hYLHFCRmhIbUI7RUU2SFgsZ0NKM0p1QjtFSTJMM0IsaUJBQWdCLEVxQ3RMZjs7QUFGRDtFckMwSUoscUJGOUdZO0VFK0daLHFCRi9Hb0I7RUU0SFosZ0NKM0p1QjtFSTZMM0IsaUJBQWdCLEVxQ3hMZjs7QUFGRDtFckMwSUoscUJGN0dZO0VFOEdaLHFCRjlHb0I7RUUySFosZ0NKM0p1QjtFSXlMM0IsaUJBQWdCLEVxQ3BMZjs7QUFjTDtFQUNJLHFDekNyQjhCLEV5Q3NCakM7O0FBRkQ7RUFDSSxnQ3pDcEIyQixFeUNxQjlCOztBQUZEO0VBQ0ksc0N6Q25CK0IsRXlDb0JsQzs7QUFJRDtFQUNJLGlCdkNpQk0sRXVDaEJUOztBQUZEO0VBQ0ksaUJ2Q2tCSSxFdUNqQlA7O0FBRkQ7RUFDSSxpQnZDbUJJLEV1Q2xCUDs7QUFGRDtFQUNJLGlCdkNvQkssRXVDbkJSOztBQUZEO0VBQ0ksaUJ2Q3FCSyxFdUNwQlI7O0FDeEJPOztFQUVJLDBCQUF3QixFQUMzQjs7QUFFRDtFQUNJLDBCQUF3QixFQUMzQjs7QUFQRDs7RUFFSSwwQkFBd0IsRUFDM0I7O0FBRUQ7RUFDSSwwQkFBd0IsRUFDM0I7O0FBUEQ7O0VBRUksMEJBQXdCLEVBQzNCOztBQUVEO0VBQ0ksMEJBQXdCLEVBQzNCOztBQUZEO0VBQ0ksMEJBQXdCLEVBQzNCOztBQVBEOztFQUVJLDBCQUF3QixFQUMzQjs7QUFFRDtFQUNJLDBCQUF3QixFQUMzQjs7QUFGRDtFQUNJLDBCQUF3QixFQUMzQjs7QUFQRDs7RUFFSSwwQkFBd0IsRUFDM0I7O0FBRUQ7RUFDSSwwQkFBd0IsRUFDM0I7O0FBRkQ7RUFDSSwwQkFBd0IsRUFDM0I7O0FBUEQ7O0VBRUksMEJBQXdCLEVBQzNCOztBQUVEO0VBQ0ksMEJBQXdCLEVBQzNCOztBQUZEO0VBQ0ksMEJBQXdCLEVBQzNCOztBQUZEO0VBQ0ksMEJBQXdCLEVBQzNCOztBQVBEOztFQUVJLDBCQUF3QixFQUMzQjs7QUFFRDtFQUNJLDBCQUF3QixFQUMzQjs7QUFGRDtFQUNJLDBCQUF3QixFQUMzQjs7QUNaYjtFQUNJLDZCQUE0QjtFQUM1Qiw0QkFBMkI7RUFDM0IseUJBQXdCLEVBQzNCOztBQUNEO0VBQ0ksNkJBQTRCO0VBQzVCLDRCQUEyQjtFQUMzQiw2QkFBNEIsRUFDL0I7O0FBQ0Q7RUFDSSxvQ0FBbUMsRUFDdEM7O0FBQ0Q7RUFDSSxrQ0FBaUMsRUFDcEM7O0FBS1c7O0VBRUkscUNBQW1DLEVBQ3RDOztBQUVEO0VBQ0kscUNBQW1DLEVBQ3RDOztBQVBEOztFQUVJLHFDQUFtQyxFQUN0Qzs7QUFFRDtFQUNJLHFDQUFtQyxFQUN0Qzs7QUFQRDs7RUFFSSxxQ0FBbUMsRUFDdEM7O0FBRUQ7RUFDSSxxQ0FBbUMsRUFDdEM7O0FBRkQ7RUFDSSxxQ0FBbUMsRUFDdEM7O0FBUEQ7O0VBRUkscUNBQW1DLEVBQ3RDOztBQUVEO0VBQ0kscUNBQW1DLEVBQ3RDOztBQUZEO0VBQ0kscUNBQW1DLEVBQ3RDOztBQVBEOztFQUVJLHFDQUFtQyxFQUN0Qzs7QUFFRDtFQUNJLHFDQUFtQyxFQUN0Qzs7QUFGRDtFQUNJLHFDQUFtQyxFQUN0Qzs7QUFQRDs7RUFFSSxxQ0FBbUMsRUFDdEM7O0FBRUQ7RUFDSSxxQ0FBbUMsRUFDdEM7O0FBRkQ7RUFDSSxxQ0FBbUMsRUFDdEM7O0FBRkQ7RUFDSSxxQ0FBbUMsRUFDdEM7O0FBUEQ7O0VBRUkscUNBQW1DLEVBQ3RDOztBQUVEO0VBQ0kscUNBQW1DLEVBQ3RDOztBQUZEO0VBQ0kscUNBQW1DLEVBQ3RDOztBQzNCYjtFQUNJLFVBQVMsRUFDWjs7QUFDRDtFQUNJLFdBQVUsRUFDYjs7QUFFRztFQUNJLGNBQXlCLEVBQzVCOztBQUNEO0VBQ0ksZUFBMkIsRUFDOUI7O0FBTEQ7RUFDSSxnQkFBeUIsRUFDNUI7O0FBQ0Q7RUFDSSxpQkFBMkIsRUFDOUI7O0FBTEQ7RUFDSSxpQkFBeUIsRUFDNUI7O0FBQ0Q7RUFDSSxrQkFBMkIsRUFDOUI7O0FBTEQ7RUFDSSxlQUF5QixFQUM1Qjs7QUFDRDtFQUNJLGdCQUEyQixFQUM5Qjs7QUFHRDtFQUNJLFlBQVEsRUFDWDs7QUFDRDtFQUNJLGFBQVMsRUFDWjs7QUFFRztFQUNJLGdCQUF3QixFQUMzQjs7QUFDRDtFQUNJLGlCQUEwQixFQUM3Qjs7QUFMRDtFQUNJLGtCQUF3QixFQUMzQjs7QUFDRDtFQUNJLG1CQUEwQixFQUM3Qjs7QUFMRDtFQUNJLG1CQUF3QixFQUMzQjs7QUFDRDtFQUNJLG9CQUEwQixFQUM3Qjs7QUFMRDtFQUNJLGlCQUF3QixFQUMzQjs7QUFDRDtFQUNJLGtCQUEwQixFQUM3Qjs7QUFaTDtFQUNJLFlBQVEsRUFDWDs7QUFDRDtFQUNJLGFBQVMsRUFDWjs7QUFFRztFQUNJLGdCQUF3QixFQUMzQjs7QUFDRDtFQUNJLGlCQUEwQixFQUM3Qjs7QUFMRDtFQUNJLGtCQUF3QixFQUMzQjs7QUFDRDtFQUNJLG1CQUEwQixFQUM3Qjs7QUFMRDtFQUNJLG1CQUF3QixFQUMzQjs7QUFDRDtFQUNJLG9CQUEwQixFQUM3Qjs7QUFMRDtFQUNJLGlCQUF3QixFQUMzQjs7QUFDRDtFQUNJLGtCQUEwQixFQUM3Qjs7QUFaTDtFQUNJLGFBQVEsRUFDWDs7QUFDRDtFQUNJLGNBQVMsRUFDWjs7QUFFRztFQUNJLGlCQUF3QixFQUMzQjs7QUFDRDtFQUNJLGtCQUEwQixFQUM3Qjs7QUFMRDtFQUNJLG1CQUF3QixFQUMzQjs7QUFDRDtFQUNJLG9CQUEwQixFQUM3Qjs7QUFMRDtFQUNJLG9CQUF3QixFQUMzQjs7QUFDRDtFQUNJLHFCQUEwQixFQUM3Qjs7QUFMRDtFQUNJLGtCQUF3QixFQUMzQjs7QUFDRDtFQUNJLG1CQUEwQixFQUM3Qjs7QUFaTDtFQUNJLGFBQVEsRUFDWDs7QUFDRDtFQUNJLGNBQVMsRUFDWjs7QUFFRztFQUNJLGlCQUF3QixFQUMzQjs7QUFDRDtFQUNJLGtCQUEwQixFQUM3Qjs7QUFMRDtFQUNJLG1CQUF3QixFQUMzQjs7QUFDRDtFQUNJLG9CQUEwQixFQUM3Qjs7QUFMRDtFQUNJLG9CQUF3QixFQUMzQjs7QUFDRDtFQUNJLHFCQUEwQixFQUM3Qjs7QUFMRDtFQUNJLGtCQUF3QixFQUMzQjs7QUFDRDtFQUNJLG1CQUEwQixFQUM3Qjs7QUFaTDtFQUNJLGFBQVEsRUFDWDs7QUFDRDtFQUNJLGNBQVMsRUFDWjs7QUFFRztFQUNJLGlCQUF3QixFQUMzQjs7QUFDRDtFQUNJLGtCQUEwQixFQUM3Qjs7QUFMRDtFQUNJLG1CQUF3QixFQUMzQjs7QUFDRDtFQUNJLG9CQUEwQixFQUM3Qjs7QUFMRDtFQUNJLG9CQUF3QixFQUMzQjs7QUFDRDtFQUNJLHFCQUEwQixFQUM3Qjs7QUFMRDtFQUNJLGtCQUF3QixFQUMzQjs7QUFDRDtFQUNJLG1CQUEwQixFQUM3Qjs7QUFaTDtFQUNJLGNBQVEsRUFDWDs7QUFDRDtFQUNJLGVBQVMsRUFDWjs7QUFFRztFQUNJLGtCQUF3QixFQUMzQjs7QUFDRDtFQUNJLG1CQUEwQixFQUM3Qjs7QUFMRDtFQUNJLG9CQUF3QixFQUMzQjs7QUFDRDtFQUNJLHFCQUEwQixFQUM3Qjs7QUFMRDtFQUNJLHFCQUF3QixFQUMzQjs7QUFDRDtFQUNJLHNCQUEwQixFQUM3Qjs7QUFMRDtFQUNJLG1CQUF3QixFQUMzQjs7QUFDRDtFQUNJLG9CQUEwQixFQUM3Qjs7QUFaTDtFQUNJLGNBQVEsRUFDWDs7QUFDRDtFQUNJLGVBQVMsRUFDWjs7QUFFRztFQUNJLGtCQUF3QixFQUMzQjs7QUFDRDtFQUNJLG1CQUEwQixFQUM3Qjs7QUFMRDtFQUNJLG9CQUF3QixFQUMzQjs7QUFDRDtFQUNJLHFCQUEwQixFQUM3Qjs7QUFMRDtFQUNJLHFCQUF3QixFQUMzQjs7QUFDRDtFQUNJLHNCQUEwQixFQUM3Qjs7QUFMRDtFQUNJLG1CQUF3QixFQUMzQjs7QUFDRDtFQUNJLG9CQUEwQixFQUM3Qjs7QXhDa0VMO0VBQ0ksWUFBVztFQUNYLGVBQWM7RUFDZCxZQUFXLEVBQ2Q7O0F5QzVGTDtFQUNJLHFCQUFhO0VBQWIscUJBQWE7RUFBYixjQUFhLEVBQ2hCOztBQUNEO0VBQ0ksZUFBYyxFQUNqQjs7QUFDRDtFQUNJLDBCQUFtQjtNQUFuQix1QkFBbUI7VUFBbkIsb0JBQW1CLEVBQ3RCOztBQUNEO0VBQ0ksb0JBQVk7TUFBWixxQkFBWTtVQUFaLGFBQVksRUFDZiIsImZpbGUiOiJmdW5kYW1lbnRhbC11aS5jc3MiLCJzb3VyY2VzQ29udGVudCI6WyJAY2hhcnNldCBcIlVURi04XCI7XG5AaW1wb3J0IHVybChcIi8vZm9udHMuZ29vZ2xlYXBpcy5jb20vY3NzP2ZhbWlseT1Sb2JvdG86NDAwLDUwMCw3MDBcIik7XG5AaW1wb3J0IHVybChcIi8vZm9udHMuZ29vZ2xlYXBpcy5jb20vY3NzP2ZhbWlseT1PcGVuK1NhbnM6NDAwLDQwMGl0YWxpYyw2MDAsNzAwXCIpO1xuLyohXG4qIEBzZWN0aW9uIFJvb3QgRWxlbWVudFxuKiBEZWZhdWx0IHN0eWxlcyBmb3Igcm9vdCBlbGVtZW50c1xuKi9cbmh0bWwge1xuICBib3gtc2l6aW5nOiBib3JkZXItYm94O1xuICBtaW4taGVpZ2h0OiAxMDAlOyB9XG5cbmh0bWwsXG5ib2R5IHtcbiAgZm9udC1zaXplOiAxcmVtO1xuICBmb250LWZhbWlseTogJ09wZW4gU2FucycsIHNhbnMtc2VyaWY7XG4gIGxpbmUtaGVpZ2h0OiAxLjU7IH1cblxuKiB7XG4gIGJveC1zaXppbmc6IGluaGVyaXQ7IH1cbiAgKjo6YmVmb3JlLCAqOjphZnRlciB7XG4gICAgYm94LXNpemluZzogaW5oZXJpdDsgfVxuXG5ib2R5IHtcbiAgbWFyZ2luOiAwO1xuICBiYWNrZ3JvdW5kLWNvbG9yOiAjZmZmZmZmO1xuICAtd2Via2l0LWZvbnQtc21vb3RoaW5nOiBhbnRpYWxpYXNlZDtcbiAgY29sb3I6ICMyMTI2MmM7IH1cblxuLyoqXG4qIEBzZWN0aW9uIEhlYWRlciBFbGVtZW50c1xuKiBEZWZhdWx0IHN0eWxlcyBmb3IgaGVhZGVyIGVsZW1lbnRzXG4qL1xuaDEsIGgyLCBoMywgaDQsIGg1LCBoNiB7XG4gIHRleHQtcmVuZGVyaW5nOiBvcHRpbWl6ZUxlZ2liaWxpdHk7XG4gIG1hcmdpbi1ib3R0b206IDIwcHg7XG4gIG1hcmdpbi10b3A6IDA7IH1cblxuLyohXG4qIEBzZWN0aW9uIEJsb2NrIEVsZW1lbnRzXG4qIERlZmF1bHQgc3R5bGVzIGZvciBibG9jayBlbGVtZW50c1xuKi9cbnAsIHVsLCBvbCwgYmxvY2txdW90ZSwgdGFibGUsIGZpZ3VyZSB7XG4gIG1hcmdpbi10b3A6IDA7XG4gIG1hcmdpbi1ib3R0b206IDIwcHg7IH1cbiAgcDpsYXN0LWNoaWxkLCB1bDpsYXN0LWNoaWxkLCBvbDpsYXN0LWNoaWxkLCBibG9ja3F1b3RlOmxhc3QtY2hpbGQsIHRhYmxlOmxhc3QtY2hpbGQsIGZpZ3VyZTpsYXN0LWNoaWxkIHtcbiAgICBtYXJnaW4tYm90dG9tOiAwOyB9XG5cbi8qIVxuKiBAc2VjdGlvbiBMaXN0IEVsZW1lbnRzXG4qIERlZmF1bHQgc3R5bGVzIGZvciBsaXN0c1xuKi9cbnVsLCBvbCB7XG4gIHBhZGRpbmctbGVmdDogMDsgfVxuXG4vKiFcbiogQHNlY3Rpb24gUGhyYXNlcyBFbGVtZW50c1xuKiBEZWZhdWx0IHN0eWxlcyBmb3IgcGhyYXNlIGVsZW1lbnRzXG4qL1xuaW1nIHtcbiAgbGluZS1oZWlnaHQ6IDA7XG4gIHZlcnRpY2FsLWFsaWduOiBtaWRkbGU7IH1cblxuYSB7XG4gIGNvbG9yOiAjMDA5Y2RmO1xuICB0ZXh0LWRlY29yYXRpb246IG5vbmU7IH1cbiAgYTpob3ZlciB7XG4gICAgY29sb3I6ICMwMDhhYzY7IH1cbiAgYTphY3RpdmUsIGE6Zm9jdXMge1xuICAgIGNvbG9yOiAjMDA4YWM2O1xuICAgIG91dGxpbmU6IG5vbmU7IH1cbiAgYVthcmlhLWRpc2FibGVkPVwidHJ1ZVwiXSwgYS5pcy1kaXNhYmxlZCB7XG4gICAgY29sb3I6ICM3ZjkwYTQ7XG4gICAgY3Vyc29yOiBub3QtYWxsb3dlZDsgfVxuXG4vKiFcbiogQHNlY3Rpb24gQnV0dG9uIEVsZW1lbnRzXG4qIERlZmF1bHQgc3R5bGVzIGZvciBidXR0b24gZWxlbWVudHNcbiovXG5idXR0b246Oi1tb3otZm9jdXMtaW5uZXIsXG5pbnB1dFt0eXBlPVwic3VibWl0XCJdOjotbW96LWZvY3VzLWlubmVyIHtcbiAgYm9yZGVyOiAwO1xuICBwYWRkaW5nOiAwOyB9XG5cbmlucHV0W3R5cGU9cmFkaW9dLCBpbnB1dFt0eXBlPWNoZWNrYm94XSB7XG4gIGZvbnQtc2l6ZTogMXJlbTtcbiAgbGluZS1oZWlnaHQ6IDEuNTtcbiAgY29sb3I6ICMyMTI2MmM7XG4gIGZvbnQtc2l6ZTogMXJlbTtcbiAgbGluZS1oZWlnaHQ6IDEuNTtcbiAgZm9udC1mYW1pbHk6ICdPcGVuIFNhbnMnLCBzYW5zLXNlcmlmO1xuICBmb250LXdlaWdodDogNDAwO1xuICBhcHBlYXJhbmNlOiBub25lO1xuICAtd2Via2l0LWFwcGVhcmFuY2U6IHRleHRmaWVsZDtcbiAgLW1vei1hcHBlYXJhbmNlOiB0ZXh0ZmllbGQ7XG4gIGZvbnQtc2l6ZTogaW5oZXJpdDtcbiAgYm94LXNpemluZzogYm9yZGVyLWJveDtcbiAgb3V0bGluZTogbm9uZTtcbiAgYm9yZGVyLXN0eWxlOiBzb2xpZDtcbiAgYm9yZGVyLXdpZHRoOiAxcHg7XG4gIGJvcmRlci1jb2xvcjogI2NjZGFlYjtcbiAgYm9yZGVyLXJhZGl1czogMDtcbiAgY29sb3I6ICMyMTI2MmM7XG4gIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50O1xuICB0cmFuc2l0aW9uOiBib3JkZXItY29sb3IgMC4xMjVzO1xuICB0cmFuc2l0aW9uOiBib3JkZXItY29sb3IgMC4xMjVzIGVhc2UtaW4sIGJhY2tncm91bmQtY29sb3IgMC4xMjVzIGVhc2UtaW4sIGJhY2tncm91bmQtaW1hZ2UgMC4xMjVzIGVhc2UtaW47IH1cbiAgaW5wdXRbdHlwZT1yYWRpb106Zm9jdXMsIGlucHV0W3R5cGU9Y2hlY2tib3hdOmZvY3VzLCBpbnB1dFt0eXBlPXJhZGlvXTpob3ZlciwgaW5wdXRbdHlwZT1jaGVja2JveF06aG92ZXIge1xuICAgIGJvcmRlci1jb2xvcjogIzAwOWNkZjsgfVxuICBpbnB1dC5pcy1pbnZhbGlkW3R5cGU9cmFkaW9dLCBpbnB1dC5pcy1pbnZhbGlkW3R5cGU9Y2hlY2tib3hdIHtcbiAgICBib3JkZXItY29sb3I6ICNkZjE5MTk7IH1cbiAgaW5wdXQuaXMtdmFsaWRbdHlwZT1yYWRpb10sIGlucHV0LmlzLXZhbGlkW3R5cGU9Y2hlY2tib3hdIHtcbiAgICBib3JkZXItY29sb3I6ICM2MWJmMzM7IH1cbiAgaW5wdXQuaXMtd2FybmluZ1t0eXBlPXJhZGlvXSwgaW5wdXQuaXMtd2FybmluZ1t0eXBlPWNoZWNrYm94XSB7XG4gICAgYm9yZGVyLWNvbG9yOiAjZTk3MzI2OyB9XG4gIGlucHV0W3R5cGU9cmFkaW9dOmRpc2FibGVkLCBpbnB1dFt0eXBlPWNoZWNrYm94XTpkaXNhYmxlZCwgaW5wdXRbYXJpYS1kaXNhYmxlZD1cInRydWVcIl1bdHlwZT1yYWRpb10sIGlucHV0W2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdW3R5cGU9Y2hlY2tib3hdLCBpbnB1dC5pcy1kaXNhYmxlZFt0eXBlPXJhZGlvXSwgaW5wdXQuaXMtZGlzYWJsZWRbdHlwZT1jaGVja2JveF0ge1xuICAgIGN1cnNvcjogbm90LWFsbG93ZWQ7XG4gICAgY29sb3I6ICM2Mzc1OGI7XG4gICAgYm9yZGVyLWNvbG9yOiAjZTRlNGU0O1xuICAgIGJhY2tncm91bmQtY29sb3I6ICNmOWZiZmM7IH1cbiAgaW5wdXRbcmVhZG9ubHldW3R5cGU9cmFkaW9dLCBpbnB1dFtyZWFkb25seV1bdHlwZT1jaGVja2JveF0sIGlucHV0LmlzLXJlYWRvbmx5W3R5cGU9cmFkaW9dLCBpbnB1dC5pcy1yZWFkb25seVt0eXBlPWNoZWNrYm94XSB7XG4gICAgY29sb3I6ICMyMTI2MmM7XG4gICAgYm9yZGVyLWNvbG9yOiAjZTRlNGU0O1xuICAgIGJvcmRlci13aWR0aDogMCAwIDFweDsgfVxuICBpbnB1dFt0eXBlPXJhZGlvXTo6YWZ0ZXIsIGlucHV0W3R5cGU9Y2hlY2tib3hdOjphZnRlciB7XG4gICAgdHJhbnNpdGlvbjogYm9yZGVyLWNvbG9yIDAuMTI1cyBlYXNlLWluOyB9XG4gIGlucHV0W3R5cGU9cmFkaW9dOjpwbGFjZWhvbGRlciwgaW5wdXRbdHlwZT1jaGVja2JveF06OnBsYWNlaG9sZGVyIHtcbiAgICBjb2xvcjogIzYzNzU4YjsgfVxuXG5maWVsZHNldCB7XG4gIGJvcmRlcjogMDtcbiAgcGFkZGluZzogMDtcbiAgbWFyZ2luOiAwOyB9XG5cbmlucHV0W3R5cGU9dGV4dF0sIGlucHV0W3R5cGU9cGFzc3dvcmRdLCBpbnB1dFt0eXBlPWVtYWlsXSwgaW5wdXRbdHlwZT11cmxdLCBpbnB1dFt0eXBlPXNlYXJjaF0sIGlucHV0W3R5cGU9dGVsXSwgaW5wdXRbdHlwZT1udW1iZXJdLCBpbnB1dFt0eXBlPWRhdGVdLFxudGV4dGFyZWEge1xuICBmb250LXNpemU6IDFyZW07XG4gIGxpbmUtaGVpZ2h0OiAxLjU7XG4gIGNvbG9yOiAjMjEyNjJjO1xuICBmb250LXNpemU6IDFyZW07XG4gIGxpbmUtaGVpZ2h0OiAxLjU7XG4gIGZvbnQtZmFtaWx5OiAnT3BlbiBTYW5zJywgc2Fucy1zZXJpZjtcbiAgZm9udC13ZWlnaHQ6IDQwMDtcbiAgYXBwZWFyYW5jZTogbm9uZTtcbiAgLXdlYmtpdC1hcHBlYXJhbmNlOiB0ZXh0ZmllbGQ7XG4gIC1tb3otYXBwZWFyYW5jZTogdGV4dGZpZWxkO1xuICBmb250LXNpemU6IGluaGVyaXQ7XG4gIGJveC1zaXppbmc6IGJvcmRlci1ib3g7XG4gIG91dGxpbmU6IG5vbmU7XG4gIGJvcmRlci1zdHlsZTogc29saWQ7XG4gIGJvcmRlci13aWR0aDogMXB4O1xuICBib3JkZXItY29sb3I6ICNjY2RhZWI7XG4gIGJvcmRlci1yYWRpdXM6IDA7XG4gIGNvbG9yOiAjMjEyNjJjO1xuICBiYWNrZ3JvdW5kLWNvbG9yOiB0cmFuc3BhcmVudDtcbiAgdHJhbnNpdGlvbjogYm9yZGVyLWNvbG9yIDAuMTI1cztcbiAgaGVpZ2h0OiA1MnB4O1xuICBwYWRkaW5nLWxlZnQ6IDE2cHg7XG4gIHBhZGRpbmctcmlnaHQ6IDE2cHg7XG4gIHdpZHRoOiAxMDAlOyB9XG4gIGlucHV0W3R5cGU9dGV4dF06Zm9jdXMsIGlucHV0W3R5cGU9dGV4dF06aG92ZXIsIGlucHV0W3R5cGU9cGFzc3dvcmRdOmZvY3VzLCBpbnB1dFt0eXBlPXBhc3N3b3JkXTpob3ZlciwgaW5wdXRbdHlwZT1lbWFpbF06Zm9jdXMsIGlucHV0W3R5cGU9ZW1haWxdOmhvdmVyLCBpbnB1dFt0eXBlPXVybF06Zm9jdXMsIGlucHV0W3R5cGU9dXJsXTpob3ZlciwgaW5wdXRbdHlwZT1zZWFyY2hdOmZvY3VzLCBpbnB1dFt0eXBlPXNlYXJjaF06aG92ZXIsIGlucHV0W3R5cGU9dGVsXTpmb2N1cywgaW5wdXRbdHlwZT10ZWxdOmhvdmVyLCBpbnB1dFt0eXBlPW51bWJlcl06Zm9jdXMsIGlucHV0W3R5cGU9bnVtYmVyXTpob3ZlciwgaW5wdXRbdHlwZT1kYXRlXTpmb2N1cywgaW5wdXRbdHlwZT1kYXRlXTpob3ZlcixcbiAgdGV4dGFyZWE6Zm9jdXMsXG4gIHRleHRhcmVhOmhvdmVyIHtcbiAgICBib3JkZXItY29sb3I6ICMwMDljZGY7IH1cbiAgaW5wdXRbdHlwZT10ZXh0XS5pcy1pbnZhbGlkLCBpbnB1dFt0eXBlPXBhc3N3b3JkXS5pcy1pbnZhbGlkLCBpbnB1dFt0eXBlPWVtYWlsXS5pcy1pbnZhbGlkLCBpbnB1dFt0eXBlPXVybF0uaXMtaW52YWxpZCwgaW5wdXRbdHlwZT1zZWFyY2hdLmlzLWludmFsaWQsIGlucHV0W3R5cGU9dGVsXS5pcy1pbnZhbGlkLCBpbnB1dFt0eXBlPW51bWJlcl0uaXMtaW52YWxpZCwgaW5wdXRbdHlwZT1kYXRlXS5pcy1pbnZhbGlkLFxuICB0ZXh0YXJlYS5pcy1pbnZhbGlkIHtcbiAgICBib3JkZXItY29sb3I6ICNkZjE5MTk7IH1cbiAgaW5wdXRbdHlwZT10ZXh0XS5pcy12YWxpZCwgaW5wdXRbdHlwZT1wYXNzd29yZF0uaXMtdmFsaWQsIGlucHV0W3R5cGU9ZW1haWxdLmlzLXZhbGlkLCBpbnB1dFt0eXBlPXVybF0uaXMtdmFsaWQsIGlucHV0W3R5cGU9c2VhcmNoXS5pcy12YWxpZCwgaW5wdXRbdHlwZT10ZWxdLmlzLXZhbGlkLCBpbnB1dFt0eXBlPW51bWJlcl0uaXMtdmFsaWQsIGlucHV0W3R5cGU9ZGF0ZV0uaXMtdmFsaWQsXG4gIHRleHRhcmVhLmlzLXZhbGlkIHtcbiAgICBib3JkZXItY29sb3I6ICM2MWJmMzM7IH1cbiAgaW5wdXRbdHlwZT10ZXh0XS5pcy13YXJuaW5nLCBpbnB1dFt0eXBlPXBhc3N3b3JkXS5pcy13YXJuaW5nLCBpbnB1dFt0eXBlPWVtYWlsXS5pcy13YXJuaW5nLCBpbnB1dFt0eXBlPXVybF0uaXMtd2FybmluZywgaW5wdXRbdHlwZT1zZWFyY2hdLmlzLXdhcm5pbmcsIGlucHV0W3R5cGU9dGVsXS5pcy13YXJuaW5nLCBpbnB1dFt0eXBlPW51bWJlcl0uaXMtd2FybmluZywgaW5wdXRbdHlwZT1kYXRlXS5pcy13YXJuaW5nLFxuICB0ZXh0YXJlYS5pcy13YXJuaW5nIHtcbiAgICBib3JkZXItY29sb3I6ICNlOTczMjY7IH1cbiAgaW5wdXRbdHlwZT10ZXh0XTpkaXNhYmxlZCwgaW5wdXRbdHlwZT10ZXh0XVthcmlhLWRpc2FibGVkPVwidHJ1ZVwiXSwgaW5wdXRbdHlwZT10ZXh0XS5pcy1kaXNhYmxlZCwgaW5wdXRbdHlwZT1wYXNzd29yZF06ZGlzYWJsZWQsIGlucHV0W3R5cGU9cGFzc3dvcmRdW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLCBpbnB1dFt0eXBlPXBhc3N3b3JkXS5pcy1kaXNhYmxlZCwgaW5wdXRbdHlwZT1lbWFpbF06ZGlzYWJsZWQsIGlucHV0W3R5cGU9ZW1haWxdW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLCBpbnB1dFt0eXBlPWVtYWlsXS5pcy1kaXNhYmxlZCwgaW5wdXRbdHlwZT11cmxdOmRpc2FibGVkLCBpbnB1dFt0eXBlPXVybF1bYXJpYS1kaXNhYmxlZD1cInRydWVcIl0sIGlucHV0W3R5cGU9dXJsXS5pcy1kaXNhYmxlZCwgaW5wdXRbdHlwZT1zZWFyY2hdOmRpc2FibGVkLCBpbnB1dFt0eXBlPXNlYXJjaF1bYXJpYS1kaXNhYmxlZD1cInRydWVcIl0sIGlucHV0W3R5cGU9c2VhcmNoXS5pcy1kaXNhYmxlZCwgaW5wdXRbdHlwZT10ZWxdOmRpc2FibGVkLCBpbnB1dFt0eXBlPXRlbF1bYXJpYS1kaXNhYmxlZD1cInRydWVcIl0sIGlucHV0W3R5cGU9dGVsXS5pcy1kaXNhYmxlZCwgaW5wdXRbdHlwZT1udW1iZXJdOmRpc2FibGVkLCBpbnB1dFt0eXBlPW51bWJlcl1bYXJpYS1kaXNhYmxlZD1cInRydWVcIl0sIGlucHV0W3R5cGU9bnVtYmVyXS5pcy1kaXNhYmxlZCwgaW5wdXRbdHlwZT1kYXRlXTpkaXNhYmxlZCwgaW5wdXRbdHlwZT1kYXRlXVthcmlhLWRpc2FibGVkPVwidHJ1ZVwiXSwgaW5wdXRbdHlwZT1kYXRlXS5pcy1kaXNhYmxlZCxcbiAgdGV4dGFyZWE6ZGlzYWJsZWQsXG4gIHRleHRhcmVhW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLFxuICB0ZXh0YXJlYS5pcy1kaXNhYmxlZCB7XG4gICAgY3Vyc29yOiBub3QtYWxsb3dlZDtcbiAgICBjb2xvcjogIzYzNzU4YjtcbiAgICBib3JkZXItY29sb3I6ICNlNGU0ZTQ7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogI2Y5ZmJmYzsgfVxuICBpbnB1dFt0eXBlPXRleHRdW3JlYWRvbmx5XSwgaW5wdXRbdHlwZT10ZXh0XS5pcy1yZWFkb25seSwgaW5wdXRbdHlwZT1wYXNzd29yZF1bcmVhZG9ubHldLCBpbnB1dFt0eXBlPXBhc3N3b3JkXS5pcy1yZWFkb25seSwgaW5wdXRbdHlwZT1lbWFpbF1bcmVhZG9ubHldLCBpbnB1dFt0eXBlPWVtYWlsXS5pcy1yZWFkb25seSwgaW5wdXRbdHlwZT11cmxdW3JlYWRvbmx5XSwgaW5wdXRbdHlwZT11cmxdLmlzLXJlYWRvbmx5LCBpbnB1dFt0eXBlPXNlYXJjaF1bcmVhZG9ubHldLCBpbnB1dFt0eXBlPXNlYXJjaF0uaXMtcmVhZG9ubHksIGlucHV0W3R5cGU9dGVsXVtyZWFkb25seV0sIGlucHV0W3R5cGU9dGVsXS5pcy1yZWFkb25seSwgaW5wdXRbdHlwZT1udW1iZXJdW3JlYWRvbmx5XSwgaW5wdXRbdHlwZT1udW1iZXJdLmlzLXJlYWRvbmx5LCBpbnB1dFt0eXBlPWRhdGVdW3JlYWRvbmx5XSwgaW5wdXRbdHlwZT1kYXRlXS5pcy1yZWFkb25seSxcbiAgdGV4dGFyZWFbcmVhZG9ubHldLFxuICB0ZXh0YXJlYS5pcy1yZWFkb25seSB7XG4gICAgY29sb3I6ICMyMTI2MmM7XG4gICAgYm9yZGVyLWNvbG9yOiAjZTRlNGU0O1xuICAgIGJvcmRlci13aWR0aDogMCAwIDFweDsgfVxuXG50ZXh0YXJlYSB7XG4gIGhlaWdodDogMTA0cHg7XG4gIHBhZGRpbmctdG9wOiAxNnB4OyB9XG5cbnNlbGVjdCB7XG4gIGZvbnQtc2l6ZTogMXJlbTtcbiAgbGluZS1oZWlnaHQ6IDEuNTtcbiAgY29sb3I6ICMyMTI2MmM7XG4gIGZvbnQtc2l6ZTogMXJlbTtcbiAgbGluZS1oZWlnaHQ6IDEuNTtcbiAgZm9udC1mYW1pbHk6ICdPcGVuIFNhbnMnLCBzYW5zLXNlcmlmO1xuICBmb250LXdlaWdodDogNDAwO1xuICBhcHBlYXJhbmNlOiBub25lO1xuICAtd2Via2l0LWFwcGVhcmFuY2U6IHRleHRmaWVsZDtcbiAgLW1vei1hcHBlYXJhbmNlOiB0ZXh0ZmllbGQ7XG4gIGZvbnQtc2l6ZTogaW5oZXJpdDtcbiAgYm94LXNpemluZzogYm9yZGVyLWJveDtcbiAgb3V0bGluZTogbm9uZTtcbiAgYm9yZGVyLXN0eWxlOiBzb2xpZDtcbiAgYm9yZGVyLXdpZHRoOiAxcHg7XG4gIGJvcmRlci1jb2xvcjogI2NjZGFlYjtcbiAgYm9yZGVyLXJhZGl1czogMDtcbiAgY29sb3I6ICMyMTI2MmM7XG4gIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50O1xuICB0cmFuc2l0aW9uOiBib3JkZXItY29sb3IgMC4xMjVzO1xuICBoZWlnaHQ6IDUycHg7XG4gIHBhZGRpbmctbGVmdDogMTZweDtcbiAgcGFkZGluZy1yaWdodDogMTZweDtcbiAgYXBwZWFyYW5jZTogbm9uZTtcbiAgLW1vei1hcHBlYXJhbmNlOiBub25lO1xuICBiYWNrZ3JvdW5kLWltYWdlOiB1cmwoZGF0YTppbWFnZS9zdmcreG1sO2Jhc2U2NCxQSE4yWnlCNGJXeHVjejBpYUhSMGNEb3ZMM2QzZHk1M015NXZjbWN2TWpBd01DOXpkbWNpSUhkcFpIUm9QU0l4TWlJZ2FHVnBaMmgwUFNJNUlqNDhjR0YwYUNCbWFXeHNMWEoxYkdVOUltVjJaVzV2WkdRaUlHWnBiR3c5SWlNeU1USTJNa01pSUdROUlrMHhNUzQ1TXpVZ01TNDBOelZNTmk0eE9EZ2dOeTQ1TWpkaExqSTJOQzR5TmpRZ01DQXdJREV0TGpNM09DQXdUQzR3TmpVZ01TNDBOelZoTGpJek5pNHlNellnTUNBd0lERWdMakF5TmkwdU16UXpUREV1TXpneExqQTFPR0V1TWpVekxqSTFNeUF3SURBZ01TQXVNVFl6TFM0d05UbE1NUzQxTmpNZ01HRXVNalV5TGpJMU1pQXdJREFnTVNBdU1UY3hMakE0Tld3MExqSTJOU0EwTGpnNElEUXVNalkzTFRRdU9EaGhMakkxTWk0eU5USWdNQ0F3SURFZ0xqTTFNaTB1TURJM2JERXVNamt4SURFdU1EYzBZeTR3TlM0d05ESXVNRGd4TGpFd01pNHdPRFl1TVRZMllTNHlNell1TWpNMklEQWdNQ0F4TFM0d05pNHhOemQ2SWk4K1BDOXpkbWMrKTtcbiAgYmFja2dyb3VuZC1yZXBlYXQ6IG5vLXJlcGVhdDtcbiAgYmFja2dyb3VuZC1wb3NpdGlvbjogY2FsYygxMDAlIC0gMTJweCkgY2VudGVyO1xuICBwYWRkaW5nLXJpZ2h0OiA0NHB4O1xuICB3aWR0aDogMTAwJTsgfVxuICBzZWxlY3Q6Zm9jdXMsIHNlbGVjdDpob3ZlciB7XG4gICAgYm9yZGVyLWNvbG9yOiAjMDA5Y2RmOyB9XG4gIHNlbGVjdC5pcy1pbnZhbGlkIHtcbiAgICBib3JkZXItY29sb3I6ICNkZjE5MTk7IH1cbiAgc2VsZWN0LmlzLXZhbGlkIHtcbiAgICBib3JkZXItY29sb3I6ICM2MWJmMzM7IH1cbiAgc2VsZWN0LmlzLXdhcm5pbmcge1xuICAgIGJvcmRlci1jb2xvcjogI2U5NzMyNjsgfVxuICBzZWxlY3Q6ZGlzYWJsZWQsIHNlbGVjdFthcmlhLWRpc2FibGVkPVwidHJ1ZVwiXSwgc2VsZWN0LmlzLWRpc2FibGVkIHtcbiAgICBjdXJzb3I6IG5vdC1hbGxvd2VkO1xuICAgIGNvbG9yOiAjNjM3NThiO1xuICAgIGJvcmRlci1jb2xvcjogI2U0ZTRlNDtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjZjlmYmZjOyB9XG4gIHNlbGVjdFtyZWFkb25seV0sIHNlbGVjdC5pcy1yZWFkb25seSB7XG4gICAgY29sb3I6ICMyMTI2MmM7XG4gICAgYm9yZGVyLWNvbG9yOiAjZTRlNGU0O1xuICAgIGJvcmRlci13aWR0aDogMCAwIDFweDsgfVxuICBzZWxlY3Q6Zm9jdXMsIHNlbGVjdDpob3ZlciB7XG4gICAgYmFja2dyb3VuZC1pbWFnZTogdXJsKGRhdGE6aW1hZ2Uvc3ZnK3htbDtiYXNlNjQsUEhOMlp5QjRiV3h1Y3owaWFIUjBjRG92TDNkM2R5NTNNeTV2Y21jdk1qQXdNQzl6ZG1jaUlIZHBaSFJvUFNJeE1pSWdhR1ZwWjJoMFBTSTVJajQ4Y0dGMGFDQm1hV3hzTFhKMWJHVTlJbVYyWlc1dlpHUWlJR1pwYkd3OUlpTXdNRGhHUkRJaUlHUTlJazB4TVM0NU16VWdNUzQwTnpWTU5pNHhPRGdnTnk0NU1qZGhMakkyTkM0eU5qUWdNQ0F3SURFdExqTTNPQ0F3VEM0d05qVWdNUzQwTnpWaExqSXpOaTR5TXpZZ01DQXdJREVnTGpBeU5pMHVNelF6VERFdU16Z3hMakExT0dFdU1qVXpMakkxTXlBd0lEQWdNU0F1TVRZekxTNHdOVGxNTVM0MU5qTWdNR0V1TWpVeUxqSTFNaUF3SURBZ01TQXVNVGN4TGpBNE5XdzBMakkyTlNBMExqZzRJRFF1TWpZM0xUUXVPRGhoTGpJMU1pNHlOVElnTUNBd0lERWdMak0xTWkwdU1ESTNiREV1TWpreElERXVNRGMwWXk0d05TNHdOREl1TURneExqRXdNaTR3T0RZdU1UWTJZUzR5TXpZdU1qTTJJREFnTUNBeExTNHdOaTR4TnpkNklpOCtQQzl6ZG1jKyk7IH1cbiAgc2VsZWN0W2FyaWEtZXhwYW5kZWQ9XCJ0cnVlXCJdLCBzZWxlY3QuaXMtZXhwYW5kZWQge1xuICAgIGJhY2tncm91bmQtaW1hZ2U6IHVybChkYXRhOmltYWdlL3N2Zyt4bWw7YmFzZTY0LFBITjJaeUI0Yld4dWN6MGlhSFIwY0RvdkwzZDNkeTUzTXk1dmNtY3ZNakF3TUM5emRtY2lJSGRwWkhSb1BTSXhNaUlnYUdWcFoyaDBQU0k0SWo0OGNHRjBhQ0JtYVd4c0xYSjFiR1U5SW1WMlpXNXZaR1FpSUdacGJHdzlJaU13TURoR1JESWlJR1E5SWsweE1TNDVNelVnTmk0MU0wdzJMakU0T0M0eE1EUmhMakkyTkM0eU5qUWdNQ0F3SURBdExqTTNPQ0F3VEM0d05qVWdOaTQxTTJFdU1qUXVNalFnTUNBd0lEQXRMakEyTVM0eE56Y3VNak0zTGpJek55QXdJREFnTUNBdU1EZzNMakUyTld3eExqSTVJREV1TURjeFlTNHlOVGd1TWpVNElEQWdNQ0F3SUM0eE5qTXVNRFU0VERFdU5UWXpJRGhoTGpJMU1pNHlOVElnTUNBd0lEQWdMakUzTVMwdU1EZzFiRFF1TWpZMUxUUXVPRFl4SURRdU1qWTNJRFF1T0RZeFl5NHdORE11TURRNUxqRXdOQzR3T0M0eE55NHdPRFZoTGpJMk1TNHlOakVnTUNBd0lEQWdMakU0TWkwdU1EVTNiREV1TWpreExURXVNRGN4WVM0eU16WXVNak0ySURBZ01DQXdJQzR3TWpZdExqTTBNbm9pTHo0OEwzTjJaejQ9KTsgfVxuICBzZWxlY3RbZGlzYWJsZWRdLCBzZWxlY3RbYXJpYS1kaXNhYmxlZD1cInRydWVcIl0sIHNlbGVjdC5pcy1kaXNhYmxlZCB7XG4gICAgYmFja2dyb3VuZC1pbWFnZTogdXJsKGRhdGE6aW1hZ2Uvc3ZnK3htbDtiYXNlNjQsUEhOMlp5QjRiV3h1Y3owaWFIUjBjRG92TDNkM2R5NTNNeTV2Y21jdk1qQXdNQzl6ZG1jaUlIZHBaSFJvUFNJeE1pSWdhR1ZwWjJoMFBTSTVJajQ4Y0dGMGFDQm1hV3hzTFhKMWJHVTlJbVYyWlc1dlpHUWlJR1pwYkd3OUlpTTJNemMxT0VJaUlHUTlJazB4TVM0NU16VWdNUzQwTnpWTU5pNHhPRGdnTnk0NU1qZGhMakkyTkM0eU5qUWdNQ0F3SURFdExqTTNPQ0F3VEM0d05qVWdNUzQwTnpWaExqSXpOUzR5TXpVZ01DQXdJREVnTGpBeU5pMHVNelF6VERFdU16Z3hMakExT0dFdU1qVXpMakkxTXlBd0lEQWdNU0F1TVRZekxTNHdOVGxNTVM0MU5qTWdNR0V1TWpVeUxqSTFNaUF3SURBZ01TQXVNVGN4TGpBNE5XdzBMakkyTlNBMExqZzRJRFF1TWpZM0xUUXVPRGhoTGpJMU1pNHlOVElnTUNBd0lERWdMak0xTWkwdU1ESTNiREV1TWpreElERXVNRGMwWXk0d05TNHdOREl1TURneExqRXdNaTR3T0RZdU1UWTJZUzR5TXpRdU1qTTBJREFnTUNBeExTNHdOaTR4TnpkNklpOCtQQzl6ZG1jKyk7IH1cbiAgc2VsZWN0W211bHRpcGxlXSB7XG4gICAgaGVpZ2h0OiAxNTZweDtcbiAgICBiYWNrZ3JvdW5kLWltYWdlOiBub25lO1xuICAgIHBhZGRpbmctdG9wOiAxNnB4OyB9XG5cbmlucHV0W3R5cGU9cmFkaW9dLCBpbnB1dFt0eXBlPWNoZWNrYm94XSB7XG4gIGhlaWdodDogMjhweDtcbiAgd2lkdGg6IDI4cHg7XG4gIG1hcmdpbjogMDtcbiAgdmVydGljYWwtYWxpZ246IG1pZGRsZTtcbiAgcG9zaXRpb246IHJlbGF0aXZlOyB9XG4gIGlucHV0W3R5cGU9cmFkaW9dOmNoZWNrZWQsIGlucHV0W3R5cGU9Y2hlY2tib3hdOmNoZWNrZWQge1xuICAgIGJvcmRlci1jb2xvcjogIzAwOWNkZjtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjMDA5Y2RmOyB9XG4gIGlucHV0W3R5cGU9cmFkaW9dW2Rpc2FibGVkXSwgaW5wdXRbdHlwZT1yYWRpb11bYXJpYS1kaXNhYmxlZD1cInRydWVcIl0sIGlucHV0W3R5cGU9cmFkaW9dLmlzLWRpc2FibGVkLCBpbnB1dFt0eXBlPWNoZWNrYm94XVtkaXNhYmxlZF0sIGlucHV0W3R5cGU9Y2hlY2tib3hdW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLCBpbnB1dFt0eXBlPWNoZWNrYm94XS5pcy1kaXNhYmxlZCB7XG4gICAgYm9yZGVyLWNvbG9yOiAjZTRlNGU0O1xuICAgIGJhY2tncm91bmQtY29sb3I6ICNmOWZiZmM7IH1cblxuaW5wdXRbdHlwZT1cImNoZWNrYm94XCJdOmNoZWNrZWQ6OmFmdGVyIHtcbiAgY29udGVudDogXCJcIjtcbiAgd2lkdGg6IDE2cHg7XG4gIGhlaWdodDogNnB4O1xuICBib3JkZXItY29sb3I6ICNmZmZmZmY7XG4gIGJvcmRlci1zdHlsZTogc29saWQ7XG4gIGJvcmRlci13aWR0aDogMCAwIDFweCAxcHg7XG4gIHRyYW5zZm9ybTogcm90YXRlKC00NWRlZyk7XG4gIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgei1pbmRleDogMjtcbiAgdG9wOiBjYWxjKDUwJSAtIDVweCk7XG4gIGxlZnQ6IGNhbGMoNTAlIC0gMTZweC8yKTsgfVxuXG5pbnB1dFt0eXBlPVwiY2hlY2tib3hcIl06Y2hlY2tlZFtkaXNhYmxlZF06OmFmdGVyLCBpbnB1dFt0eXBlPVwiY2hlY2tib3hcIl06Y2hlY2tlZFthcmlhLWRpc2FibGVkPVwidHJ1ZVwiXTo6YWZ0ZXIsIGlucHV0W3R5cGU9XCJjaGVja2JveFwiXTpjaGVja2VkLmlzLWRpc2FibGVkOjphZnRlciB7XG4gIGJvcmRlci1jb2xvcjogIzdmOTBhNDsgfVxuXG5pbnB1dFt0eXBlPVwicmFkaW9cIl0ge1xuICBib3JkZXItcmFkaXVzOiA1MCU7IH1cbiAgaW5wdXRbdHlwZT1cInJhZGlvXCJdOjphZnRlciB7XG4gICAgY29udGVudDogXCJcIjtcbiAgICBib3JkZXItcmFkaXVzOiA1MCU7XG4gICAgd2lkdGg6IDE2cHg7XG4gICAgaGVpZ2h0OiAxNnB4O1xuICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICBib3R0b206IDA7XG4gICAgcmlnaHQ6IDA7XG4gICAgdG9wOiBjYWxjKDUwJSAtICgxNnB4LzIpKTtcbiAgICBsZWZ0OiBjYWxjKDUwJSAtICgxNnB4LzIpKTtcbiAgICB0cmFuc2l0aW9uOiBiYWNrZ3JvdW5kLWNvbG9yIDAuMTI1cyBlYXNlLWluO1xuICAgIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50OyB9XG4gIGlucHV0W3R5cGU9XCJyYWRpb1wiXTpjaGVja2VkIHtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjZmZmZmZmOyB9XG4gICAgaW5wdXRbdHlwZT1cInJhZGlvXCJdOmNoZWNrZWQ6OmFmdGVyIHtcbiAgICAgIGJhY2tncm91bmQtY29sb3I6ICMwMDljZGY7IH1cbiAgICBpbnB1dFt0eXBlPVwicmFkaW9cIl06Y2hlY2tlZFtkaXNhYmxlZF06OmFmdGVyLCBpbnB1dFt0eXBlPVwicmFkaW9cIl06Y2hlY2tlZFthcmlhLWRpc2FibGVkPVwidHJ1ZVwiXTo6YWZ0ZXIsIGlucHV0W3R5cGU9XCJyYWRpb1wiXTpjaGVja2VkLmlzLWRpc2FibGVkOjphZnRlciB7XG4gICAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjN2Y5MGE0OyB9XG5cbi8qIVxuLmZkLXNlY3Rpb24rKC0tZnVsbC1ibGVlZCwgLS1uby1ib3JkZXIpXG4gICAgLmZkLXNlY3Rpb25fX2hlYWRlclxuICAgICAgICAuZmQtc2VjdGlvbl9fdGl0bGVcbiAgICAgICAgLmZkLXNlY3Rpb25fX2FjdGlvbnNcbiAgICAuZmQtc2VjdGlvbl9fZm9vdGVyXG4qL1xuLmZkLXNlY3Rpb24ge1xuICBwYWRkaW5nOiA0MHB4IDIwcHggMjBweDtcbiAgYm9yZGVyLWJvdHRvbTogc29saWQgMnB4ICNjY2RhZWI7IH1cbiAgLmZkLXNlY3Rpb246OmFmdGVyIHtcbiAgICBjb250ZW50OiBcIlwiO1xuICAgIGRpc3BsYXk6IHRhYmxlO1xuICAgIGNsZWFyOiBib3RoOyB9XG4gIC5mZC1zZWN0aW9uOmxhc3QtY2hpbGQsIC5mZC1zZWN0aW9uLS1uby1ib3JkZXIge1xuICAgIGJvcmRlci1ib3R0b206IDA7IH1cbiAgLmZkLXNlY3Rpb24tLWZ1bGwtYmxlZWQge1xuICAgIHBhZGRpbmctcmlnaHQ6IDA7XG4gICAgcGFkZGluZy1sZWZ0OiAwOyB9XG4gICAgLmZkLXNlY3Rpb24tLWZ1bGwtYmxlZWQgLmZkLXNlY3Rpb25fX2hlYWRlciwgLmZkLXNlY3Rpb24tLWZ1bGwtYmxlZWQgLmZkLXNlY3Rpb25fX2Zvb3RlciB7XG4gICAgICBtYXJnaW4tbGVmdDogMjBweDtcbiAgICAgIG1hcmdpbi1yaWdodDogMjBweDsgfVxuICAuZmQtc2VjdGlvbl9faGVhZGVyIHtcbiAgICBtaW4taGVpZ2h0OiA0MHB4O1xuICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgYWxpZ24taXRlbXM6IGNlbnRlcjtcbiAgICBtYXJnaW4tYm90dG9tOiAxNnB4OyB9XG4gIC5mZC1zZWN0aW9uX190aXRsZSB7XG4gICAgZm9udC1zaXplOiAxLjYyNXJlbTtcbiAgICBsaW5lLWhlaWdodDogMS4yMzA3NztcbiAgICBmb250LWZhbWlseTogUm9ib3RvLCBzYW5zLXNlcmlmO1xuICAgIGZvbnQtd2VpZ2h0OiA2MDA7XG4gICAgZmxleDogMTtcbiAgICBtYXJnaW4tYm90dG9tOiAwOyB9XG4gIC5mZC1zZWN0aW9uX19hY3Rpb25zIHtcbiAgICBtYXJnaW4tbGVmdDogYXV0bzsgfVxuICAuZmQtc2VjdGlvbl9fZm9vdGVyIHtcbiAgICBkaXNwbGF5OiBmbGV4O1xuICAgIGp1c3RpZnktY29udGVudDogY2VudGVyOyB9XG5cbi5mZC1jb250YWluZXIge1xuICBtYXJnaW4tYm90dG9tOiAyMHB4O1xuICBtYXgtd2lkdGg6IDEyOTBweDsgfVxuICAuZmQtY29udGFpbmVyOjphZnRlciB7XG4gICAgY29udGVudDogXCJcIjtcbiAgICBkaXNwbGF5OiB0YWJsZTtcbiAgICBjbGVhcjogYm90aDsgfVxuICAuZmQtY29udGFpbmVyOmxhc3QtY2hpbGQge1xuICAgIG1hcmdpbi1ib3R0b206IDA7IH1cbiAgLmZkLWNvbnRhaW5lci0tZmx1aWQge1xuICAgIG1heC13aWR0aDogMTAwJTsgfVxuICAuZmQtY29udGFpbmVyLS1mbGV4IHtcbiAgICBkaXNwbGF5OiBmbGV4OyB9XG4gIC5mZC1jb250YWluZXItLWNlbnRlcmVkIHtcbiAgICBtYXJnaW4tbGVmdDogYXV0bztcbiAgICBtYXJnaW4tcmlnaHQ6IGF1dG87IH1cblxuLypcbldIWSBUSElTOlxuT3RoZXIgc2VtYW50aWMgZ3JpZHMgZG9uJ3QgZWFpbHkgYWxsb3cgZm9yIGZpeGVkIGd1dHRlciB3aWR0aHNcbm5vciBkbyB0aGV5IHRha2UgYWR2YW50YWdlIG9mIHRoZSBDU1MgY2FsYyBmdW5jdGlvblxuYW5kIHRoZXkgY2FuIGdldCBraW5kIG9mIGNvbmZ1c2luZy5cblRoaXMgaXMgbWVhbnQgZm9yIHNpbXBsZSBsYXlvdXQgcHJvYmxlbXMg4oCUwqBcbmkuZS4sIHlvdSBoYXZlIGEgYm94IGFuZCB5b3UgbmVlZCB0aHJlZSBjb2xzIGluc2lkZSBvZiBlcXVhbCB3aWR0aHNcbndpdGggZ3V0dGVycyBiZXR3ZWVuLlxuXG5UaGUgRkxPVyB0ZXJtaW5vbG9neSBpcyBtZWFudCB0byBiZSBuZXR1cmFsIG91dHNpZGUgb2Ygcm93cyBhbmQgY29sdW1uc1xuYW5kIGNvbWVzIGZyb20gdGhlIEhUTUw1IHNwZWMgcmVmZXJyaW5nIHRvIGVsZW1lbnRzIHRoYXQgY2FuIGNvbnRhaW4gb3RoZXIgZWxlbWVudHNcbmh0dHA6Ly93M2MuZ2l0aHViLmlvL2h0bWwvZG9tLmh0bWwja2luZHMtb2YtY29udGVudC1mbG93LWNvbnRlbnRcblxuVVNBR0U6XG7igJTCoE91dGVyIGNvbnRhaW5lcnMgc2hvdWxkIGNvbnRhaW4gdGhlIGBAaW5jbHVkZSBmbG93LWJveGAgYmFzZSBzdHlsZXNcbuKAlMKgQ29sdW1ucyBnZXQgYEBpbmNsdWRlIGZsb3dgIHdpdGggYCRzcGFuYCBhbmQgYCRjb2xzYCBwYXJhbXNcblxuRVhBTVBMRSBNQVJLVVA6XG48c2VjdGlvbj5cbiAgPGRpdiBjbGFzcz1cImJveFwiPng8L2Rpdj5cbiAgPGRpdiBjbGFzcz1cImJveFwiPng8L2Rpdj5cbiAgPGRpdiBjbGFzcz1cImJveFwiPng8L2Rpdj5cbiAgPGRpdiBjbGFzcz1cImJveFwiPng8L2Rpdj5cbjwvc2VjdGlvbj5cblxuRVhBTVBMRSBDU1M6XG5zZWN0aW9uIHtcbiAgQGluY2x1ZGUgZmxvdy1ib3goKVxuICAuYm94IHtcbiAgICBAaW5jbHVkZSBmbG93KDIpO1xuICAgICY6Zmlyc3QtY2hpbGQge1xuICAgICAgQGluY2x1ZGUgZmxvdy1zaGlmdCgyKTtcbiAgICB9XG4gIH1cbn1cblxuT1VUUFVUOlxuVGhpcyB3aWxsIHJlbmRlciA0IGJveGVzIHNwYW5uaW5nIDIgY29scyBlYWNoIGluZGVudGVkIDIgY29sc1xuKGJhc2VkIG9uIGRlZmF1bHRzKVxuXG58LS18IHwtLXwgfC0tfCB8LS18IHwtLXwgfC0tfCB8LS18IHwtLXwgfC0tfCB8LS18IHwtLXwgfC0tfFxuICAgICAgICAgIHwgIGJveCAgfCB8ICBib3ggIHwgfCAgYm94ICB8IHwgIGJveCAgfFxuXG4qL1xuLyohXG4gICAgLmZkLWNvbCsoLS0xLi4uMTIsIC0tc2hpZnQtMS4uLjExKVxuKi9cbi5mZC1jb2wge1xuICBmbGV4OiAxOyB9XG4gIEBtZWRpYSAobWluLXdpZHRoOiA4MDBweCkge1xuICAgIC5mZC1jb2wtLTEge1xuICAgICAgZmxvYXQ6IGxlZnQ7XG4gICAgICBtYXJnaW4tcmlnaHQ6IDMycHg7XG4gICAgICB3aWR0aDogY2FsYyggKCAoICgxMDAlIC0gMzUycHgpIC8gMTIgKSAqIDEgKSArIDBweCk7IH1cbiAgICAgIC5mZC1jb2wtLTE6bGFzdC1jaGlsZCB7XG4gICAgICAgIG1hcmdpbi1yaWdodDogMDsgfVxuICAgIC5mZC1jb2wtLTIge1xuICAgICAgZmxvYXQ6IGxlZnQ7XG4gICAgICBtYXJnaW4tcmlnaHQ6IDMycHg7XG4gICAgICB3aWR0aDogY2FsYyggKCAoICgxMDAlIC0gMzUycHgpIC8gMTIgKSAqIDIgKSArIDMycHgpOyB9XG4gICAgICAuZmQtY29sLS0yOmxhc3QtY2hpbGQge1xuICAgICAgICBtYXJnaW4tcmlnaHQ6IDA7IH1cbiAgICAuZmQtY29sLS0zIHtcbiAgICAgIGZsb2F0OiBsZWZ0O1xuICAgICAgbWFyZ2luLXJpZ2h0OiAzMnB4O1xuICAgICAgd2lkdGg6IGNhbGMoICggKCAoMTAwJSAtIDM1MnB4KSAvIDEyICkgKiAzICkgKyA2NHB4KTsgfVxuICAgICAgLmZkLWNvbC0tMzpsYXN0LWNoaWxkIHtcbiAgICAgICAgbWFyZ2luLXJpZ2h0OiAwOyB9XG4gICAgLmZkLWNvbC0tNCB7XG4gICAgICBmbG9hdDogbGVmdDtcbiAgICAgIG1hcmdpbi1yaWdodDogMzJweDtcbiAgICAgIHdpZHRoOiBjYWxjKCAoICggKDEwMCUgLSAzNTJweCkgLyAxMiApICogNCApICsgOTZweCk7IH1cbiAgICAgIC5mZC1jb2wtLTQ6bGFzdC1jaGlsZCB7XG4gICAgICAgIG1hcmdpbi1yaWdodDogMDsgfVxuICAgIC5mZC1jb2wtLTUge1xuICAgICAgZmxvYXQ6IGxlZnQ7XG4gICAgICBtYXJnaW4tcmlnaHQ6IDMycHg7XG4gICAgICB3aWR0aDogY2FsYyggKCAoICgxMDAlIC0gMzUycHgpIC8gMTIgKSAqIDUgKSArIDEyOHB4KTsgfVxuICAgICAgLmZkLWNvbC0tNTpsYXN0LWNoaWxkIHtcbiAgICAgICAgbWFyZ2luLXJpZ2h0OiAwOyB9XG4gICAgLmZkLWNvbC0tNiB7XG4gICAgICBmbG9hdDogbGVmdDtcbiAgICAgIG1hcmdpbi1yaWdodDogMzJweDtcbiAgICAgIHdpZHRoOiBjYWxjKCAoICggKDEwMCUgLSAzNTJweCkgLyAxMiApICogNiApICsgMTYwcHgpOyB9XG4gICAgICAuZmQtY29sLS02Omxhc3QtY2hpbGQge1xuICAgICAgICBtYXJnaW4tcmlnaHQ6IDA7IH1cbiAgICAuZmQtY29sLS03IHtcbiAgICAgIGZsb2F0OiBsZWZ0O1xuICAgICAgbWFyZ2luLXJpZ2h0OiAzMnB4O1xuICAgICAgd2lkdGg6IGNhbGMoICggKCAoMTAwJSAtIDM1MnB4KSAvIDEyICkgKiA3ICkgKyAxOTJweCk7IH1cbiAgICAgIC5mZC1jb2wtLTc6bGFzdC1jaGlsZCB7XG4gICAgICAgIG1hcmdpbi1yaWdodDogMDsgfVxuICAgIC5mZC1jb2wtLTgge1xuICAgICAgZmxvYXQ6IGxlZnQ7XG4gICAgICBtYXJnaW4tcmlnaHQ6IDMycHg7XG4gICAgICB3aWR0aDogY2FsYyggKCAoICgxMDAlIC0gMzUycHgpIC8gMTIgKSAqIDggKSArIDIyNHB4KTsgfVxuICAgICAgLmZkLWNvbC0tODpsYXN0LWNoaWxkIHtcbiAgICAgICAgbWFyZ2luLXJpZ2h0OiAwOyB9XG4gICAgLmZkLWNvbC0tOSB7XG4gICAgICBmbG9hdDogbGVmdDtcbiAgICAgIG1hcmdpbi1yaWdodDogMzJweDtcbiAgICAgIHdpZHRoOiBjYWxjKCAoICggKDEwMCUgLSAzNTJweCkgLyAxMiApICogOSApICsgMjU2cHgpOyB9XG4gICAgICAuZmQtY29sLS05Omxhc3QtY2hpbGQge1xuICAgICAgICBtYXJnaW4tcmlnaHQ6IDA7IH1cbiAgICAuZmQtY29sLS0xMCB7XG4gICAgICBmbG9hdDogbGVmdDtcbiAgICAgIG1hcmdpbi1yaWdodDogMzJweDtcbiAgICAgIHdpZHRoOiBjYWxjKCAoICggKDEwMCUgLSAzNTJweCkgLyAxMiApICogMTAgKSArIDI4OHB4KTsgfVxuICAgICAgLmZkLWNvbC0tMTA6bGFzdC1jaGlsZCB7XG4gICAgICAgIG1hcmdpbi1yaWdodDogMDsgfVxuICAgIC5mZC1jb2wtLTExIHtcbiAgICAgIGZsb2F0OiBsZWZ0O1xuICAgICAgbWFyZ2luLXJpZ2h0OiAzMnB4O1xuICAgICAgd2lkdGg6IGNhbGMoICggKCAoMTAwJSAtIDM1MnB4KSAvIDEyICkgKiAxMSApICsgMzIwcHgpOyB9XG4gICAgICAuZmQtY29sLS0xMTpsYXN0LWNoaWxkIHtcbiAgICAgICAgbWFyZ2luLXJpZ2h0OiAwOyB9XG4gICAgLmZkLWNvbC0tMTIge1xuICAgICAgZmxvYXQ6IGxlZnQ7XG4gICAgICBtYXJnaW4tcmlnaHQ6IDMycHg7XG4gICAgICB3aWR0aDogY2FsYyggKCAoICgxMDAlIC0gMzUycHgpIC8gMTIgKSAqIDEyICkgKyAzNTJweCk7IH1cbiAgICAgIC5mZC1jb2wtLTEyOmxhc3QtY2hpbGQge1xuICAgICAgICBtYXJnaW4tcmlnaHQ6IDA7IH1cbiAgICAuZmQtY29sLS1zaGlmdC0xIHtcbiAgICAgIG1hcmdpbi1sZWZ0OiBjYWxjKCAoICggKDEwMCUgLSAzNTJweCkgLyAxMiApICogMSApICsgMzJweCk7IH1cbiAgICAuZmQtY29sLS1zaGlmdC0yIHtcbiAgICAgIG1hcmdpbi1sZWZ0OiBjYWxjKCAoICggKDEwMCUgLSAzNTJweCkgLyAxMiApICogMiApICsgNjRweCk7IH1cbiAgICAuZmQtY29sLS1zaGlmdC0zIHtcbiAgICAgIG1hcmdpbi1sZWZ0OiBjYWxjKCAoICggKDEwMCUgLSAzNTJweCkgLyAxMiApICogMyApICsgOTZweCk7IH1cbiAgICAuZmQtY29sLS1zaGlmdC00IHtcbiAgICAgIG1hcmdpbi1sZWZ0OiBjYWxjKCAoICggKDEwMCUgLSAzNTJweCkgLyAxMiApICogNCApICsgMTI4cHgpOyB9XG4gICAgLmZkLWNvbC0tc2hpZnQtNSB7XG4gICAgICBtYXJnaW4tbGVmdDogY2FsYyggKCAoICgxMDAlIC0gMzUycHgpIC8gMTIgKSAqIDUgKSArIDE2MHB4KTsgfVxuICAgIC5mZC1jb2wtLXNoaWZ0LTYge1xuICAgICAgbWFyZ2luLWxlZnQ6IGNhbGMoICggKCAoMTAwJSAtIDM1MnB4KSAvIDEyICkgKiA2ICkgKyAxOTJweCk7IH1cbiAgICAuZmQtY29sLS1zaGlmdC03IHtcbiAgICAgIG1hcmdpbi1sZWZ0OiBjYWxjKCAoICggKDEwMCUgLSAzNTJweCkgLyAxMiApICogNyApICsgMjI0cHgpOyB9XG4gICAgLmZkLWNvbC0tc2hpZnQtOCB7XG4gICAgICBtYXJnaW4tbGVmdDogY2FsYyggKCAoICgxMDAlIC0gMzUycHgpIC8gMTIgKSAqIDggKSArIDI1NnB4KTsgfVxuICAgIC5mZC1jb2wtLXNoaWZ0LTkge1xuICAgICAgbWFyZ2luLWxlZnQ6IGNhbGMoICggKCAoMTAwJSAtIDM1MnB4KSAvIDEyICkgKiA5ICkgKyAyODhweCk7IH1cbiAgICAuZmQtY29sLS1zaGlmdC0xMCB7XG4gICAgICBtYXJnaW4tbGVmdDogY2FsYyggKCAoICgxMDAlIC0gMzUycHgpIC8gMTIgKSAqIDEwICkgKyAzMjBweCk7IH1cbiAgICAuZmQtY29sLS1zaGlmdC0xMSB7XG4gICAgICBtYXJnaW4tbGVmdDogY2FsYyggKCAoICgxMDAlIC0gMzUycHgpIC8gMTIgKSAqIDExICkgKyAzNTJweCk7IH0gfVxuICBbY2xhc3NePVwiZmQtY29sXCJdIHtcbiAgICBtYXJnaW4tYm90dG9tOiAyMHB4OyB9XG4gICAgW2NsYXNzXj1cImZkLWNvbFwiXTpsYXN0LWNoaWxkIHtcbiAgICAgIG1hcmdpbi1ib3R0b206IDA7IH1cbiAgICBAbWVkaWEgKG1pbi13aWR0aDogODAwcHgpIHtcbiAgICAgIFtjbGFzc149XCJmZC1jb2xcIl0ge1xuICAgICAgICBtYXJnaW4tYm90dG9tOiAwOyB9IH1cblxuLyohXG4uZmQtdWkrKC0tZml4ZWQpXG4gICAgLmZkLXVpX19oZWFkZXIrKC0tZml4ZWQpXG4gICAgLmZkLXVpX19hcHBcbiAgICAuZmQtdWlfX2Zvb3RlcisoLS1maXhlZClcbiAgICAuZmQtdWlfX292ZXJsYXlcbiovXG4uZmQtdWkge1xuICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gIG1pbi1oZWlnaHQ6IDEwMHZoO1xuICB3aWR0aDogMTAwdnc7XG4gIG1heC13aWR0aDogMTAwdnc7IH1cbiAgLmZkLXVpLS1maXhlZCB7XG4gICAgZGlzcGxheTogZmxleDtcbiAgICBmbGV4LWRpcmVjdGlvbjogY29sdW1uO1xuICAgIG1heC1oZWlnaHQ6IDEwMHZoOyB9XG4gICAgLmZkLXVpLS1maXhlZCAuZmQtdWlfX2hlYWRlciB7XG4gICAgICBmbGV4OiAwIDAgNTBweDtcbiAgICAgIHBvc2l0aW9uOiBzdGF0aWM7IH1cbiAgICAuZmQtdWktLWZpeGVkIC5mZC11aV9fZm9vdGVyIHtcbiAgICAgIGZsZXg6IDAgMCA0MHB4O1xuICAgICAgcG9zaXRpb246IHN0YXRpYzsgfVxuICAgIC5mZC11aS0tZml4ZWQgLmZkLXVpX19hcHAge1xuICAgICAgb3ZlcmZsb3c6IHNjcm9sbDtcbiAgICAgIG1hcmdpbi10b3A6IDA7XG4gICAgICBmbGV4OiAxO1xuICAgICAgbWluLWhlaWdodDogYXV0bzsgfVxuICAuZmQtdWlfX2hlYWRlciB7XG4gICAgcG9zaXRpb246IGFic29sdXRlO1xuICAgIHotaW5kZXg6IDE7XG4gICAgYmFja2dyb3VuZDogIzAwNmZiYjtcbiAgICB3aWR0aDogMTAwJTtcbiAgICBtaW4taGVpZ2h0OiA1MHB4O1xuICAgIGhlaWdodDogNTBweDsgfVxuICAgIC5mZC11aV9faGVhZGVyLS1maXhlZCB7XG4gICAgICBwb3NpdGlvbjogZml4ZWQ7IH1cbiAgLmZkLXVpX19mb290ZXIge1xuICAgIGJhY2tncm91bmQ6ICMyNzM5NGY7XG4gICAgd2lkdGg6IDEwMCU7XG4gICAgbWluLWhlaWdodDogNDBweDtcbiAgICBoZWlnaHQ6IDQwcHg7IH1cbiAgICAuZmQtdWlfX2Zvb3Rlci0tZml4ZWQge1xuICAgICAgcG9zaXRpb246IGZpeGVkO1xuICAgICAgYm90dG9tOiAwOyB9XG4gIC5mZC11aV9fYXBwIHtcbiAgICBtYXJnaW4tdG9wOiA1MHB4O1xuICAgIG1pbi1oZWlnaHQ6IGNhbGMoMTAwdmggLSA0MHB4IC0gNTBweCk7XG4gICAgd2lkdGg6IDEwMCU7XG4gICAgZGlzcGxheTogZmxleDtcbiAgICBwb3NpdGlvbjogcmVsYXRpdmU7IH1cbiAgLmZkLXVpX19vdmVybGF5IHtcbiAgICBwb3NpdGlvbjogYWJzb2x1dGU7IH1cblxuLyohXG4uZmQtYXBwXG4gICAgLmZkLWFwcF9fc2lkZWJhclxuICAgIC5mZC1hcHBfX21haW5cbiovXG4uZmQtYXBwIHtcbiAgd2lkdGg6IDEwMCU7IH1cbiAgQG1lZGlhIChtaW4td2lkdGg6IDgwMHB4KSB7XG4gICAgLmZkLWFwcCB7XG4gICAgICBkaXNwbGF5OiBmbGV4OyB9IH1cbiAgLmZkLWFwcF9fc2lkZWJhciB7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogIzI3Mzk0ZjtcbiAgICB3aWR0aDogMTAwdnc7XG4gICAgbWF4LWhlaWdodDogNDBweDtcbiAgICBvdmVyZmxvdzogc2Nyb2xsOyB9XG4gICAgLmZkLWFwcF9fc2lkZWJhcjpob3ZlciB7XG4gICAgICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gICAgICBtaW4taGVpZ2h0OiAxMDAlOyB9XG4gICAgQG1lZGlhIChtaW4td2lkdGg6IDgwMHB4KSB7XG4gICAgICAuZmQtYXBwX19zaWRlYmFyIHtcbiAgICAgICAgd2lkdGg6IDgwcHg7XG4gICAgICAgIG1heC1oZWlnaHQ6IDEwMCU7IH1cbiAgICAgICAgLmZkLWFwcF9fc2lkZWJhcjpob3ZlciB7XG4gICAgICAgICAgd2lkdGg6IDI1MHB4O1xuICAgICAgICAgIHBvc2l0aW9uOiByZWxhdGl2ZTtcbiAgICAgICAgICBtYXJnaW4tcmlnaHQ6IC0yMDBweDsgfSB9XG4gICAgQG1lZGlhIChtaW4td2lkdGg6IDE0NDBweCkge1xuICAgICAgLmZkLWFwcF9fc2lkZWJhciB7XG4gICAgICAgIHdpZHRoOiAyNTBweDsgfVxuICAgICAgICAuZmQtYXBwX19zaWRlYmFyOmhvdmVyIHtcbiAgICAgICAgICB3aWR0aDogMjUwcHg7XG4gICAgICAgICAgbWFyZ2luLXJpZ2h0OiAwOyB9IH1cbiAgLmZkLWFwcF9fbWFpbiB7XG4gICAgZmxleDogMTtcbiAgICBvdmVyZmxvdzogc2Nyb2xsOyB9XG5cbi5mZC1wYWdlIHtcbiAgZGlzcGxheTogZmxleDtcbiAgZmxleC1kaXJlY3Rpb246IGNvbHVtbjtcbiAgbWluLWhlaWdodDogMTAwJTtcbiAgd2lkdGg6IDEwMCU7IH1cbiAgLmZkLXBhZ2VfX2hlYWRlciB7XG4gICAgYm9yZGVyLWJvdHRvbTogc29saWQgMXB4ICNjY2RhZWI7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogI2YwZjVmZjtcbiAgICBoZWlnaHQ6IDc2cHg7IH1cbiAgLmZkLXBhZ2VfX2ludHJvIHtcbiAgICBmb250LXNpemU6IDAuODc1cmVtO1xuICAgIGxpbmUtaGVpZ2h0OiAxLjQyODU4O1xuICAgIGZvbnQtd2VpZ2h0OiA0MDA7XG4gICAgcGFkZGluZzogMTZweCAyMHB4O1xuICAgIGJhY2tncm91bmQtY29sb3I6ICNmMGY1ZmY7XG4gICAgdGV4dC1hbGlnbjogY2VudGVyO1xuICAgIGJvcmRlci1ib3R0b206IHNvbGlkIDFweCAjY2NkYWViO1xuICAgIG1hcmdpbi1ib3R0b206IC0xcHg7IH1cbiAgLmZkLXBhZ2VfX2NvbnRlbnQge1xuICAgIGZsZXgtZ3JvdzogMTsgfVxuXG4vKiFcbi5mZC1zZWN0aW9uKygtLWZ1bGwtYmxlZWQsIC0tbm8tYm9yZGVyKVxuICAgIC5mZC1zZWN0aW9uX19oZWFkZXJcbiAgICAgICAgLmZkLXNlY3Rpb25fX3RpdGxlXG4gICAgICAgIC5mZC1zZWN0aW9uX19hY3Rpb25zXG4gICAgLmZkLXNlY3Rpb25fX2Zvb3RlclxuKi9cbi5mZC1zZWN0aW9uIHtcbiAgcGFkZGluZzogNDBweCAyMHB4IDIwcHg7XG4gIGJvcmRlci1ib3R0b206IHNvbGlkIDJweCAjY2NkYWViOyB9XG4gIC5mZC1zZWN0aW9uOjphZnRlciB7XG4gICAgY29udGVudDogXCJcIjtcbiAgICBkaXNwbGF5OiB0YWJsZTtcbiAgICBjbGVhcjogYm90aDsgfVxuICAuZmQtc2VjdGlvbjpsYXN0LWNoaWxkLCAuZmQtc2VjdGlvbi0tbm8tYm9yZGVyIHtcbiAgICBib3JkZXItYm90dG9tOiAwOyB9XG4gIC5mZC1zZWN0aW9uLS1mdWxsLWJsZWVkIHtcbiAgICBwYWRkaW5nLXJpZ2h0OiAwO1xuICAgIHBhZGRpbmctbGVmdDogMDsgfVxuICAgIC5mZC1zZWN0aW9uLS1mdWxsLWJsZWVkIC5mZC1zZWN0aW9uX19oZWFkZXIsIC5mZC1zZWN0aW9uLS1mdWxsLWJsZWVkIC5mZC1zZWN0aW9uX19mb290ZXIge1xuICAgICAgbWFyZ2luLWxlZnQ6IDIwcHg7XG4gICAgICBtYXJnaW4tcmlnaHQ6IDIwcHg7IH1cbiAgLmZkLXNlY3Rpb25fX2hlYWRlciB7XG4gICAgbWluLWhlaWdodDogNDBweDtcbiAgICBkaXNwbGF5OiBmbGV4O1xuICAgIGFsaWduLWl0ZW1zOiBjZW50ZXI7XG4gICAgbWFyZ2luLWJvdHRvbTogMTZweDsgfVxuICAuZmQtc2VjdGlvbl9fdGl0bGUge1xuICAgIGZvbnQtc2l6ZTogMS42MjVyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuMjMwNzc7XG4gICAgZm9udC1mYW1pbHk6IFJvYm90bywgc2Fucy1zZXJpZjtcbiAgICBmb250LXdlaWdodDogNjAwO1xuICAgIGZsZXg6IDE7XG4gICAgbWFyZ2luLWJvdHRvbTogMDsgfVxuICAuZmQtc2VjdGlvbl9fYWN0aW9ucyB7XG4gICAgbWFyZ2luLWxlZnQ6IGF1dG87IH1cbiAgLmZkLXNlY3Rpb25fX2Zvb3RlciB7XG4gICAgZGlzcGxheTogZmxleDtcbiAgICBqdXN0aWZ5LWNvbnRlbnQ6IGNlbnRlcjsgfVxuXG4vKiFcbi5mZC1wYW5lbFxuICAgIC5mZC1wYW5lbF9faGVhZGVyXG4gICAgICAgIC5mZC1wYW5lbF9fdGl0bGVcbiAgICAgICAgLmZkLXBhbmVsX19hY3Rpb25zXG4gICAgLmZkLXBhbmVsX19mb290ZXJcbiovXG4uZmQtcGFuZWw6OmFmdGVyIHtcbiAgY29udGVudDogXCJcIjtcbiAgZGlzcGxheTogdGFibGU7XG4gIGNsZWFyOiBib3RoOyB9XG5cbi5mZC1wYW5lbF9faGVhZGVyIHtcbiAgbWluLWhlaWdodDogNDBweDtcbiAgZGlzcGxheTogZmxleDtcbiAgYWxpZ24taXRlbXM6IGNlbnRlcjtcbiAgbWFyZ2luLWJvdHRvbTogMTZweDsgfVxuXG4uZmQtcGFuZWxfX3RpdGxlIHtcbiAgZm9udC1zaXplOiAxLjYyNXJlbTtcbiAgbGluZS1oZWlnaHQ6IDEuMjMwNzc7XG4gIGZvbnQtZmFtaWx5OiBSb2JvdG8sIHNhbnMtc2VyaWY7XG4gIGZvbnQtd2VpZ2h0OiA2MDA7XG4gIGZsZXg6IDE7XG4gIG1hcmdpbi1ib3R0b206IDA7IH1cblxuLmZkLXBhbmVsX19hY3Rpb25zIHtcbiAgbWFyZ2luLWxlZnQ6IGF1dG87IH1cblxuLmZkLXBhbmVsX19mb290ZXIge1xuICBkaXNwbGF5OiBmbGV4O1xuICBqdXN0aWZ5LWNvbnRlbnQ6IGNlbnRlcjsgfVxuXG4vKiFcbi5mZC1vdmVybGF5XG5cbiovXG4uZmQtb3ZlcmxheSB7XG4gIHBvc2l0aW9uOiBmaXhlZDtcbiAgZGlzcGxheTogZmxleDtcbiAgYWxpZ24taXRlbXM6IGNlbnRlcjtcbiAganVzdGlmeS1jb250ZW50OiBjZW50ZXI7XG4gIGhlaWdodDogMTAwdmg7XG4gIHdpZHRoOiAxMDB2dztcbiAgdG9wOiAwO1xuICBiYWNrZ3JvdW5kOiByZ2JhKDAsIDAsIDAsIDAuOCk7XG4gIHotaW5kZXg6IDEwMDA7XG4gIGNvbG9yOiAjZmZmZmZmOyB9XG4gIC5mZC1vdmVybGF5W2FyaWEtaGlkZGVuPVwidHJ1ZVwiXSB7XG4gICAgZGlzcGxheTogbm9uZTsgfVxuXG4vKiFcbi5mZC1hbGVydCsoLS13YXJuaW5nLiAtLWVycm9yKVxuICAgIC5mZC1hbGVydF9fY2xvc2VcbiovXG4uZmQtYWxlcnQge1xuICBjb2xvcjogI2ZmZmZmZjtcbiAgYm9yZGVyOiBzb2xpZCAxcHggI2Q3ZDdkNztcbiAgYmFja2dyb3VuZC1jb2xvcjogIzYzNzU4YjtcbiAgbWluLWhlaWdodDogNTJweDtcbiAgcGFkZGluZzogMTJweDsgfVxuICAuZmQtYWxlcnRfX2Nsb3NlIHtcbiAgICBtYXJnaW46IDA7XG4gICAgcGFkZGluZzogMDtcbiAgICBmb250LXNtb290aGluZzogYW50aWFsaWFzZWQ7XG4gICAgYXBwZWFyYW5jZTogbm9uZTtcbiAgICBvdXRsaW5lOiAwO1xuICAgIGJvcmRlcjogMDtcbiAgICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gICAgdGV4dC1kZWNvcmF0aW9uOiBub25lO1xuICAgIGN1cnNvcjogcG9pbnRlcjtcbiAgICB1c2VyLXNlbGVjdDogbm9uZTtcbiAgICB2ZXJ0aWNhbC1hbGlnbjogbWlkZGxlO1xuICAgIHdoaXRlLXNwYWNlOiBub3dyYXA7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogdHJhbnNwYXJlbnQ7XG4gICAgY29sb3I6ICNmZmZmZmY7XG4gICAgd2lkdGg6IDQwcHg7XG4gICAgaGVpZ2h0OiA0MHB4O1xuICAgIGZsb2F0OiByaWdodDtcbiAgICBtYXJnaW46IC02cHg7IH1cbiAgLmZkLWFsZXJ0LS13YXJuaW5nIHtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjZTk3MzI2O1xuICAgIGNvbG9yOiAjMjEyNjJjOyB9XG4gIC5mZC1hbGVydC0tZXJyb3Ige1xuICAgIGJhY2tncm91bmQtY29sb3I6ICNkZjE5MTk7IH1cblxuLyohXG4uZmQtYnV0dG9uKyggKC0tc21hbGwgfCAtLWxhcmdlKSwgLS1pY29uLCAtLXRleHQsIC0tbGluaywgLS1hY3Rpb24tYmFyKSsoICguaXMtZGlzYWJsZWQgfCBbYXJpYS1kaXNhYmxlZD10cnVlXSkgfCAoLmlzLXNlbGVjdGVkIHwgW2FyaWEtc2VsZWN0ZWQ9dHJ1ZV0gfCAoLmlzLXByZXNzZWQgfCBbYXJpYS1wcmVzc2VkPXRydWVdKSlcbiovXG4uZmQtYnV0dG9uLCAuZmQtbW9kYWxfX2J1dHRvbi1wcmltYXJ5LCAuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnkge1xuICBtYXJnaW46IDA7XG4gIHBhZGRpbmc6IDA7XG4gIGZvbnQtc21vb3RoaW5nOiBhbnRpYWxpYXNlZDtcbiAgYXBwZWFyYW5jZTogbm9uZTtcbiAgb3V0bGluZTogMDtcbiAgYm9yZGVyOiAwO1xuICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gIHRleHQtZGVjb3JhdGlvbjogbm9uZTtcbiAgY3Vyc29yOiBwb2ludGVyO1xuICB1c2VyLXNlbGVjdDogbm9uZTtcbiAgdmVydGljYWwtYWxpZ246IG1pZGRsZTtcbiAgd2hpdGUtc3BhY2U6IG5vd3JhcDtcbiAgYmFja2dyb3VuZC1jb2xvcjogdHJhbnNwYXJlbnQ7XG4gIGZvbnQtc2l6ZTogMS4xMjVyZW07XG4gIGxpbmUtaGVpZ2h0OiAxLjMzMzM0O1xuICBmb250LWZhbWlseTogUm9ib3RvLCBzYW5zLXNlcmlmO1xuICBmb250LXdlaWdodDogNTAwO1xuICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gIGJhY2tncm91bmQtY29sb3I6ICMwMDljZGY7XG4gIHRyYW5zaXRpb246IGJhY2tncm91bmQtY29sb3IgMC4xMjVzIGVhc2UtaW47XG4gIGNvbG9yOiAjZjZmOGY5O1xuICBtYXgtaGVpZ2h0OiA1MnB4O1xuICBoZWlnaHQ6IDUycHg7XG4gIGxpbmUtaGVpZ2h0OiA1MnB4O1xuICBwYWRkaW5nLWxlZnQ6IDIwcHg7XG4gIHBhZGRpbmctcmlnaHQ6IDIwcHg7XG4gIHRleHQtYWxpZ246IGNlbnRlcjtcbiAgdGV4dC10cmFuc2Zvcm06IHVwcGVyY2FzZTtcbiAgYm9yZGVyLXJhZGl1czogMDsgfVxuICAuZmQtYnV0dG9uLS1zbWFsbCB7XG4gICAgZm9udC1zaXplOiAxcmVtO1xuICAgIGxpbmUtaGVpZ2h0OiAxLjU7XG4gICAgZm9udC13ZWlnaHQ6IDQwMDtcbiAgICBmb250LXdlaWdodDogNjAwO1xuICAgIG1heC1oZWlnaHQ6IDQwcHg7XG4gICAgaGVpZ2h0OiA0MHB4O1xuICAgIGxpbmUtaGVpZ2h0OiA0MHB4O1xuICAgIHBhZGRpbmctbGVmdDogMTZweDtcbiAgICBwYWRkaW5nLXJpZ2h0OiAxNnB4OyB9XG4gIC5mZC1idXR0b24tLWxhcmdlLCAuZmQtYnV0dG9uLS1hY3Rpb24tYmFyIHtcbiAgICBmb250LXNpemU6IDEuMjVyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuNDtcbiAgICBmb250LXdlaWdodDogNjAwO1xuICAgIG1heC1oZWlnaHQ6IDc2cHg7XG4gICAgaGVpZ2h0OiA3NnB4O1xuICAgIGxpbmUtaGVpZ2h0OiA3NnB4O1xuICAgIHBhZGRpbmctbGVmdDogMjhweDtcbiAgICBwYWRkaW5nLXJpZ2h0OiAyOHB4OyB9XG4gIC5mZC1idXR0b246aG92ZXIsIC5mZC1tb2RhbF9fYnV0dG9uLXByaW1hcnk6aG92ZXIsIC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeTpob3ZlciB7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogIzAwOGFjNjtcbiAgICBjb2xvcjogI2Y2ZjhmOTtcbiAgICB0ZXh0LWRlY29yYXRpb246IG5vbmU7IH1cbiAgLmZkLWJ1dHRvbjpmb2N1cywgLmZkLW1vZGFsX19idXR0b24tcHJpbWFyeTpmb2N1cywgLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5OmZvY3VzIHtcbiAgICBjb2xvcjogI2Y2ZjhmOTtcbiAgICBib3gtc2hhZG93OiAwIDAgNHB4IDFweCAjOGE4ZmExO1xuICAgIG91dGxpbmU6IHNvbGlkIDJweCAjMmRjMGZmOyB9XG4gIC5mZC1idXR0b246YWN0aXZlLCAuZmQtbW9kYWxfX2J1dHRvbi1wcmltYXJ5OmFjdGl2ZSwgLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5OmFjdGl2ZSwgLmZkLWJ1dHRvbi5pcy1hY3RpdmUsIC5pcy1hY3RpdmUuZmQtbW9kYWxfX2J1dHRvbi1wcmltYXJ5LCAuaXMtYWN0aXZlLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uW2FyaWEtc2VsZWN0ZWQ9XCJ0cnVlXCJdLCBbYXJpYS1zZWxlY3RlZD1cInRydWVcIl0uZmQtbW9kYWxfX2J1dHRvbi1wcmltYXJ5LCBbYXJpYS1zZWxlY3RlZD1cInRydWVcIl0uZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b24uaXMtc2VsZWN0ZWQsIC5pcy1zZWxlY3RlZC5mZC1tb2RhbF9fYnV0dG9uLXByaW1hcnksIC5pcy1zZWxlY3RlZC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvblthcmlhLXByZXNzZWQ9XCJ0cnVlXCJdLCBbYXJpYS1wcmVzc2VkPVwidHJ1ZVwiXS5mZC1tb2RhbF9fYnV0dG9uLXByaW1hcnksIFthcmlhLXByZXNzZWQ9XCJ0cnVlXCJdLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uLmlzLXByZXNzZWQsIC5pcy1wcmVzc2VkLmZkLW1vZGFsX19idXR0b24tcHJpbWFyeSwgLmlzLXByZXNzZWQuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnkge1xuICAgIGJhY2tncm91bmQtY29sb3I6ICMwMDc4YWM7XG4gICAgY29sb3I6ICNmNmY4Zjk7IH1cbiAgLmZkLWJ1dHRvblthcmlhLWRpc2FibGVkPVwidHJ1ZVwiXSwgW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLmZkLW1vZGFsX19idXR0b24tcHJpbWFyeSwgW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uLmlzLWRpc2FibGVkLCAuaXMtZGlzYWJsZWQuZmQtbW9kYWxfX2J1dHRvbi1wcmltYXJ5LCAuaXMtZGlzYWJsZWQuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b246ZGlzYWJsZWQsIC5mZC1tb2RhbF9fYnV0dG9uLXByaW1hcnk6ZGlzYWJsZWQsIC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeTpkaXNhYmxlZCB7XG4gICAgb3V0bGluZTogc29saWQgMXB4ICNkN2Q3ZDc7XG4gICAgY29sb3I6ICM3ZjkwYTQ7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogI2Y5ZmJmYztcbiAgICBjdXJzb3I6IG5vdC1hbGxvd2VkOyB9XG4gIC5mZC1idXR0b24tLXRleHQsIC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvbi0tbGluayB7XG4gICAgY29sb3I6ICMwMDljZGY7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogdHJhbnNwYXJlbnQ7IH1cbiAgICAuZmQtYnV0dG9uLS10ZXh0OmhvdmVyLCAuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnk6aG92ZXIsIC5mZC1idXR0b24tLXRleHQ6Zm9jdXMsIC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeTpmb2N1cywgLmZkLWJ1dHRvbi0tbGluazpob3ZlciwgLmZkLWJ1dHRvbi0tbGluazpmb2N1cyB7XG4gICAgICBiYWNrZ3JvdW5kLWNvbG9yOiB0cmFuc3BhcmVudDtcbiAgICAgIGNvbG9yOiAjMDA4YWM2OyB9XG4gICAgLmZkLWJ1dHRvbi0tdGV4dDphY3RpdmUsIC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeTphY3RpdmUsIC5mZC1idXR0b24tLXRleHRbYXJpYS1zZWxlY3RlZD1cInRydWVcIl0sIFthcmlhLXNlbGVjdGVkPVwidHJ1ZVwiXS5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvbi0tdGV4dC5pcy1zZWxlY3RlZCwgLmlzLXNlbGVjdGVkLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uLS10ZXh0W2FyaWEtcHJlc3NlZD1cInRydWVcIl0sIFthcmlhLXByZXNzZWQ9XCJ0cnVlXCJdLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uLS10ZXh0LmlzLXByZXNzZWQsIC5pcy1wcmVzc2VkLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uLS10ZXh0W2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLCBbYXJpYS1kaXNhYmxlZD1cInRydWVcIl0uZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b24tLXRleHQuaXMtZGlzYWJsZWQsIC5pcy1kaXNhYmxlZC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvbi0tdGV4dDpkaXNhYmxlZCwgLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5OmRpc2FibGVkLCAuZmQtYnV0dG9uLS1saW5rOmFjdGl2ZSwgLmZkLWJ1dHRvbi0tbGlua1thcmlhLXNlbGVjdGVkPVwidHJ1ZVwiXSwgLmZkLWJ1dHRvbi0tbGluay5pcy1zZWxlY3RlZCwgLmZkLWJ1dHRvbi0tbGlua1thcmlhLXByZXNzZWQ9XCJ0cnVlXCJdLCAuZmQtYnV0dG9uLS1saW5rLmlzLXByZXNzZWQsIC5mZC1idXR0b24tLWxpbmtbYXJpYS1kaXNhYmxlZD1cInRydWVcIl0sIC5mZC1idXR0b24tLWxpbmsuaXMtZGlzYWJsZWQsIC5mZC1idXR0b24tLWxpbms6ZGlzYWJsZWQge1xuICAgICAgYmFja2dyb3VuZC1jb2xvcjogdHJhbnNwYXJlbnQ7XG4gICAgICBvdXRsaW5lOiBub25lO1xuICAgICAgYm94LXNoYWRvdzogbm9uZTsgfVxuICAgIC5mZC1idXR0b24tLXRleHQ6YWN0aXZlLCAuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnk6YWN0aXZlLCAuZmQtYnV0dG9uLS10ZXh0W2FyaWEtc2VsZWN0ZWQ9XCJ0cnVlXCJdLCBbYXJpYS1zZWxlY3RlZD1cInRydWVcIl0uZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b24tLXRleHQuaXMtc2VsZWN0ZWQsIC5pcy1zZWxlY3RlZC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvbi0tdGV4dFthcmlhLXByZXNzZWQ9XCJ0cnVlXCJdLCBbYXJpYS1wcmVzc2VkPVwidHJ1ZVwiXS5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvbi0tdGV4dC5pcy1wcmVzc2VkLCAuaXMtcHJlc3NlZC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvbi0tbGluazphY3RpdmUsIC5mZC1idXR0b24tLWxpbmtbYXJpYS1zZWxlY3RlZD1cInRydWVcIl0sIC5mZC1idXR0b24tLWxpbmsuaXMtc2VsZWN0ZWQsIC5mZC1idXR0b24tLWxpbmtbYXJpYS1wcmVzc2VkPVwidHJ1ZVwiXSwgLmZkLWJ1dHRvbi0tbGluay5pcy1wcmVzc2VkIHtcbiAgICAgIGNvbG9yOiAjMDA3OGFjOyB9XG4gICAgLmZkLWJ1dHRvbi0tdGV4dFthcmlhLWRpc2FibGVkPVwidHJ1ZVwiXSwgW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uLS10ZXh0LmlzLWRpc2FibGVkLCAuaXMtZGlzYWJsZWQuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b24tLXRleHQ6ZGlzYWJsZWQsIC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeTpkaXNhYmxlZCwgLmZkLWJ1dHRvbi0tbGlua1thcmlhLWRpc2FibGVkPVwidHJ1ZVwiXSwgLmZkLWJ1dHRvbi0tbGluay5pcy1kaXNhYmxlZCwgLmZkLWJ1dHRvbi0tbGluazpkaXNhYmxlZCB7XG4gICAgICBjb2xvcjogIzdmOTBhNDsgfVxuICAuZmQtYnV0dG9uLS1saW5rIHtcbiAgICBoZWlnaHQ6IDI4cHg7XG4gICAgbGluZS1oZWlnaHQ6IDI4cHg7XG4gICAgcGFkZGluZy1sZWZ0OiAxNnB4O1xuICAgIHBhZGRpbmctcmlnaHQ6IDE2cHg7XG4gICAgcG9zaXRpb246IHJlbGF0aXZlOyB9XG4gICAgLmZkLWJ1dHRvbi0tbGluay5mZC1idXR0b24tLXNtYWxsIHtcbiAgICAgIGhlaWdodDogMjRweDtcbiAgICAgIGxpbmUtaGVpZ2h0OiAyNHB4OyB9XG4gICAgLmZkLWJ1dHRvbi0tbGluazo6YWZ0ZXIge1xuICAgICAgY29udGVudDogXCJcIjtcbiAgICAgIGJvcmRlci1ib3R0b206IHNvbGlkIDJweCB0cmFuc3BhcmVudDtcbiAgICAgIHdpZHRoOiBjYWxjKDEwMCUgLSAxNnB4KjIpO1xuICAgICAgaGVpZ2h0OiAycHg7XG4gICAgICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gICAgICBib3R0b206IDFweDtcbiAgICAgIGxlZnQ6IDA7XG4gICAgICBtYXJnaW4tbGVmdDogMTZweDtcbiAgICAgIHRyYW5zaXRpb246IGJvcmRlci1ib3R0b20tY29sb3IgMC4xMjVzIGVhc2UtaW47IH1cbiAgICAuZmQtYnV0dG9uLS1saW5rOmZvY3VzIHtcbiAgICAgIG91dGxpbmU6IG5vbmU7XG4gICAgICBib3gtc2hhZG93OiBub25lOyB9XG4gICAgLmZkLWJ1dHRvbi0tbGluazpob3Zlcjo6YWZ0ZXIsIC5mZC1idXR0b24tLWxpbms6Zm9jdXM6OmFmdGVyLCAuZmQtYnV0dG9uLS1saW5rOmFjdGl2ZTo6YWZ0ZXIsIC5mZC1idXR0b24tLWxpbmtbYXJpYS1zZWxlY3RlZD1cInRydWVcIl06OmFmdGVyLCAuZmQtYnV0dG9uLS1saW5rLmlzLXNlbGVjdGVkOjphZnRlciwgLmZkLWJ1dHRvbi0tbGlua1thcmlhLXByZXNzZWQ9XCJ0cnVlXCJdOjphZnRlciwgLmZkLWJ1dHRvbi0tbGluay5pcy1wcmVzc2VkOjphZnRlciB7XG4gICAgICBib3JkZXItYm90dG9tLWNvbG9yOiAjMDA5Y2RmOyB9XG4gICAgLmZkLWJ1dHRvbi0tbGlua1thcmlhLWRpc2FibGVkPVwidHJ1ZVwiXTo6YWZ0ZXIsIC5mZC1idXR0b24tLWxpbmsuaXMtZGlzYWJsZWQ6OmFmdGVyLCAuZmQtYnV0dG9uLS1saW5rOmRpc2FibGVkOjphZnRlciB7XG4gICAgICBkaXNwbGF5OiBub25lOyB9XG4gIC5mZC1idXR0b24gPiAqLCAuZmQtbW9kYWxfX2J1dHRvbi1wcmltYXJ5ID4gKiwgLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5ID4gKiB7XG4gICAgZGlzcGxheTogaW5saW5lLWJsb2NrO1xuICAgIHZlcnRpY2FsLWFsaWduOiB0b3A7XG4gICAgbWFyZ2luLXJpZ2h0OiAxMnB4O1xuICAgIG1hcmdpbi10b3A6IDEzcHg7IH1cbiAgICAuZmQtYnV0dG9uLS1pY29uID4gKiB7XG4gICAgICBtYXJnaW4tbGVmdDogYXV0bztcbiAgICAgIG1hcmdpbi1yaWdodDogYXV0bzsgfVxuICAgIC5mZC1idXR0b24tLXNtYWxsID4gKiB7XG4gICAgICBtYXJnaW4tdG9wOiAxMXB4OyB9XG4gICAgLmZkLWJ1dHRvbi0tbGFyZ2UgPiAqLCAuZmQtYnV0dG9uLS1hY3Rpb24tYmFyID4gKiB7XG4gICAgICBtYXJnaW4tdG9wOiAyMnB4OyB9XG4gIC5mZC1idXR0b24tLWFjdGlvbi1iYXIge1xuICAgIGZvbnQtc2l6ZTogMC43NXJlbTtcbiAgICBsaW5lLWhlaWdodDogMS4zMzMzNDtcbiAgICBmb250LXdlaWdodDogNzAwO1xuICAgIHRleHQtdHJhbnNmb3JtOiB1cHBlcmNhc2U7XG4gICAgbWluLXdpZHRoOiAxMzVweDtcbiAgICBsaW5lLWhlaWdodDogMzJweDtcbiAgICB2ZXJ0aWNhbC1hbGlnbjogbWlkZGxlOyB9XG4gICAgLmZkLWJ1dHRvbi0tYWN0aW9uLWJhciA+ICoge1xuICAgICAgZGlzcGxheTogYmxvY2sgIWltcG9ydGFudDtcbiAgICAgIG1hcmdpbi10b3A6IDEycHg7XG4gICAgICBtYXJnaW4tbGVmdDogYXV0bztcbiAgICAgIG1hcmdpbi1yaWdodDogYXV0bzsgfVxuXG4vKiFcbi5mZC1kcm9wZG93bisoKVxuICAgIC5mZC1kcm9wZG93bl9fY29udHJvbCsoW2Rpc2FibGVkXSlcbiAgICAuZmQtZHJvcGRvd25fX21lbnUrKClcbiovXG4uZmQtZHJvcGRvd24ge1xuICBmb250LXNpemU6IDFyZW07XG4gIGxpbmUtaGVpZ2h0OiAxLjU7XG4gIGNvbG9yOiAjMjEyNjJjO1xuICBwb3NpdGlvbjogcmVsYXRpdmU7XG4gIGRpc3BsYXk6IGlubGluZS1ibG9jazsgfVxuICAuZmQtZHJvcGRvd25fX2NvbnRyb2wge1xuICAgIG1hcmdpbjogMDtcbiAgICBwYWRkaW5nOiAwO1xuICAgIGZvbnQtc21vb3RoaW5nOiBhbnRpYWxpYXNlZDtcbiAgICBhcHBlYXJhbmNlOiBub25lO1xuICAgIG91dGxpbmU6IDA7XG4gICAgYm9yZGVyOiAwO1xuICAgIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgICB0ZXh0LWRlY29yYXRpb246IG5vbmU7XG4gICAgY3Vyc29yOiBwb2ludGVyO1xuICAgIHVzZXItc2VsZWN0OiBub25lO1xuICAgIHZlcnRpY2FsLWFsaWduOiBtaWRkbGU7XG4gICAgd2hpdGUtc3BhY2U6IG5vd3JhcDtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiB0cmFuc3BhcmVudDtcbiAgICBmb250LXNpemU6IDFyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuNTtcbiAgICBjb2xvcjogIzIxMjYyYztcbiAgICBmb250LXNpemU6IDFyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuNTtcbiAgICBmb250LWZhbWlseTogJ09wZW4gU2FucycsIHNhbnMtc2VyaWY7XG4gICAgZm9udC13ZWlnaHQ6IDQwMDtcbiAgICBhcHBlYXJhbmNlOiBub25lO1xuICAgIC13ZWJraXQtYXBwZWFyYW5jZTogdGV4dGZpZWxkO1xuICAgIC1tb3otYXBwZWFyYW5jZTogdGV4dGZpZWxkO1xuICAgIGZvbnQtc2l6ZTogaW5oZXJpdDtcbiAgICBib3gtc2l6aW5nOiBib3JkZXItYm94O1xuICAgIG91dGxpbmU6IG5vbmU7XG4gICAgYm9yZGVyLXN0eWxlOiBzb2xpZDtcbiAgICBib3JkZXItd2lkdGg6IDFweDtcbiAgICBib3JkZXItY29sb3I6ICNjY2RhZWI7XG4gICAgYm9yZGVyLXJhZGl1czogMDtcbiAgICBjb2xvcjogIzIxMjYyYztcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiB0cmFuc3BhcmVudDtcbiAgICB0cmFuc2l0aW9uOiBib3JkZXItY29sb3IgMC4xMjVzO1xuICAgIGhlaWdodDogNTJweDtcbiAgICBwYWRkaW5nLWxlZnQ6IDE2cHg7XG4gICAgcGFkZGluZy1yaWdodDogMTZweDtcbiAgICBhcHBlYXJhbmNlOiBub25lO1xuICAgIC1tb3otYXBwZWFyYW5jZTogbm9uZTtcbiAgICBiYWNrZ3JvdW5kLWltYWdlOiB1cmwoZGF0YTppbWFnZS9zdmcreG1sO2Jhc2U2NCxQSE4yWnlCNGJXeHVjejBpYUhSMGNEb3ZMM2QzZHk1M015NXZjbWN2TWpBd01DOXpkbWNpSUhkcFpIUm9QU0l4TWlJZ2FHVnBaMmgwUFNJNUlqNDhjR0YwYUNCbWFXeHNMWEoxYkdVOUltVjJaVzV2WkdRaUlHWnBiR3c5SWlNeU1USTJNa01pSUdROUlrMHhNUzQ1TXpVZ01TNDBOelZNTmk0eE9EZ2dOeTQ1TWpkaExqSTJOQzR5TmpRZ01DQXdJREV0TGpNM09DQXdUQzR3TmpVZ01TNDBOelZoTGpJek5pNHlNellnTUNBd0lERWdMakF5TmkwdU16UXpUREV1TXpneExqQTFPR0V1TWpVekxqSTFNeUF3SURBZ01TQXVNVFl6TFM0d05UbE1NUzQxTmpNZ01HRXVNalV5TGpJMU1pQXdJREFnTVNBdU1UY3hMakE0Tld3MExqSTJOU0EwTGpnNElEUXVNalkzTFRRdU9EaGhMakkxTWk0eU5USWdNQ0F3SURFZ0xqTTFNaTB1TURJM2JERXVNamt4SURFdU1EYzBZeTR3TlM0d05ESXVNRGd4TGpFd01pNHdPRFl1TVRZMllTNHlNell1TWpNMklEQWdNQ0F4TFM0d05pNHhOemQ2SWk4K1BDOXpkbWMrKTtcbiAgICBiYWNrZ3JvdW5kLXJlcGVhdDogbm8tcmVwZWF0O1xuICAgIGJhY2tncm91bmQtcG9zaXRpb246IGNhbGMoMTAwJSAtIDEycHgpIGNlbnRlcjtcbiAgICBwYWRkaW5nLXJpZ2h0OiA0NHB4O1xuICAgIHBvc2l0aW9uOiByZWxhdGl2ZTtcbiAgICBsaW5lLWhlaWdodDogNTJweDsgfVxuICAgIC5mZC1kcm9wZG93bl9fY29udHJvbDpmb2N1cywgLmZkLWRyb3Bkb3duX19jb250cm9sOmhvdmVyIHtcbiAgICAgIGJvcmRlci1jb2xvcjogIzAwOWNkZjsgfVxuICAgIC5mZC1kcm9wZG93bl9fY29udHJvbC5pcy1pbnZhbGlkIHtcbiAgICAgIGJvcmRlci1jb2xvcjogI2RmMTkxOTsgfVxuICAgIC5mZC1kcm9wZG93bl9fY29udHJvbC5pcy12YWxpZCB7XG4gICAgICBib3JkZXItY29sb3I6ICM2MWJmMzM7IH1cbiAgICAuZmQtZHJvcGRvd25fX2NvbnRyb2wuaXMtd2FybmluZyB7XG4gICAgICBib3JkZXItY29sb3I6ICNlOTczMjY7IH1cbiAgICAuZmQtZHJvcGRvd25fX2NvbnRyb2w6ZGlzYWJsZWQsIC5mZC1kcm9wZG93bl9fY29udHJvbFthcmlhLWRpc2FibGVkPVwidHJ1ZVwiXSwgLmZkLWRyb3Bkb3duX19jb250cm9sLmlzLWRpc2FibGVkIHtcbiAgICAgIGN1cnNvcjogbm90LWFsbG93ZWQ7XG4gICAgICBjb2xvcjogIzYzNzU4YjtcbiAgICAgIGJvcmRlci1jb2xvcjogI2U0ZTRlNDtcbiAgICAgIGJhY2tncm91bmQtY29sb3I6ICNmOWZiZmM7IH1cbiAgICAuZmQtZHJvcGRvd25fX2NvbnRyb2xbcmVhZG9ubHldLCAuZmQtZHJvcGRvd25fX2NvbnRyb2wuaXMtcmVhZG9ubHkge1xuICAgICAgY29sb3I6ICMyMTI2MmM7XG4gICAgICBib3JkZXItY29sb3I6ICNlNGU0ZTQ7XG4gICAgICBib3JkZXItd2lkdGg6IDAgMCAxcHg7IH1cbiAgICAuZmQtZHJvcGRvd25fX2NvbnRyb2w6Zm9jdXMsIC5mZC1kcm9wZG93bl9fY29udHJvbDpob3ZlciB7XG4gICAgICBiYWNrZ3JvdW5kLWltYWdlOiB1cmwoZGF0YTppbWFnZS9zdmcreG1sO2Jhc2U2NCxQSE4yWnlCNGJXeHVjejBpYUhSMGNEb3ZMM2QzZHk1M015NXZjbWN2TWpBd01DOXpkbWNpSUhkcFpIUm9QU0l4TWlJZ2FHVnBaMmgwUFNJNUlqNDhjR0YwYUNCbWFXeHNMWEoxYkdVOUltVjJaVzV2WkdRaUlHWnBiR3c5SWlNd01EaEdSRElpSUdROUlrMHhNUzQ1TXpVZ01TNDBOelZNTmk0eE9EZ2dOeTQ1TWpkaExqSTJOQzR5TmpRZ01DQXdJREV0TGpNM09DQXdUQzR3TmpVZ01TNDBOelZoTGpJek5pNHlNellnTUNBd0lERWdMakF5TmkwdU16UXpUREV1TXpneExqQTFPR0V1TWpVekxqSTFNeUF3SURBZ01TQXVNVFl6TFM0d05UbE1NUzQxTmpNZ01HRXVNalV5TGpJMU1pQXdJREFnTVNBdU1UY3hMakE0Tld3MExqSTJOU0EwTGpnNElEUXVNalkzTFRRdU9EaGhMakkxTWk0eU5USWdNQ0F3SURFZ0xqTTFNaTB1TURJM2JERXVNamt4SURFdU1EYzBZeTR3TlM0d05ESXVNRGd4TGpFd01pNHdPRFl1TVRZMllTNHlNell1TWpNMklEQWdNQ0F4TFM0d05pNHhOemQ2SWk4K1BDOXpkbWMrKTsgfVxuICAgIC5mZC1kcm9wZG93bl9fY29udHJvbFthcmlhLWV4cGFuZGVkPVwidHJ1ZVwiXSwgLmZkLWRyb3Bkb3duX19jb250cm9sLmlzLWV4cGFuZGVkIHtcbiAgICAgIGJhY2tncm91bmQtaW1hZ2U6IHVybChkYXRhOmltYWdlL3N2Zyt4bWw7YmFzZTY0LFBITjJaeUI0Yld4dWN6MGlhSFIwY0RvdkwzZDNkeTUzTXk1dmNtY3ZNakF3TUM5emRtY2lJSGRwWkhSb1BTSXhNaUlnYUdWcFoyaDBQU0k0SWo0OGNHRjBhQ0JtYVd4c0xYSjFiR1U5SW1WMlpXNXZaR1FpSUdacGJHdzlJaU13TURoR1JESWlJR1E5SWsweE1TNDVNelVnTmk0MU0wdzJMakU0T0M0eE1EUmhMakkyTkM0eU5qUWdNQ0F3SURBdExqTTNPQ0F3VEM0d05qVWdOaTQxTTJFdU1qUXVNalFnTUNBd0lEQXRMakEyTVM0eE56Y3VNak0zTGpJek55QXdJREFnTUNBdU1EZzNMakUyTld3eExqSTVJREV1TURjeFlTNHlOVGd1TWpVNElEQWdNQ0F3SUM0eE5qTXVNRFU0VERFdU5UWXpJRGhoTGpJMU1pNHlOVElnTUNBd0lEQWdMakUzTVMwdU1EZzFiRFF1TWpZMUxUUXVPRFl4SURRdU1qWTNJRFF1T0RZeFl5NHdORE11TURRNUxqRXdOQzR3T0M0eE55NHdPRFZoTGpJMk1TNHlOakVnTUNBd0lEQWdMakU0TWkwdU1EVTNiREV1TWpreExURXVNRGN4WVM0eU16WXVNak0ySURBZ01DQXdJQzR3TWpZdExqTTBNbm9pTHo0OEwzTjJaejQ9KTsgfVxuICAgIC5mZC1kcm9wZG93bl9fY29udHJvbFtkaXNhYmxlZF0sIC5mZC1kcm9wZG93bl9fY29udHJvbFthcmlhLWRpc2FibGVkPVwidHJ1ZVwiXSwgLmZkLWRyb3Bkb3duX19jb250cm9sLmlzLWRpc2FibGVkIHtcbiAgICAgIGJhY2tncm91bmQtaW1hZ2U6IHVybChkYXRhOmltYWdlL3N2Zyt4bWw7YmFzZTY0LFBITjJaeUI0Yld4dWN6MGlhSFIwY0RvdkwzZDNkeTUzTXk1dmNtY3ZNakF3TUM5emRtY2lJSGRwWkhSb1BTSXhNaUlnYUdWcFoyaDBQU0k1SWo0OGNHRjBhQ0JtYVd4c0xYSjFiR1U5SW1WMlpXNXZaR1FpSUdacGJHdzlJaU0yTXpjMU9FSWlJR1E5SWsweE1TNDVNelVnTVM0ME56Vk1OaTR4T0RnZ055NDVNamRoTGpJMk5DNHlOalFnTUNBd0lERXRMak0zT0NBd1RDNHdOalVnTVM0ME56VmhMakl6TlM0eU16VWdNQ0F3SURFZ0xqQXlOaTB1TXpRelRERXVNemd4TGpBMU9HRXVNalV6TGpJMU15QXdJREFnTVNBdU1UWXpMUzR3TlRsTU1TNDFOak1nTUdFdU1qVXlMakkxTWlBd0lEQWdNU0F1TVRjeExqQTROV3cwTGpJMk5TQTBMamc0SURRdU1qWTNMVFF1T0RoaExqSTFNaTR5TlRJZ01DQXdJREVnTGpNMU1pMHVNREkzYkRFdU1qa3hJREV1TURjMFl5NHdOUzR3TkRJdU1EZ3hMakV3TWk0d09EWXVNVFkyWVM0eU16UXVNak0wSURBZ01DQXhMUzR3Tmk0eE56ZDZJaTgrUEM5emRtYyspOyB9XG4gICAgLmZkLWRyb3Bkb3duX19jb250cm9sW2FyaWEtZXhwYW5kZWQ9XCJ0cnVlXCJdLCAuZmQtZHJvcGRvd25fX2NvbnRyb2wuaXMtZXhwYW5kZWQge1xuICAgICAgYm9yZGVyLWNvbG9yOiAjMDA5Y2RmO1xuICAgICAgei1pbmRleDogMztcbiAgICAgIGJveC1zaGFkb3c6IDAgMCA0cHggMXB4IHJnYmEoMTM4LCAxNDMsIDE2MSwgMC4yKTsgfVxuICAgIC5mZC1kcm9wZG93bl9fY29udHJvbC0tbm8tYm9yZGVyIHtcbiAgICAgIGJvcmRlci1jb2xvcjogdHJhbnNwYXJlbnQ7IH1cbiAgICAgIC5mZC1kcm9wZG93bl9fY29udHJvbC0tbm8tYm9yZGVyW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLCAuZmQtZHJvcGRvd25fX2NvbnRyb2wtLW5vLWJvcmRlci5pcy1kaXNhYmxlZCwgLmZkLWRyb3Bkb3duX19jb250cm9sLS1uby1ib3JkZXI6ZGlzYWJsZWQge1xuICAgICAgICBib3JkZXItY29sb3I6IHRyYW5zcGFyZW50OyB9XG4gIC5mZC1kcm9wZG93bl9faWNvbiB7XG4gICAgbWFyZ2luLXJpZ2h0OiAxMnB4O1xuICAgIHZlcnRpY2FsLWFsaWduOiBtaWRkbGU7XG4gICAgdHJhbnNmb3JtOiB0cmFuc2xhdGVZKC0ycHgpOyB9XG4gIC5mZC1kcm9wZG93bl9fbWVudSwgLmZkLWRyb3Bkb3duX19vcHRpb25zIHtcbiAgICBtYXJnaW4tbGVmdDogMDtcbiAgICBwYWRkaW5nLWxlZnQ6IDA7XG4gICAgbGlzdC1zdHlsZTogbm9uZTtcbiAgICBtaW4td2lkdGg6IDEwMCU7XG4gICAgYm9yZGVyOiBzb2xpZCAxcHggI2NjZGFlYjtcbiAgICBiYWNrZ3JvdW5kOiAjZmZmZmZmO1xuICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICB3aGl0ZS1zcGFjZTogbm93cmFwO1xuICAgIHotaW5kZXg6IDI7XG4gICAgdHJhbnNmb3JtOiB0cmFuc2xhdGVZKC0xcHgpO1xuICAgIGJveC1zaGFkb3c6IDAgMCA0cHggMXB4IHJnYmEoMTM4LCAxNDMsIDE2MSwgMC4yKTtcbiAgICBvcGFjaXR5OiAxO1xuICAgIHZpc2liaWxpdHk6IHZpc2libGU7XG4gICAgdHJhbnNpdGlvbjogb3BhY2l0eSAwLjEyNXMgZWFzZS1pbjsgfVxuICAgIC5mZC1kcm9wZG93bl9fbWVudVthcmlhLWhpZGRlbj1cInRydWVcIl0sIC5mZC1kcm9wZG93bl9fbWVudS5pcy1oaWRkZW4sIC5mZC1kcm9wZG93bl9fb3B0aW9uc1thcmlhLWhpZGRlbj1cInRydWVcIl0sIC5mZC1kcm9wZG93bl9fb3B0aW9ucy5pcy1oaWRkZW4ge1xuICAgICAgb3BhY2l0eTogMDtcbiAgICAgIHZpc2liaWxpdHk6IGhpZGRlbjsgfVxuICAuZmQtZHJvcGRvd25fX2dyb3VwIHtcbiAgICBtYXJnaW4tbGVmdDogMDtcbiAgICBwYWRkaW5nLWxlZnQ6IDA7XG4gICAgbGlzdC1zdHlsZTogbm9uZTsgfVxuICAuZmQtZHJvcGRvd25fX2l0ZW0sIC5mZC1kcm9wZG93bl9fb3B0aW9uIHtcbiAgICBmb250LXNpemU6IDFyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuNTtcbiAgICBjb2xvcjogIzIxMjYyYztcbiAgICBmb250LXNpemU6IDAuODc1cmVtO1xuICAgIGxpbmUtaGVpZ2h0OiAxLjQyODU4O1xuICAgIGZvbnQtZmFtaWx5OiAnT3BlbiBTYW5zJywgc2Fucy1zZXJpZjtcbiAgICBmb250LXdlaWdodDogNDAwO1xuICAgIGRpc3BsYXk6IGJsb2NrO1xuICAgIHBhZGRpbmctbGVmdDogMDtcbiAgICBsaXN0LXN0eWxlOiBub25lO1xuICAgIHBhZGRpbmc6IDEycHggMTZweDsgfVxuICAgIC5mZC1kcm9wZG93bl9faXRlbTpob3ZlciwgLmZkLWRyb3Bkb3duX19vcHRpb246aG92ZXIge1xuICAgICAgY29sb3I6ICNmZmZmZmY7XG4gICAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjMDA4YWM2O1xuICAgICAgdGV4dC1kZWNvcmF0aW9uOiBub25lOyB9XG4gIC5mZC1kcm9wZG93bl9fc2VwYXJhdG9yIHtcbiAgICBmb250LXNpemU6IDFyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuNTtcbiAgICBjb2xvcjogIzIxMjYyYztcbiAgICBmb250LXNpemU6IDAuNzVyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuMzMzMzQ7XG4gICAgZm9udC1mYW1pbHk6ICdPcGVuIFNhbnMnLCBzYW5zLXNlcmlmO1xuICAgIGZvbnQtd2VpZ2h0OiA0MDA7XG4gICAgdGV4dC10cmFuc2Zvcm06IG5vbmU7XG4gICAgZGlzcGxheTogYmxvY2s7XG4gICAgY29sb3I6ICM3ZjkwYTQ7XG4gICAgcGFkZGluZzogMTJweCAxNnB4O1xuICAgIHBhZGRpbmctdG9wOiAxNnB4O1xuICAgIGJvcmRlci10b3A6IHNvbGlkIDFweCAjY2NkYWViOyB9XG5cbi8qIVxuLmZkLWNvbnRleHR1YWwtbWVudVxuKi9cbi5mZC1jb250ZXh0dWFsLW1lbnUge1xuICBtaW4td2lkdGg6IDE2OXB4O1xuICByaWdodDogMDsgfVxuXG4vKiFcbi5mZC1hY3Rpb24tYmFyXG5cdC5mZC1hY3Rpb24tYmFyX19uYXZpZ2F0aW9uXG5cdC5mZC1hY3Rpb24tYmFyX190aXRsZVxuXHQuZmQtYWN0aW9uLWJhcl9fYWN0aW9ucysoLmlzLWRpc2FibGVkIHwgYXJpYS1oaWRkZW4pP1xuICAgICAgICAuZmQtYWN0aW9uLWJhcl9fYWN0aW9uLWl0ZW1cbiovXG4uZmQtYWN0aW9uLWJhciB7XG4gIGZvbnQtc2l6ZTogMXJlbTtcbiAgbGluZS1oZWlnaHQ6IDEuNTtcbiAgY29sb3I6ICMyMTI2MmM7XG4gIGhlaWdodDogNzZweDtcbiAgYmFja2dyb3VuZC1jb2xvcjogI2YwZjVmZjtcbiAgYm9yZGVyLXN0eWxlOiBzb2xpZDtcbiAgYm9yZGVyLXdpZHRoOiAxcHggMDtcbiAgYm9yZGVyLWNvbG9yOiAjY2NkYWViO1xuICBkaXNwbGF5OiBmbGV4O1xuICBhbGlnbi1pdGVtczogY2VudGVyOyB9XG4gIC5mZC1hY3Rpb24tYmFyX190aXRsZSB7XG4gICAgZm9udC1zaXplOiAxcmVtO1xuICAgIGxpbmUtaGVpZ2h0OiAxLjU7XG4gICAgY29sb3I6ICMyMTI2MmM7XG4gICAgZm9udC1zaXplOiAxLjYyNXJlbTtcbiAgICBsaW5lLWhlaWdodDogMS4yMzA3NztcbiAgICBmb250LWZhbWlseTogUm9ib3RvLCBzYW5zLXNlcmlmO1xuICAgIGZvbnQtd2VpZ2h0OiA1MDA7XG4gICAgZmxleDogMTtcbiAgICBtYXJnaW4tYm90dG9tOiAwOyB9XG4gICAgLmZkLWFjdGlvbi1iYXJfX3RpdGxlOmZpcnN0LWNoaWxkIHtcbiAgICAgIHBhZGRpbmctbGVmdDogMjRweDsgfVxuICAuZmQtYWN0aW9uLWJhcl9fYWN0aW9ucyB7XG4gICAgZm9udC1zaXplOiAxcmVtO1xuICAgIGxpbmUtaGVpZ2h0OiAxLjU7XG4gICAgY29sb3I6ICMyMTI2MmM7XG4gICAgZGlzcGxheTogZmxleDtcbiAgICB0cmFuc2l0aW9uOiBvcGFjaXR5IDAuMjVzIGVhc2UtaW47XG4gICAgdmlzaWJpbGl0eTogdmlzaWJsZTsgfVxuICAgIC5mZC1hY3Rpb24tYmFyX19hY3Rpb25zLmlzLWRpc2FibGVkLCAuZmQtYWN0aW9uLWJhcl9fYWN0aW9uc1thcmlhLWhpZGRlbj1cInRydWVcIl0ge1xuICAgICAgb3BhY2l0eTogMDtcbiAgICAgIHZpc2liaWxpdHk6IGhpZGRlbjsgfVxuXG4vKiFcbi5mZC1iYWRnZSsoKCAtLXN1Y2Nlc3MgfCAtLXdhcm5pbmcgfCAtLWVycm9yICksIC0tcGlsbClcbiovXG4uZmQtYmFkZ2Uge1xuICBmb250LXNpemU6IDFyZW07XG4gIGxpbmUtaGVpZ2h0OiAxLjU7XG4gIGNvbG9yOiAjMjEyNjJjO1xuICBmb250LXNpemU6IDAuNzVyZW07XG4gIGxpbmUtaGVpZ2h0OiAxLjMzMzM0O1xuICBmb250LXdlaWdodDogNzAwO1xuICB0ZXh0LXRyYW5zZm9ybTogdXBwZXJjYXNlO1xuICBsaW5lLWhlaWdodDogMjBweDtcbiAgYm9yZGVyLXJhZGl1czogNXB4O1xuICBib3JkZXItd2lkdGg6IDFweDtcbiAgYm9yZGVyLXN0eWxlOiBzb2xpZDtcbiAgcGFkZGluZzogNHB4IDhweDtcbiAgdmVydGljYWwtYWxpZ246IG1pZGRsZTsgfVxuICAuZmQtYmFkZ2UtLXBpbGwge1xuICAgIGJvcmRlci1yYWRpdXM6IDEyLjVweDsgfVxuICAuZmQtYmFkZ2UtLXN1Y2Nlc3Mge1xuICAgIGNvbG9yOiAjNjFiZjMzOyB9XG4gIC5mZC1iYWRnZS0td2FybmluZyB7XG4gICAgY29sb3I6ICNlOTczMjY7IH1cbiAgLmZkLWJhZGdlLS1lcnJvciB7XG4gICAgY29sb3I6ICNkZjE5MTk7IH1cblxuLyohXG4uZmQtYnV0dG9uKyggKC0tc21hbGwgfCAtLWxhcmdlKSwgLS1pY29uLCAtLXRleHQsIC0tbGluaywgLS1hY3Rpb24tYmFyKSsoICguaXMtZGlzYWJsZWQgfCBbYXJpYS1kaXNhYmxlZD10cnVlXSkgfCAoLmlzLXNlbGVjdGVkIHwgW2FyaWEtc2VsZWN0ZWQ9dHJ1ZV0gfCAoLmlzLXByZXNzZWQgfCBbYXJpYS1wcmVzc2VkPXRydWVdKSlcbiovXG4uZmQtYnV0dG9uLCAuZmQtbW9kYWxfX2J1dHRvbi1wcmltYXJ5LCAuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnkge1xuICBtYXJnaW46IDA7XG4gIHBhZGRpbmc6IDA7XG4gIGZvbnQtc21vb3RoaW5nOiBhbnRpYWxpYXNlZDtcbiAgYXBwZWFyYW5jZTogbm9uZTtcbiAgb3V0bGluZTogMDtcbiAgYm9yZGVyOiAwO1xuICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gIHRleHQtZGVjb3JhdGlvbjogbm9uZTtcbiAgY3Vyc29yOiBwb2ludGVyO1xuICB1c2VyLXNlbGVjdDogbm9uZTtcbiAgdmVydGljYWwtYWxpZ246IG1pZGRsZTtcbiAgd2hpdGUtc3BhY2U6IG5vd3JhcDtcbiAgYmFja2dyb3VuZC1jb2xvcjogdHJhbnNwYXJlbnQ7XG4gIGZvbnQtc2l6ZTogMS4xMjVyZW07XG4gIGxpbmUtaGVpZ2h0OiAxLjMzMzM0O1xuICBmb250LWZhbWlseTogUm9ib3RvLCBzYW5zLXNlcmlmO1xuICBmb250LXdlaWdodDogNTAwO1xuICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gIGJhY2tncm91bmQtY29sb3I6ICMwMDljZGY7XG4gIHRyYW5zaXRpb246IGJhY2tncm91bmQtY29sb3IgMC4xMjVzIGVhc2UtaW47XG4gIGNvbG9yOiAjZjZmOGY5O1xuICBtYXgtaGVpZ2h0OiA1MnB4O1xuICBoZWlnaHQ6IDUycHg7XG4gIGxpbmUtaGVpZ2h0OiA1MnB4O1xuICBwYWRkaW5nLWxlZnQ6IDIwcHg7XG4gIHBhZGRpbmctcmlnaHQ6IDIwcHg7XG4gIHRleHQtYWxpZ246IGNlbnRlcjtcbiAgdGV4dC10cmFuc2Zvcm06IHVwcGVyY2FzZTtcbiAgYm9yZGVyLXJhZGl1czogMDsgfVxuICAuZmQtYnV0dG9uLS1zbWFsbCB7XG4gICAgZm9udC1zaXplOiAxcmVtO1xuICAgIGxpbmUtaGVpZ2h0OiAxLjU7XG4gICAgZm9udC13ZWlnaHQ6IDQwMDtcbiAgICBmb250LXdlaWdodDogNjAwO1xuICAgIG1heC1oZWlnaHQ6IDQwcHg7XG4gICAgaGVpZ2h0OiA0MHB4O1xuICAgIGxpbmUtaGVpZ2h0OiA0MHB4O1xuICAgIHBhZGRpbmctbGVmdDogMTZweDtcbiAgICBwYWRkaW5nLXJpZ2h0OiAxNnB4OyB9XG4gIC5mZC1idXR0b24tLWxhcmdlLCAuZmQtYnV0dG9uLS1hY3Rpb24tYmFyIHtcbiAgICBmb250LXNpemU6IDEuMjVyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuNDtcbiAgICBmb250LXdlaWdodDogNjAwO1xuICAgIG1heC1oZWlnaHQ6IDc2cHg7XG4gICAgaGVpZ2h0OiA3NnB4O1xuICAgIGxpbmUtaGVpZ2h0OiA3NnB4O1xuICAgIHBhZGRpbmctbGVmdDogMjhweDtcbiAgICBwYWRkaW5nLXJpZ2h0OiAyOHB4OyB9XG4gIC5mZC1idXR0b246aG92ZXIsIC5mZC1tb2RhbF9fYnV0dG9uLXByaW1hcnk6aG92ZXIsIC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeTpob3ZlciB7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogIzAwOGFjNjtcbiAgICBjb2xvcjogI2Y2ZjhmOTtcbiAgICB0ZXh0LWRlY29yYXRpb246IG5vbmU7IH1cbiAgLmZkLWJ1dHRvbjpmb2N1cywgLmZkLW1vZGFsX19idXR0b24tcHJpbWFyeTpmb2N1cywgLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5OmZvY3VzIHtcbiAgICBjb2xvcjogI2Y2ZjhmOTtcbiAgICBib3gtc2hhZG93OiAwIDAgNHB4IDFweCAjOGE4ZmExO1xuICAgIG91dGxpbmU6IHNvbGlkIDJweCAjMmRjMGZmOyB9XG4gIC5mZC1idXR0b246YWN0aXZlLCAuZmQtbW9kYWxfX2J1dHRvbi1wcmltYXJ5OmFjdGl2ZSwgLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5OmFjdGl2ZSwgLmZkLWJ1dHRvbi5pcy1hY3RpdmUsIC5pcy1hY3RpdmUuZmQtbW9kYWxfX2J1dHRvbi1wcmltYXJ5LCAuaXMtYWN0aXZlLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uW2FyaWEtc2VsZWN0ZWQ9XCJ0cnVlXCJdLCBbYXJpYS1zZWxlY3RlZD1cInRydWVcIl0uZmQtbW9kYWxfX2J1dHRvbi1wcmltYXJ5LCBbYXJpYS1zZWxlY3RlZD1cInRydWVcIl0uZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b24uaXMtc2VsZWN0ZWQsIC5pcy1zZWxlY3RlZC5mZC1tb2RhbF9fYnV0dG9uLXByaW1hcnksIC5pcy1zZWxlY3RlZC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvblthcmlhLXByZXNzZWQ9XCJ0cnVlXCJdLCBbYXJpYS1wcmVzc2VkPVwidHJ1ZVwiXS5mZC1tb2RhbF9fYnV0dG9uLXByaW1hcnksIFthcmlhLXByZXNzZWQ9XCJ0cnVlXCJdLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uLmlzLXByZXNzZWQsIC5pcy1wcmVzc2VkLmZkLW1vZGFsX19idXR0b24tcHJpbWFyeSwgLmlzLXByZXNzZWQuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnkge1xuICAgIGJhY2tncm91bmQtY29sb3I6ICMwMDc4YWM7XG4gICAgY29sb3I6ICNmNmY4Zjk7IH1cbiAgLmZkLWJ1dHRvblthcmlhLWRpc2FibGVkPVwidHJ1ZVwiXSwgW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLmZkLW1vZGFsX19idXR0b24tcHJpbWFyeSwgW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uLmlzLWRpc2FibGVkLCAuaXMtZGlzYWJsZWQuZmQtbW9kYWxfX2J1dHRvbi1wcmltYXJ5LCAuaXMtZGlzYWJsZWQuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b246ZGlzYWJsZWQsIC5mZC1tb2RhbF9fYnV0dG9uLXByaW1hcnk6ZGlzYWJsZWQsIC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeTpkaXNhYmxlZCB7XG4gICAgb3V0bGluZTogc29saWQgMXB4ICNkN2Q3ZDc7XG4gICAgY29sb3I6ICM3ZjkwYTQ7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogI2Y5ZmJmYztcbiAgICBjdXJzb3I6IG5vdC1hbGxvd2VkOyB9XG4gIC5mZC1idXR0b24tLXRleHQsIC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvbi0tbGluayB7XG4gICAgY29sb3I6ICMwMDljZGY7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogdHJhbnNwYXJlbnQ7IH1cbiAgICAuZmQtYnV0dG9uLS10ZXh0OmhvdmVyLCAuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnk6aG92ZXIsIC5mZC1idXR0b24tLXRleHQ6Zm9jdXMsIC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeTpmb2N1cywgLmZkLWJ1dHRvbi0tbGluazpob3ZlciwgLmZkLWJ1dHRvbi0tbGluazpmb2N1cyB7XG4gICAgICBiYWNrZ3JvdW5kLWNvbG9yOiB0cmFuc3BhcmVudDtcbiAgICAgIGNvbG9yOiAjMDA4YWM2OyB9XG4gICAgLmZkLWJ1dHRvbi0tdGV4dDphY3RpdmUsIC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeTphY3RpdmUsIC5mZC1idXR0b24tLXRleHRbYXJpYS1zZWxlY3RlZD1cInRydWVcIl0sIFthcmlhLXNlbGVjdGVkPVwidHJ1ZVwiXS5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvbi0tdGV4dC5pcy1zZWxlY3RlZCwgLmlzLXNlbGVjdGVkLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uLS10ZXh0W2FyaWEtcHJlc3NlZD1cInRydWVcIl0sIFthcmlhLXByZXNzZWQ9XCJ0cnVlXCJdLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uLS10ZXh0LmlzLXByZXNzZWQsIC5pcy1wcmVzc2VkLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uLS10ZXh0W2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLCBbYXJpYS1kaXNhYmxlZD1cInRydWVcIl0uZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b24tLXRleHQuaXMtZGlzYWJsZWQsIC5pcy1kaXNhYmxlZC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvbi0tdGV4dDpkaXNhYmxlZCwgLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5OmRpc2FibGVkLCAuZmQtYnV0dG9uLS1saW5rOmFjdGl2ZSwgLmZkLWJ1dHRvbi0tbGlua1thcmlhLXNlbGVjdGVkPVwidHJ1ZVwiXSwgLmZkLWJ1dHRvbi0tbGluay5pcy1zZWxlY3RlZCwgLmZkLWJ1dHRvbi0tbGlua1thcmlhLXByZXNzZWQ9XCJ0cnVlXCJdLCAuZmQtYnV0dG9uLS1saW5rLmlzLXByZXNzZWQsIC5mZC1idXR0b24tLWxpbmtbYXJpYS1kaXNhYmxlZD1cInRydWVcIl0sIC5mZC1idXR0b24tLWxpbmsuaXMtZGlzYWJsZWQsIC5mZC1idXR0b24tLWxpbms6ZGlzYWJsZWQge1xuICAgICAgYmFja2dyb3VuZC1jb2xvcjogdHJhbnNwYXJlbnQ7XG4gICAgICBvdXRsaW5lOiBub25lO1xuICAgICAgYm94LXNoYWRvdzogbm9uZTsgfVxuICAgIC5mZC1idXR0b24tLXRleHQ6YWN0aXZlLCAuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnk6YWN0aXZlLCAuZmQtYnV0dG9uLS10ZXh0W2FyaWEtc2VsZWN0ZWQ9XCJ0cnVlXCJdLCBbYXJpYS1zZWxlY3RlZD1cInRydWVcIl0uZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b24tLXRleHQuaXMtc2VsZWN0ZWQsIC5pcy1zZWxlY3RlZC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvbi0tdGV4dFthcmlhLXByZXNzZWQ9XCJ0cnVlXCJdLCBbYXJpYS1wcmVzc2VkPVwidHJ1ZVwiXS5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvbi0tdGV4dC5pcy1wcmVzc2VkLCAuaXMtcHJlc3NlZC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvbi0tbGluazphY3RpdmUsIC5mZC1idXR0b24tLWxpbmtbYXJpYS1zZWxlY3RlZD1cInRydWVcIl0sIC5mZC1idXR0b24tLWxpbmsuaXMtc2VsZWN0ZWQsIC5mZC1idXR0b24tLWxpbmtbYXJpYS1wcmVzc2VkPVwidHJ1ZVwiXSwgLmZkLWJ1dHRvbi0tbGluay5pcy1wcmVzc2VkIHtcbiAgICAgIGNvbG9yOiAjMDA3OGFjOyB9XG4gICAgLmZkLWJ1dHRvbi0tdGV4dFthcmlhLWRpc2FibGVkPVwidHJ1ZVwiXSwgW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uLS10ZXh0LmlzLWRpc2FibGVkLCAuaXMtZGlzYWJsZWQuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b24tLXRleHQ6ZGlzYWJsZWQsIC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeTpkaXNhYmxlZCwgLmZkLWJ1dHRvbi0tbGlua1thcmlhLWRpc2FibGVkPVwidHJ1ZVwiXSwgLmZkLWJ1dHRvbi0tbGluay5pcy1kaXNhYmxlZCwgLmZkLWJ1dHRvbi0tbGluazpkaXNhYmxlZCB7XG4gICAgICBjb2xvcjogIzdmOTBhNDsgfVxuICAuZmQtYnV0dG9uLS1saW5rIHtcbiAgICBoZWlnaHQ6IDI4cHg7XG4gICAgbGluZS1oZWlnaHQ6IDI4cHg7XG4gICAgcGFkZGluZy1sZWZ0OiAxNnB4O1xuICAgIHBhZGRpbmctcmlnaHQ6IDE2cHg7XG4gICAgcG9zaXRpb246IHJlbGF0aXZlOyB9XG4gICAgLmZkLWJ1dHRvbi0tbGluay5mZC1idXR0b24tLXNtYWxsIHtcbiAgICAgIGhlaWdodDogMjRweDtcbiAgICAgIGxpbmUtaGVpZ2h0OiAyNHB4OyB9XG4gICAgLmZkLWJ1dHRvbi0tbGluazo6YWZ0ZXIge1xuICAgICAgY29udGVudDogXCJcIjtcbiAgICAgIGJvcmRlci1ib3R0b206IHNvbGlkIDJweCB0cmFuc3BhcmVudDtcbiAgICAgIHdpZHRoOiBjYWxjKDEwMCUgLSAxNnB4KjIpO1xuICAgICAgaGVpZ2h0OiAycHg7XG4gICAgICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gICAgICBib3R0b206IDFweDtcbiAgICAgIGxlZnQ6IDA7XG4gICAgICBtYXJnaW4tbGVmdDogMTZweDtcbiAgICAgIHRyYW5zaXRpb246IGJvcmRlci1ib3R0b20tY29sb3IgMC4xMjVzIGVhc2UtaW47IH1cbiAgICAuZmQtYnV0dG9uLS1saW5rOmZvY3VzIHtcbiAgICAgIG91dGxpbmU6IG5vbmU7XG4gICAgICBib3gtc2hhZG93OiBub25lOyB9XG4gICAgLmZkLWJ1dHRvbi0tbGluazpob3Zlcjo6YWZ0ZXIsIC5mZC1idXR0b24tLWxpbms6Zm9jdXM6OmFmdGVyLCAuZmQtYnV0dG9uLS1saW5rOmFjdGl2ZTo6YWZ0ZXIsIC5mZC1idXR0b24tLWxpbmtbYXJpYS1zZWxlY3RlZD1cInRydWVcIl06OmFmdGVyLCAuZmQtYnV0dG9uLS1saW5rLmlzLXNlbGVjdGVkOjphZnRlciwgLmZkLWJ1dHRvbi0tbGlua1thcmlhLXByZXNzZWQ9XCJ0cnVlXCJdOjphZnRlciwgLmZkLWJ1dHRvbi0tbGluay5pcy1wcmVzc2VkOjphZnRlciB7XG4gICAgICBib3JkZXItYm90dG9tLWNvbG9yOiAjMDA5Y2RmOyB9XG4gICAgLmZkLWJ1dHRvbi0tbGlua1thcmlhLWRpc2FibGVkPVwidHJ1ZVwiXTo6YWZ0ZXIsIC5mZC1idXR0b24tLWxpbmsuaXMtZGlzYWJsZWQ6OmFmdGVyLCAuZmQtYnV0dG9uLS1saW5rOmRpc2FibGVkOjphZnRlciB7XG4gICAgICBkaXNwbGF5OiBub25lOyB9XG4gIC5mZC1idXR0b24gPiAqLCAuZmQtbW9kYWxfX2J1dHRvbi1wcmltYXJ5ID4gKiwgLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5ID4gKiB7XG4gICAgZGlzcGxheTogaW5saW5lLWJsb2NrO1xuICAgIHZlcnRpY2FsLWFsaWduOiB0b3A7XG4gICAgbWFyZ2luLXJpZ2h0OiAxMnB4O1xuICAgIG1hcmdpbi10b3A6IDEzcHg7IH1cbiAgICAuZmQtYnV0dG9uLS1pY29uID4gKiB7XG4gICAgICBtYXJnaW4tbGVmdDogYXV0bztcbiAgICAgIG1hcmdpbi1yaWdodDogYXV0bzsgfVxuICAgIC5mZC1idXR0b24tLXNtYWxsID4gKiB7XG4gICAgICBtYXJnaW4tdG9wOiAxMXB4OyB9XG4gICAgLmZkLWJ1dHRvbi0tbGFyZ2UgPiAqLCAuZmQtYnV0dG9uLS1hY3Rpb24tYmFyID4gKiB7XG4gICAgICBtYXJnaW4tdG9wOiAyMnB4OyB9XG4gIC5mZC1idXR0b24tLWFjdGlvbi1iYXIge1xuICAgIGZvbnQtc2l6ZTogMC43NXJlbTtcbiAgICBsaW5lLWhlaWdodDogMS4zMzMzNDtcbiAgICBmb250LXdlaWdodDogNzAwO1xuICAgIHRleHQtdHJhbnNmb3JtOiB1cHBlcmNhc2U7XG4gICAgbWluLXdpZHRoOiAxMzVweDtcbiAgICBsaW5lLWhlaWdodDogMzJweDtcbiAgICB2ZXJ0aWNhbC1hbGlnbjogbWlkZGxlOyB9XG4gICAgLmZkLWJ1dHRvbi0tYWN0aW9uLWJhciA+ICoge1xuICAgICAgZGlzcGxheTogYmxvY2sgIWltcG9ydGFudDtcbiAgICAgIG1hcmdpbi10b3A6IDEycHg7XG4gICAgICBtYXJnaW4tbGVmdDogYXV0bztcbiAgICAgIG1hcmdpbi1yaWdodDogYXV0bzsgfVxuXG4vKiFcbiAgICBjYXJkIHN0cnVjdHVyZVxuICAgIC5mZC1jYXJkKygtLWJ1dHRvbiwtLXZlcnRpY2FsKSsoLmlzLWRpc2FibGVkfFthcmlhLWRpc2FibGVkPXRydWVdKVxuICAgICAgICAuZmQtY2FyZF9fbWVkaWErKC0tcm91bmQsLS1maWxsKVxuICAgICAgICAuZmQtY2FyZF9fY29udGVudFxuICAgICAgICAgICAgLmZkLWNhcmRfX2hlYWRlciwgLmZkLWNhcmRfX2Rlc2NyaXB0aW9uLCAuZmQtY2FyZF9fc3RhdHVzXG4gICAgICAgIC5mZC1jYXJkX19hY3Rpb25zXG4qL1xuLmZkLWNhcmQge1xuICBmb250LXNpemU6IDFyZW07XG4gIGxpbmUtaGVpZ2h0OiAxLjU7XG4gIGNvbG9yOiAjMjEyNjJjO1xuICBkaXNwbGF5OiBmbGV4O1xuICBtYXJnaW4tYm90dG9tOiAyMHB4O1xuICBib3JkZXItc3R5bGU6IHNvbGlkO1xuICBib3JkZXItd2lkdGg6IDFweDtcbiAgYm9yZGVyLWNvbG9yOiAjY2NkYWViO1xuICBiYWNrZ3JvdW5kLWNvbG9yOiAjZmZmZmZmOyB9XG4gIC5mZC1jYXJkLS12ZXJ0aWNhbCB7XG4gICAgZGlzcGxheTogYmxvY2s7IH1cbiAgICAuZmQtY2FyZC0tdmVydGljYWwgLmZkLWNhcmRfX21lZGlhIHtcbiAgICAgIHdpZHRoOiAxMDAlO1xuICAgICAgaGVpZ2h0OiAzNzBweDtcbiAgICAgIG1hcmdpbjogMDsgfVxuICAuZmQtY2FyZC0tYnV0dG9uLCAuZmQtY2FyZFtyb2xlPVwiYnV0dG9uXCJdIHtcbiAgICBjdXJzb3I6IGRlZmF1bHQ7IH1cbiAgICAuZmQtY2FyZC0tYnV0dG9uIC5mZC1jYXJkX19oZWFkZXIsIC5mZC1jYXJkW3JvbGU9XCJidXR0b25cIl0gLmZkLWNhcmRfX2hlYWRlciB7XG4gICAgICBjb2xvcjogIzAwOWNkZjsgfVxuICAuZmQtY2FyZC0tY29tcGFjdCAuZmQtY2FyZF9fbWVkaWEge1xuICAgIG1hcmdpbjogMTBweCAwIDEwcHggMTBweDsgfVxuICAgIC5mZC1jYXJkLS1jb21wYWN0IC5mZC1jYXJkX19tZWRpYS0tZmlsbCB7XG4gICAgICBtYXJnaW46IDA7XG4gICAgICB3aWR0aDogMTA1cHg7IH1cbiAgLmZkLWNhcmQtLWNvbXBhY3QgLmZkLWNhcmRfX2NvbnRlbnQge1xuICAgIHBhZGRpbmc6IDEwcHggMTBweDsgfVxuICAuZmQtY2FyZC0tY29tcGFjdC5mZC1jYXJkLS12ZXJ0aWNhbCAuZmQtY2FyZF9fbWVkaWEge1xuICAgIG1hcmdpbjogMDsgfVxuICAuZmQtY2FyZC0tYnV0dG9uLCAuZmQtY2FyZFtyb2xlPVwiYnV0dG9uXCJdIHtcbiAgICBjdXJzb3I6IHBvaW50ZXI7XG4gICAgdHJhbnNpdGlvbjogYmFja2dyb3VuZC1jb2xvciAwLjEyNXMgZWFzZS1pbiwgYm9yZGVyLWNvbG9yIDAuMTI1cyBlYXNlLWluLCBib3gtc2hhZG93IDAuMTI1cyBlYXNlLWluOyB9XG4gICAgLmZkLWNhcmQtLWJ1dHRvbjpob3ZlciwgLmZkLWNhcmRbcm9sZT1cImJ1dHRvblwiXTpob3ZlciB7XG4gICAgICBib3JkZXItY29sb3I6ICMwMDljZGY7XG4gICAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjZmZmZmZmO1xuICAgICAgYm94LXNoYWRvdzogMCAwIDVweCAwIHJnYmEoMTM4LCAxNDMsIDE2MSwgMC40KTtcbiAgICAgIHRleHQtZGVjb3JhdGlvbjogbm9uZTtcbiAgICAgIGNvbG9yOiBpbmhlcml0OyB9XG4gIC5mZC1jYXJkW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLCAuZmQtY2FyZC5pcy1kaXNhYmxlZCB7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogI2Y5ZmJmYyAhaW1wb3J0YW50O1xuICAgIGJvcmRlci1jb2xvcjogI2U0ZTRlNCAhaW1wb3J0YW50O1xuICAgIGJveC1zaGFkb3c6IG5vbmUgIWltcG9ydGFudDtcbiAgICBjdXJzb3I6IGRlZmF1bHQ7IH1cbiAgICAuZmQtY2FyZFthcmlhLWRpc2FibGVkPVwidHJ1ZVwiXSAqLCAuZmQtY2FyZC5pcy1kaXNhYmxlZCAqIHtcbiAgICAgIGNvbG9yOiAjNjM3NThiICFpbXBvcnRhbnQ7IH1cbiAgLmZkLWNhcmRfX21lZGlhIHtcbiAgICBiYWNrZ3JvdW5kLXJlcGVhdDogbm8tcmVwZWF0O1xuICAgIGJhY2tncm91bmQtcG9zaXRpb246IGNlbnRlciBjZW50ZXI7XG4gICAgYmFja2dyb3VuZC1zaXplOiBjb3ZlcjtcbiAgICBtaW4td2lkdGg6IDc1cHg7XG4gICAgbWluLWhlaWdodDogNzVweDtcbiAgICBtYXJnaW46IDIwcHggMCAyMHB4IDIwcHg7IH1cbiAgICAuZmQtY2FyZF9fbWVkaWEtLWZpbGwge1xuICAgICAgbWFyZ2luOiAwO1xuICAgICAgd2lkdGg6IDEzNXB4O1xuICAgICAgYmFja2dyb3VuZC1zaXplOiBjb3ZlcjsgfVxuICAgICAgLmZkLWNhcmRfX21lZGlhLS1maWxsICsgLmZkLWNhcmRfX2NvbnRlbnQge1xuICAgICAgICBwYWRkaW5nLWxlZnQ6IDEwcHg7IH1cbiAgICAuZmQtY2FyZF9fbWVkaWEtLXJvdW5kIHtcbiAgICAgIGJvcmRlci1yYWRpdXM6IDUwJTsgfVxuICAuZmQtY2FyZF9fY29udGVudCB7XG4gICAgcGFkZGluZzogMjBweCAyMHB4O1xuICAgIG1heC13aWR0aDogMTAwJTtcbiAgICBmbGV4OiAxO1xuICAgIG92ZXJmbG93OiBoaWRkZW47IH1cbiAgLmZkLWNhcmRfX2hlYWRlciB7XG4gICAgY29sb3I6ICMyMTI2MmM7XG4gICAgZm9udC1zaXplOiAxLjEyNXJlbTtcbiAgICBsaW5lLWhlaWdodDogMS4zMzMzNDtcbiAgICBmb250LXdlaWdodDogNjAwO1xuICAgIG1hcmdpbi1ib3R0b206IDFweDsgfVxuICAuZmQtY2FyZF9fZGVzY3JpcHRpb24ge1xuICAgIGZvbnQtc2l6ZTogMC44MTI1cmVtO1xuICAgIGxpbmUtaGVpZ2h0OiAxLjUzODQ3O1xuICAgIGZvbnQtd2VpZ2h0OiA0MDA7XG4gICAgbWFyZ2luLWJvdHRvbTogMTJweDtcbiAgICBvdmVyZmxvdzogaGlkZGVuO1xuICAgIHRleHQtb3ZlcmZsb3c6IGVsbGlwc2lzOyB9XG4gIC5mZC1jYXJkX19zdGF0dXMge1xuICAgIGZvbnQtc2l6ZTogMC43NXJlbTtcbiAgICBsaW5lLWhlaWdodDogMS4zMzMzNDtcbiAgICBmb250LXdlaWdodDogNzAwO1xuICAgIHRleHQtdHJhbnNmb3JtOiB1cHBlcmNhc2U7IH1cbiAgLmZkLWNhcmRfX2FjdGlvbnMge1xuICAgIHBhZGRpbmc6IDIwcHggMTBweDsgfVxuICAuZmQtY2FyZCBhIHtcbiAgICBjb2xvcjogIzAwOWNkZjsgfVxuICAgIC5mZC1jYXJkIGE6aG92ZXIge1xuICAgICAgY29sb3I6ICMwMDljZGY7IH1cblxuLyohXG4uZmQtY2FyZC1ncm91cCsoLS0yY29sIHwgLS00Y29sKVxuKi9cbi5mZC1jYXJkLWdyb3VwIHtcbiAgZm9udC1zaXplOiAxcmVtO1xuICBsaW5lLWhlaWdodDogMS41O1xuICBjb2xvcjogIzIxMjYyYztcbiAgZGlzcGxheTogZmxleDtcbiAgZmxleC13cmFwOiB3cmFwO1xuICBmbGV4LWRpcmVjdGlvbjogY29sdW1uOyB9XG4gIC5mZC1jYXJkLWdyb3VwOjphZnRlciB7XG4gICAgY29udGVudDogXCJcIjtcbiAgICBkaXNwbGF5OiB0YWJsZTtcbiAgICBjbGVhcjogYm90aDsgfVxuICAuZmQtY2FyZC1ncm91cDpsYXN0LWNoaWxkIHtcbiAgICBtYXJnaW4tYm90dG9tOiAtMjBweDsgfVxuICBAbWVkaWEgKG1pbi13aWR0aDogODAwcHgpIHtcbiAgICAuZmQtY2FyZC1ncm91cCB7XG4gICAgICBmbGV4LWRpcmVjdGlvbjogcm93OyB9XG4gICAgICAuZmQtY2FyZC1ncm91cCA+ICoge1xuICAgICAgICBmbGV4OiAxO1xuICAgICAgICBtYXJnaW4tcmlnaHQ6IDIwcHg7XG4gICAgICAgIG1pbi13aWR0aDogY2FsYygoMTAwJSAtIDIwcHgqMikgLyAzKTtcbiAgICAgICAgbWF4LXdpZHRoOiBjYWxjKCgxMDAlIC0gMjBweCoyKSAvIDMpOyB9XG4gICAgICAgIC5mZC1jYXJkLWdyb3VwID4gKjpudGgtY2hpbGQoM24pIHtcbiAgICAgICAgICBtYXJnaW4tcmlnaHQ6IDA7IH1cbiAgICAgIC5mZC1jYXJkLWdyb3VwLS0yY29sID4gKiB7XG4gICAgICAgIG1pbi13aWR0aDogY2FsYygoMTAwJSAtIDIwcHgqMSkgLyAyKTtcbiAgICAgICAgbWF4LXdpZHRoOiBjYWxjKCgxMDAlIC0gMjBweCoxKSAvIDIpOyB9XG4gICAgICAgIC5mZC1jYXJkLWdyb3VwLS0yY29sID4gKjpudGgtY2hpbGQoM24rMykge1xuICAgICAgICAgIG1hcmdpbi1yaWdodDogMjBweDsgfVxuICAgICAgICAuZmQtY2FyZC1ncm91cC0tMmNvbCA+ICo6bnRoLWNoaWxkKDJuKzIpIHtcbiAgICAgICAgICBtYXJnaW4tcmlnaHQ6IDA7IH1cbiAgICAgIC5mZC1jYXJkLWdyb3VwLS00Y29sID4gKiB7XG4gICAgICAgIG1pbi13aWR0aDogY2FsYygoMTAwJSAtIDIwcHgqMykgLyA0KTtcbiAgICAgICAgbWF4LXdpZHRoOiBjYWxjKCgxMDAlIC0gMjBweCozKSAvIDQpOyB9XG4gICAgICAgIC5mZC1jYXJkLWdyb3VwLS00Y29sID4gKjpudGgtY2hpbGQoM24rMykge1xuICAgICAgICAgIG1hcmdpbi1yaWdodDogMjBweDsgfVxuICAgICAgICAuZmQtY2FyZC1ncm91cC0tNGNvbCA+ICo6bnRoLWNoaWxkKDRuKzQpIHtcbiAgICAgICAgICBtYXJnaW4tcmlnaHQ6IDA7IH0gfVxuXG4vKiFcbi5mZC1kcm9wZG93bisoKVxuICAgIC5mZC1kcm9wZG93bl9fY29udHJvbCsoW2Rpc2FibGVkXSlcbiAgICAuZmQtZHJvcGRvd25fX21lbnUrKClcbiovXG4uZmQtZHJvcGRvd24ge1xuICBmb250LXNpemU6IDFyZW07XG4gIGxpbmUtaGVpZ2h0OiAxLjU7XG4gIGNvbG9yOiAjMjEyNjJjO1xuICBwb3NpdGlvbjogcmVsYXRpdmU7XG4gIGRpc3BsYXk6IGlubGluZS1ibG9jazsgfVxuICAuZmQtZHJvcGRvd25fX2NvbnRyb2wge1xuICAgIG1hcmdpbjogMDtcbiAgICBwYWRkaW5nOiAwO1xuICAgIGZvbnQtc21vb3RoaW5nOiBhbnRpYWxpYXNlZDtcbiAgICBhcHBlYXJhbmNlOiBub25lO1xuICAgIG91dGxpbmU6IDA7XG4gICAgYm9yZGVyOiAwO1xuICAgIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgICB0ZXh0LWRlY29yYXRpb246IG5vbmU7XG4gICAgY3Vyc29yOiBwb2ludGVyO1xuICAgIHVzZXItc2VsZWN0OiBub25lO1xuICAgIHZlcnRpY2FsLWFsaWduOiBtaWRkbGU7XG4gICAgd2hpdGUtc3BhY2U6IG5vd3JhcDtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiB0cmFuc3BhcmVudDtcbiAgICBmb250LXNpemU6IDFyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuNTtcbiAgICBjb2xvcjogIzIxMjYyYztcbiAgICBmb250LXNpemU6IDFyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuNTtcbiAgICBmb250LWZhbWlseTogJ09wZW4gU2FucycsIHNhbnMtc2VyaWY7XG4gICAgZm9udC13ZWlnaHQ6IDQwMDtcbiAgICBhcHBlYXJhbmNlOiBub25lO1xuICAgIC13ZWJraXQtYXBwZWFyYW5jZTogdGV4dGZpZWxkO1xuICAgIC1tb3otYXBwZWFyYW5jZTogdGV4dGZpZWxkO1xuICAgIGZvbnQtc2l6ZTogaW5oZXJpdDtcbiAgICBib3gtc2l6aW5nOiBib3JkZXItYm94O1xuICAgIG91dGxpbmU6IG5vbmU7XG4gICAgYm9yZGVyLXN0eWxlOiBzb2xpZDtcbiAgICBib3JkZXItd2lkdGg6IDFweDtcbiAgICBib3JkZXItY29sb3I6ICNjY2RhZWI7XG4gICAgYm9yZGVyLXJhZGl1czogMDtcbiAgICBjb2xvcjogIzIxMjYyYztcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiB0cmFuc3BhcmVudDtcbiAgICB0cmFuc2l0aW9uOiBib3JkZXItY29sb3IgMC4xMjVzO1xuICAgIGhlaWdodDogNTJweDtcbiAgICBwYWRkaW5nLWxlZnQ6IDE2cHg7XG4gICAgcGFkZGluZy1yaWdodDogMTZweDtcbiAgICBhcHBlYXJhbmNlOiBub25lO1xuICAgIC1tb3otYXBwZWFyYW5jZTogbm9uZTtcbiAgICBiYWNrZ3JvdW5kLWltYWdlOiB1cmwoZGF0YTppbWFnZS9zdmcreG1sO2Jhc2U2NCxQSE4yWnlCNGJXeHVjejBpYUhSMGNEb3ZMM2QzZHk1M015NXZjbWN2TWpBd01DOXpkbWNpSUhkcFpIUm9QU0l4TWlJZ2FHVnBaMmgwUFNJNUlqNDhjR0YwYUNCbWFXeHNMWEoxYkdVOUltVjJaVzV2WkdRaUlHWnBiR3c5SWlNeU1USTJNa01pSUdROUlrMHhNUzQ1TXpVZ01TNDBOelZNTmk0eE9EZ2dOeTQ1TWpkaExqSTJOQzR5TmpRZ01DQXdJREV0TGpNM09DQXdUQzR3TmpVZ01TNDBOelZoTGpJek5pNHlNellnTUNBd0lERWdMakF5TmkwdU16UXpUREV1TXpneExqQTFPR0V1TWpVekxqSTFNeUF3SURBZ01TQXVNVFl6TFM0d05UbE1NUzQxTmpNZ01HRXVNalV5TGpJMU1pQXdJREFnTVNBdU1UY3hMakE0Tld3MExqSTJOU0EwTGpnNElEUXVNalkzTFRRdU9EaGhMakkxTWk0eU5USWdNQ0F3SURFZ0xqTTFNaTB1TURJM2JERXVNamt4SURFdU1EYzBZeTR3TlM0d05ESXVNRGd4TGpFd01pNHdPRFl1TVRZMllTNHlNell1TWpNMklEQWdNQ0F4TFM0d05pNHhOemQ2SWk4K1BDOXpkbWMrKTtcbiAgICBiYWNrZ3JvdW5kLXJlcGVhdDogbm8tcmVwZWF0O1xuICAgIGJhY2tncm91bmQtcG9zaXRpb246IGNhbGMoMTAwJSAtIDEycHgpIGNlbnRlcjtcbiAgICBwYWRkaW5nLXJpZ2h0OiA0NHB4O1xuICAgIHBvc2l0aW9uOiByZWxhdGl2ZTtcbiAgICBsaW5lLWhlaWdodDogNTJweDsgfVxuICAgIC5mZC1kcm9wZG93bl9fY29udHJvbDpmb2N1cywgLmZkLWRyb3Bkb3duX19jb250cm9sOmhvdmVyIHtcbiAgICAgIGJvcmRlci1jb2xvcjogIzAwOWNkZjsgfVxuICAgIC5mZC1kcm9wZG93bl9fY29udHJvbC5pcy1pbnZhbGlkIHtcbiAgICAgIGJvcmRlci1jb2xvcjogI2RmMTkxOTsgfVxuICAgIC5mZC1kcm9wZG93bl9fY29udHJvbC5pcy12YWxpZCB7XG4gICAgICBib3JkZXItY29sb3I6ICM2MWJmMzM7IH1cbiAgICAuZmQtZHJvcGRvd25fX2NvbnRyb2wuaXMtd2FybmluZyB7XG4gICAgICBib3JkZXItY29sb3I6ICNlOTczMjY7IH1cbiAgICAuZmQtZHJvcGRvd25fX2NvbnRyb2w6ZGlzYWJsZWQsIC5mZC1kcm9wZG93bl9fY29udHJvbFthcmlhLWRpc2FibGVkPVwidHJ1ZVwiXSwgLmZkLWRyb3Bkb3duX19jb250cm9sLmlzLWRpc2FibGVkIHtcbiAgICAgIGN1cnNvcjogbm90LWFsbG93ZWQ7XG4gICAgICBjb2xvcjogIzYzNzU4YjtcbiAgICAgIGJvcmRlci1jb2xvcjogI2U0ZTRlNDtcbiAgICAgIGJhY2tncm91bmQtY29sb3I6ICNmOWZiZmM7IH1cbiAgICAuZmQtZHJvcGRvd25fX2NvbnRyb2xbcmVhZG9ubHldLCAuZmQtZHJvcGRvd25fX2NvbnRyb2wuaXMtcmVhZG9ubHkge1xuICAgICAgY29sb3I6ICMyMTI2MmM7XG4gICAgICBib3JkZXItY29sb3I6ICNlNGU0ZTQ7XG4gICAgICBib3JkZXItd2lkdGg6IDAgMCAxcHg7IH1cbiAgICAuZmQtZHJvcGRvd25fX2NvbnRyb2w6Zm9jdXMsIC5mZC1kcm9wZG93bl9fY29udHJvbDpob3ZlciB7XG4gICAgICBiYWNrZ3JvdW5kLWltYWdlOiB1cmwoZGF0YTppbWFnZS9zdmcreG1sO2Jhc2U2NCxQSE4yWnlCNGJXeHVjejBpYUhSMGNEb3ZMM2QzZHk1M015NXZjbWN2TWpBd01DOXpkbWNpSUhkcFpIUm9QU0l4TWlJZ2FHVnBaMmgwUFNJNUlqNDhjR0YwYUNCbWFXeHNMWEoxYkdVOUltVjJaVzV2WkdRaUlHWnBiR3c5SWlNd01EaEdSRElpSUdROUlrMHhNUzQ1TXpVZ01TNDBOelZNTmk0eE9EZ2dOeTQ1TWpkaExqSTJOQzR5TmpRZ01DQXdJREV0TGpNM09DQXdUQzR3TmpVZ01TNDBOelZoTGpJek5pNHlNellnTUNBd0lERWdMakF5TmkwdU16UXpUREV1TXpneExqQTFPR0V1TWpVekxqSTFNeUF3SURBZ01TQXVNVFl6TFM0d05UbE1NUzQxTmpNZ01HRXVNalV5TGpJMU1pQXdJREFnTVNBdU1UY3hMakE0Tld3MExqSTJOU0EwTGpnNElEUXVNalkzTFRRdU9EaGhMakkxTWk0eU5USWdNQ0F3SURFZ0xqTTFNaTB1TURJM2JERXVNamt4SURFdU1EYzBZeTR3TlM0d05ESXVNRGd4TGpFd01pNHdPRFl1TVRZMllTNHlNell1TWpNMklEQWdNQ0F4TFM0d05pNHhOemQ2SWk4K1BDOXpkbWMrKTsgfVxuICAgIC5mZC1kcm9wZG93bl9fY29udHJvbFthcmlhLWV4cGFuZGVkPVwidHJ1ZVwiXSwgLmZkLWRyb3Bkb3duX19jb250cm9sLmlzLWV4cGFuZGVkIHtcbiAgICAgIGJhY2tncm91bmQtaW1hZ2U6IHVybChkYXRhOmltYWdlL3N2Zyt4bWw7YmFzZTY0LFBITjJaeUI0Yld4dWN6MGlhSFIwY0RvdkwzZDNkeTUzTXk1dmNtY3ZNakF3TUM5emRtY2lJSGRwWkhSb1BTSXhNaUlnYUdWcFoyaDBQU0k0SWo0OGNHRjBhQ0JtYVd4c0xYSjFiR1U5SW1WMlpXNXZaR1FpSUdacGJHdzlJaU13TURoR1JESWlJR1E5SWsweE1TNDVNelVnTmk0MU0wdzJMakU0T0M0eE1EUmhMakkyTkM0eU5qUWdNQ0F3SURBdExqTTNPQ0F3VEM0d05qVWdOaTQxTTJFdU1qUXVNalFnTUNBd0lEQXRMakEyTVM0eE56Y3VNak0zTGpJek55QXdJREFnTUNBdU1EZzNMakUyTld3eExqSTVJREV1TURjeFlTNHlOVGd1TWpVNElEQWdNQ0F3SUM0eE5qTXVNRFU0VERFdU5UWXpJRGhoTGpJMU1pNHlOVElnTUNBd0lEQWdMakUzTVMwdU1EZzFiRFF1TWpZMUxUUXVPRFl4SURRdU1qWTNJRFF1T0RZeFl5NHdORE11TURRNUxqRXdOQzR3T0M0eE55NHdPRFZoTGpJMk1TNHlOakVnTUNBd0lEQWdMakU0TWkwdU1EVTNiREV1TWpreExURXVNRGN4WVM0eU16WXVNak0ySURBZ01DQXdJQzR3TWpZdExqTTBNbm9pTHo0OEwzTjJaejQ9KTsgfVxuICAgIC5mZC1kcm9wZG93bl9fY29udHJvbFtkaXNhYmxlZF0sIC5mZC1kcm9wZG93bl9fY29udHJvbFthcmlhLWRpc2FibGVkPVwidHJ1ZVwiXSwgLmZkLWRyb3Bkb3duX19jb250cm9sLmlzLWRpc2FibGVkIHtcbiAgICAgIGJhY2tncm91bmQtaW1hZ2U6IHVybChkYXRhOmltYWdlL3N2Zyt4bWw7YmFzZTY0LFBITjJaeUI0Yld4dWN6MGlhSFIwY0RvdkwzZDNkeTUzTXk1dmNtY3ZNakF3TUM5emRtY2lJSGRwWkhSb1BTSXhNaUlnYUdWcFoyaDBQU0k1SWo0OGNHRjBhQ0JtYVd4c0xYSjFiR1U5SW1WMlpXNXZaR1FpSUdacGJHdzlJaU0yTXpjMU9FSWlJR1E5SWsweE1TNDVNelVnTVM0ME56Vk1OaTR4T0RnZ055NDVNamRoTGpJMk5DNHlOalFnTUNBd0lERXRMak0zT0NBd1RDNHdOalVnTVM0ME56VmhMakl6TlM0eU16VWdNQ0F3SURFZ0xqQXlOaTB1TXpRelRERXVNemd4TGpBMU9HRXVNalV6TGpJMU15QXdJREFnTVNBdU1UWXpMUzR3TlRsTU1TNDFOak1nTUdFdU1qVXlMakkxTWlBd0lEQWdNU0F1TVRjeExqQTROV3cwTGpJMk5TQTBMamc0SURRdU1qWTNMVFF1T0RoaExqSTFNaTR5TlRJZ01DQXdJREVnTGpNMU1pMHVNREkzYkRFdU1qa3hJREV1TURjMFl5NHdOUzR3TkRJdU1EZ3hMakV3TWk0d09EWXVNVFkyWVM0eU16UXVNak0wSURBZ01DQXhMUzR3Tmk0eE56ZDZJaTgrUEM5emRtYyspOyB9XG4gICAgLmZkLWRyb3Bkb3duX19jb250cm9sW2FyaWEtZXhwYW5kZWQ9XCJ0cnVlXCJdLCAuZmQtZHJvcGRvd25fX2NvbnRyb2wuaXMtZXhwYW5kZWQge1xuICAgICAgYm9yZGVyLWNvbG9yOiAjMDA5Y2RmO1xuICAgICAgei1pbmRleDogMztcbiAgICAgIGJveC1zaGFkb3c6IDAgMCA0cHggMXB4IHJnYmEoMTM4LCAxNDMsIDE2MSwgMC4yKTsgfVxuICAgIC5mZC1kcm9wZG93bl9fY29udHJvbC0tbm8tYm9yZGVyIHtcbiAgICAgIGJvcmRlci1jb2xvcjogdHJhbnNwYXJlbnQ7IH1cbiAgICAgIC5mZC1kcm9wZG93bl9fY29udHJvbC0tbm8tYm9yZGVyW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLCAuZmQtZHJvcGRvd25fX2NvbnRyb2wtLW5vLWJvcmRlci5pcy1kaXNhYmxlZCwgLmZkLWRyb3Bkb3duX19jb250cm9sLS1uby1ib3JkZXI6ZGlzYWJsZWQge1xuICAgICAgICBib3JkZXItY29sb3I6IHRyYW5zcGFyZW50OyB9XG4gIC5mZC1kcm9wZG93bl9faWNvbiB7XG4gICAgbWFyZ2luLXJpZ2h0OiAxMnB4O1xuICAgIHZlcnRpY2FsLWFsaWduOiBtaWRkbGU7XG4gICAgdHJhbnNmb3JtOiB0cmFuc2xhdGVZKC0ycHgpOyB9XG4gIC5mZC1kcm9wZG93bl9fbWVudSwgLmZkLWRyb3Bkb3duX19vcHRpb25zIHtcbiAgICBtYXJnaW4tbGVmdDogMDtcbiAgICBwYWRkaW5nLWxlZnQ6IDA7XG4gICAgbGlzdC1zdHlsZTogbm9uZTtcbiAgICBtaW4td2lkdGg6IDEwMCU7XG4gICAgYm9yZGVyOiBzb2xpZCAxcHggI2NjZGFlYjtcbiAgICBiYWNrZ3JvdW5kOiAjZmZmZmZmO1xuICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICB3aGl0ZS1zcGFjZTogbm93cmFwO1xuICAgIHotaW5kZXg6IDI7XG4gICAgdHJhbnNmb3JtOiB0cmFuc2xhdGVZKC0xcHgpO1xuICAgIGJveC1zaGFkb3c6IDAgMCA0cHggMXB4IHJnYmEoMTM4LCAxNDMsIDE2MSwgMC4yKTtcbiAgICBvcGFjaXR5OiAxO1xuICAgIHZpc2liaWxpdHk6IHZpc2libGU7XG4gICAgdHJhbnNpdGlvbjogb3BhY2l0eSAwLjEyNXMgZWFzZS1pbjsgfVxuICAgIC5mZC1kcm9wZG93bl9fbWVudVthcmlhLWhpZGRlbj1cInRydWVcIl0sIC5mZC1kcm9wZG93bl9fbWVudS5pcy1oaWRkZW4sIC5mZC1kcm9wZG93bl9fb3B0aW9uc1thcmlhLWhpZGRlbj1cInRydWVcIl0sIC5mZC1kcm9wZG93bl9fb3B0aW9ucy5pcy1oaWRkZW4ge1xuICAgICAgb3BhY2l0eTogMDtcbiAgICAgIHZpc2liaWxpdHk6IGhpZGRlbjsgfVxuICAuZmQtZHJvcGRvd25fX2dyb3VwIHtcbiAgICBtYXJnaW4tbGVmdDogMDtcbiAgICBwYWRkaW5nLWxlZnQ6IDA7XG4gICAgbGlzdC1zdHlsZTogbm9uZTsgfVxuICAuZmQtZHJvcGRvd25fX2l0ZW0sIC5mZC1kcm9wZG93bl9fb3B0aW9uIHtcbiAgICBmb250LXNpemU6IDFyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuNTtcbiAgICBjb2xvcjogIzIxMjYyYztcbiAgICBmb250LXNpemU6IDAuODc1cmVtO1xuICAgIGxpbmUtaGVpZ2h0OiAxLjQyODU4O1xuICAgIGZvbnQtZmFtaWx5OiAnT3BlbiBTYW5zJywgc2Fucy1zZXJpZjtcbiAgICBmb250LXdlaWdodDogNDAwO1xuICAgIGRpc3BsYXk6IGJsb2NrO1xuICAgIHBhZGRpbmctbGVmdDogMDtcbiAgICBsaXN0LXN0eWxlOiBub25lO1xuICAgIHBhZGRpbmc6IDEycHggMTZweDsgfVxuICAgIC5mZC1kcm9wZG93bl9faXRlbTpob3ZlciwgLmZkLWRyb3Bkb3duX19vcHRpb246aG92ZXIge1xuICAgICAgY29sb3I6ICNmZmZmZmY7XG4gICAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjMDA4YWM2O1xuICAgICAgdGV4dC1kZWNvcmF0aW9uOiBub25lOyB9XG4gIC5mZC1kcm9wZG93bl9fc2VwYXJhdG9yIHtcbiAgICBmb250LXNpemU6IDFyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuNTtcbiAgICBjb2xvcjogIzIxMjYyYztcbiAgICBmb250LXNpemU6IDAuNzVyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuMzMzMzQ7XG4gICAgZm9udC1mYW1pbHk6ICdPcGVuIFNhbnMnLCBzYW5zLXNlcmlmO1xuICAgIGZvbnQtd2VpZ2h0OiA0MDA7XG4gICAgdGV4dC10cmFuc2Zvcm06IG5vbmU7XG4gICAgZGlzcGxheTogYmxvY2s7XG4gICAgY29sb3I6ICM3ZjkwYTQ7XG4gICAgcGFkZGluZzogMTJweCAxNnB4O1xuICAgIHBhZGRpbmctdG9wOiAxNnB4O1xuICAgIGJvcmRlci10b3A6IHNvbGlkIDFweCAjY2NkYWViOyB9XG5cbi8qIVxuLmZkLWZvcm1cbiAgICAuZmQtZm9ybV9fc2V0P1xuICAgICAgICAuZmQtZm9ybV9fbGVnZW5kKC5pcy1yZXF1aXJlZClcbiAgICAgICAgLmZkLWZvcm1fX2dyb3VwP1xuICAgICAgICAgICAgLmZkLWZvcm1fX2l0ZW0rKC0tY2hlY2ssIC0taW5saW5lKVxuICAgICAgICAgICAgICAgIC5mZC1mb3JtX19sYWJlbCguaXMtcmVxdWlyZWQpXG4gICAgICAgICAgICAgICAgLmZkLWZvcm1fX2NvbnRyb2xcbiAgICAgICAgICAgIC5mZC1mb3JtX19tZXNzYWdlKC0taGVscCwgLS1lcnJvciwgLS13YXJuaW5nKVxuKi9cbi5mZC1mb3JtX19ncm91cDo6YWZ0ZXIge1xuICBjb250ZW50OiBcIlwiO1xuICBkaXNwbGF5OiB0YWJsZTtcbiAgY2xlYXI6IGJvdGg7IH1cblxuLmZkLWZvcm1fX2dyb3VwOmxhc3QtY2hpbGQge1xuICBtYXJnaW4tYm90dG9tOiAwO1xuICBtYXJnaW4tcmlnaHQ6IDA7IH1cblxuLmZkLWZvcm1fX2dyb3VwIC5mZC1mb3JtX19pdGVtIHtcbiAgbWFyZ2luLXJpZ2h0OiAzMnB4OyB9XG4gIC5mZC1mb3JtX19ncm91cCAuZmQtZm9ybV9faXRlbTpsYXN0LWNoaWxkIHtcbiAgICBtYXJnaW4tYm90dG9tOiAwO1xuICAgIG1hcmdpbi1yaWdodDogMDsgfVxuXG4uZmQtZm9ybV9fc2V0IHtcbiAgbWFyZ2luLWJvdHRvbTogMzJweDsgfVxuICAuZmQtZm9ybV9fc2V0IC5mZC1mb3JtX19pdGVtLS1pbmxpbmUge1xuICAgIG1hcmdpbi1ib3R0b206IDA7IH1cbiAgLmZkLWZvcm1fX3NldCAuZmQtZm9ybV9fbWVzc2FnZSB7XG4gICAgbWFyZ2luLXRvcDogOHB4OyB9XG5cbi5mZC1mb3JtX19pdGVtIHtcbiAgbWFyZ2luLWJvdHRvbTogMzJweDsgfVxuICAuZmQtZm9ybV9faXRlbTpsYXN0LWNoaWxkIHtcbiAgICBtYXJnaW4tYm90dG9tOiAwO1xuICAgIG1hcmdpbi1yaWdodDogMDsgfVxuICAuZmQtZm9ybV9faXRlbS0tY2hlY2sge1xuICAgIHBvc2l0aW9uOiByZWxhdGl2ZTtcbiAgICBkaXNwbGF5OiBibG9jazsgfVxuICAgIC5mZC1mb3JtX19pdGVtLS1jaGVjazo6YWZ0ZXIge1xuICAgICAgY29udGVudDogXCJcIjtcbiAgICAgIGRpc3BsYXk6IHRhYmxlO1xuICAgICAgY2xlYXI6IGJvdGg7IH1cbiAgICAuZmQtZm9ybV9faXRlbS0tY2hlY2sgLmZkLWZvcm1fX2xhYmVsIHtcbiAgICAgIGZvbnQtc2l6ZTogMXJlbTtcbiAgICAgIGxpbmUtaGVpZ2h0OiAxLjU7XG4gICAgICBmb250LXdlaWdodDogNDAwO1xuICAgICAgbWFyZ2luLWJvdHRvbTogMDtcbiAgICAgIHZlcnRpY2FsLWFsaWduOiBtaWRkbGU7XG4gICAgICBkaXNwbGF5OiBmbGV4O1xuICAgICAgYWxpZ24taXRlbXM6IGNlbnRlcjtcbiAgICAgIGxpbmUtaGVpZ2h0OiAyOHB4OyB9XG4gICAgLmZkLWZvcm1fX2l0ZW0tLWNoZWNrIC5mZC1mb3JtX19jb250cm9sIHtcbiAgICAgIGZsb2F0OiBsZWZ0O1xuICAgICAgdmVydGljYWwtYWxpZ246IG1pZGRsZTtcbiAgICAgIG1hcmdpbi1yaWdodDogMTJweDsgfVxuICAgIC5mZC1mb3JtX19pdGVtLS1jaGVjayAuZmQtZm9ybV9faGVscCB7XG4gICAgICBmbG9hdDogbm9uZTtcbiAgICAgIG1hcmdpbi1sZWZ0OiAxMnB4OyB9XG4gIC5mZC1mb3JtX19pdGVtLS1pbmxpbmUge1xuICAgIGZsb2F0OiBsZWZ0OyB9XG4gICAgLmZkLWZvcm1fX2l0ZW0tLWlubGluZSAuZmQtZm9ybV9fbGFiZWwge1xuICAgICAgbWFyZ2luLXRvcDogNHB4O1xuICAgICAgd2lkdGg6IGF1dG87IH1cblxuLmZkLWZvcm1fX2xhYmVsLCAuZmQtZm9ybV9fbGVnZW5kIHtcbiAgZm9udC1zaXplOiAwLjg3NXJlbTtcbiAgbGluZS1oZWlnaHQ6IDEuNDI4NTg7XG4gIGZvbnQtd2VpZ2h0OiA0MDA7XG4gIGRpc3BsYXk6IGJsb2NrO1xuICBtYXJnaW4tYm90dG9tOiA4cHg7XG4gIGJvcmRlcjogMDtcbiAgY29sb3I6ICM2Mzc1OGI7IH1cbiAgLmZkLWZvcm1fX2xhYmVsLmlzLXJlcXVpcmVkLCAuZmQtZm9ybV9fbGVnZW5kLmlzLXJlcXVpcmVkIHtcbiAgICBmb250LXdlaWdodDogNzAwOyB9XG5cbi5mZC1mb3JtX19jb250cm9sIHtcbiAgbWluLXdpZHRoOiAyOHB4OyB9XG5cbi5mZC1mb3JtX19sZWdlbmQge1xuICBtYXJnaW4tYm90dG9tOiAyMHB4OyB9XG5cbi5mZC1mb3JtX19oZWxwIHtcbiAgZmxvYXQ6IHJpZ2h0OyB9XG5cbi5mZC1mb3JtX19tZXNzYWdlIHtcbiAgY2xlYXI6IGJvdGg7XG4gIGRpc3BsYXk6IGJsb2NrO1xuICBmb250LXNpemU6IDAuODc1cmVtO1xuICBsaW5lLWhlaWdodDogMS40Mjg1ODtcbiAgZm9udC13ZWlnaHQ6IDQwMDtcbiAgY29sb3I6ICM3ZjkwYTQ7XG4gIHBhZGRpbmc6IDRweCAwO1xuICBmb250LXN0eWxlOiBpdGFsaWM7XG4gIHBvc2l0aW9uOiByZWxhdGl2ZTsgfVxuICAuZmQtZm9ybV9faXRlbS0tY2hlY2sgKyAuZmQtZm9ybV9fbWVzc2FnZSB7XG4gICAgdHJhbnNmb3JtOiB0cmFuc2xhdGVZKC0xMnB4KTtcbiAgICBtYXJnaW4tYm90dG9tOiAtMTJweDsgfVxuICAuZmQtZm9ybV9faXRlbS0taW5saW5lLmZkLWZvcm1fX2l0ZW0tLWNoZWNrICsgLmZkLWZvcm1fX21lc3NhZ2Uge1xuICAgIHRyYW5zZm9ybTogdHJhbnNsYXRlWSg4cHgpO1xuICAgIG1hcmdpbi1ib3R0b206IDhweDsgfVxuICAuZmQtZm9ybV9fbWVzc2FnZTo6YmVmb3JlIHtcbiAgICB3aWR0aDogMThweDtcbiAgICBoZWlnaHQ6IDE4cHg7XG4gICAgZm9udC1zdHlsZTogbm9ybWFsO1xuICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICBsZWZ0OiAwO1xuICAgIGNvbG9yOiAjZmZmZmZmO1xuICAgIGJvcmRlci1yYWRpdXM6IDUwJTtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjNjM3NThiO1xuICAgIHRleHQtYWxpZ246IGNlbnRlcjsgfVxuICAuZmQtZm9ybV9fbWVzc2FnZS0taGVscCB7XG4gICAgcGFkZGluZy1sZWZ0OiAyOHB4OyB9XG4gICAgLmZkLWZvcm1fX21lc3NhZ2UtLWhlbHA6OmJlZm9yZSB7XG4gICAgICBjb250ZW50OiBcIj9cIjsgfVxuICAuZmQtZm9ybV9fbWVzc2FnZS0td2FybmluZywgLmZkLWZvcm1fX21lc3NhZ2UtLWVycm9yIHtcbiAgICBwYWRkaW5nLWxlZnQ6IDM2cHg7XG4gICAgY29sb3I6ICMyMTI2MmM7IH1cbiAgICAuZmQtZm9ybV9fbWVzc2FnZS0td2FybmluZzo6YmVmb3JlLCAuZmQtZm9ybV9fbWVzc2FnZS0tZXJyb3I6OmJlZm9yZSB7XG4gICAgICBjb250ZW50OiBcIiFcIjtcbiAgICAgIGxlZnQ6IDhweDsgfVxuICAuZmQtZm9ybV9fbWVzc2FnZS0td2FybmluZyB7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogI2Y4ZDViZTsgfVxuICAgIC5mZC1mb3JtX19tZXNzYWdlLS13YXJuaW5nOjpiZWZvcmUge1xuICAgICAgYmFja2dyb3VuZC1jb2xvcjogdHJhbnNwYXJlbnQ7XG4gICAgICBib3JkZXItcmFkaXVzOiAwO1xuICAgICAgaGVpZ2h0OiAwO1xuICAgICAgd2lkdGg6IDA7XG4gICAgICBib3JkZXItYm90dG9tOiAxOHB4IHNvbGlkICNlOTczMjY7XG4gICAgICBib3JkZXItbGVmdDogMTBweCBzb2xpZCB0cmFuc3BhcmVudDtcbiAgICAgIGJvcmRlci1yaWdodDogMTBweCBzb2xpZCB0cmFuc3BhcmVudDtcbiAgICAgIHRleHQtaW5kZW50OiAtMC4xZW07IH1cbiAgLmZkLWZvcm1fX21lc3NhZ2UtLWVycm9yIHtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjZjdiOGI4OyB9XG4gICAgLmZkLWZvcm1fX21lc3NhZ2UtLWVycm9yOjpiZWZvcmUge1xuICAgICAgYmFja2dyb3VuZC1jb2xvcjogI2RmMTkxOTtcbiAgICAgIGNvbG9yOiAjZmZmZmZmOyB9XG5cbi8qIVxuLmZkLWlucHV0LWdyb3VwKygtLWlubGluZSlcbiAgICAuZmQtaW5wdXQtZ3JvdXBfX2FkZG9uKygpXG4gICAgICAgIC5mZC1pbnB1dC1ncm91cF9fYnV0dG9uXG4qL1xuLmZkLWlucHV0LWdyb3VwIHtcbiAgZm9udC1zaXplOiAxcmVtO1xuICBsaW5lLWhlaWdodDogMS41O1xuICBjb2xvcjogIzIxMjYyYztcbiAgZGlzcGxheTogZmxleDtcbiAgdmVydGljYWwtYWxpZ246IGJvdHRvbTtcbiAgbWF4LWhlaWdodDogNTJweDsgfVxuICAuZmQtaW5wdXQtZ3JvdXAgW3R5cGU9XCJudW1iZXJcIl0ge1xuICAgIC1tb3otYXBwZWFyYW5jZTogdGV4dGZpZWxkOyB9XG4gICAgLmZkLWlucHV0LWdyb3VwIFt0eXBlPVwibnVtYmVyXCJdOjotd2Via2l0LW91dGVyLXNwaW4tYnV0dG9uLCAuZmQtaW5wdXQtZ3JvdXAgW3R5cGU9XCJudW1iZXJcIl06Oi13ZWJraXQtaW5uZXItc3Bpbi1idXR0b24ge1xuICAgICAgLXdlYmtpdC1hcHBlYXJhbmNlOiBub25lO1xuICAgICAgbWFyZ2luOiAwOyB9XG4gIC5mZC1pbnB1dC1ncm91cCBbdHlwZT1cInNlYXJjaFwiXSB7XG4gICAgYmFja2dyb3VuZC1pbWFnZTogdXJsKFwiZGF0YTppbWFnZS9zdmcreG1sO2Jhc2U2NCxQSE4yWnlCNGJXeHVjejBpYUhSMGNEb3ZMM2QzZHk1M015NXZjbWN2TWpBd01DOXpkbWNpSUhkcFpIUm9QU0l5TmlJZ2FHVnBaMmgwUFNJeU5pSStQSEJoZEdnZ1ptbHNiQzF5ZFd4bFBTSmxkbVZ1YjJSa0lpQm1hV3hzUFNJak5FUTFRVFpESWlCa1BTSk5PUzQzTlRRZ01Ua3VORGsyWVRrdU5qZzBJRGt1TmpnMElEQWdNQ0F3SURZdU1EazNMVEl1TVRVNGJEZ3VNamc1SURndU16UmhNUzR3T0RRZ01TNHdPRFFnTUNBd0lEQWdNUzQxTXpVdE1TNDFNamxzTFRndU15MDRMak0xWVRrdU5qZzVJRGt1TmpnNUlEQWdNQ0F3SURJdU1USXROaTR3TlRSak1DMDFMak0zTnkwMExqTTJPUzA1TGpjMU1TMDVMamMwTVMwNUxqYzFNVk11TURFeklEUXVNelk0TGpBeE15QTVMamMwTlhNMExqTTJPU0E1TGpjMU1TQTVMamMwTVNBNUxqYzFNWHB0TUMweE55NHpNelZqTkM0eE56Y2dNQ0EzTGpVM055QXpMalF3TWlBM0xqVTNOeUEzTGpVNE5DQXdJRFF1TVRneUxUTXVOQ0EzTGpVNE5DMDNMalUzTnlBM0xqVTROQzAwTGpFM09DQXdMVGN1TlRjM0xUTXVOREF5TFRjdU5UYzNMVGN1TlRnMElEQXROQzR4T0RJZ015NHpPVGt0Tnk0MU9EUWdOeTQxTnpjdE55NDFPRFI2SWk4K1BDOXpkbWMrXCIpO1xuICAgIGJhY2tncm91bmQtcmVwZWF0OiBuby1yZXBlYXQ7XG4gICAgYmFja2dyb3VuZC1wb3NpdGlvbjogMTZweCBjZW50ZXI7XG4gICAgcGFkZGluZy1sZWZ0OiA2MHB4O1xuICAgIHBhZGRpbmctcmlnaHQ6IDYwcHg7XG4gICAgLW1vei1hcHBlYXJhbmNlOiB0ZXh0ZmllbGQ7IH1cbiAgICAuZmQtaW5wdXQtZ3JvdXAgW3R5cGU9XCJzZWFyY2hcIl06Oi13ZWJraXQtc2VhcmNoLWRlY29yYXRpb24ge1xuICAgICAgLXdlYmtpdC1hcHBlYXJhbmNlOiBub25lO1xuICAgICAgbWFyZ2luOiAwOyB9XG4gICAgLmZkLWlucHV0LWdyb3VwIFt0eXBlPVwic2VhcmNoXCJdOjotd2Via2l0LXNlYXJjaC1jYW5jZWwtYnV0dG9uIHtcbiAgICAgIC13ZWJraXQtYXBwZWFyYW5jZTogbm9uZTtcbiAgICAgIG1hcmdpbjogMDsgfVxuICAuZmQtaW5wdXQtZ3JvdXAtLWlubGluZSB7XG4gICAgZGlzcGxheTogaW5saW5lLWZsZXg7IH1cbiAgLmZkLWlucHV0LWdyb3VwLS1uby1ib3JkZXIgaW5wdXQge1xuICAgIGJvcmRlci1jb2xvcjogdHJhbnNwYXJlbnQ7IH1cbiAgLmZkLWlucHV0LWdyb3VwX19hZGRvbiB7XG4gICAgZm9udC1zaXplOiAwLjgxMjVyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuNTM4NDc7XG4gICAgZm9udC1mYW1pbHk6ICdPcGVuIFNhbnMnLCBzYW5zLXNlcmlmO1xuICAgIGZvbnQtd2VpZ2h0OiA3MDA7XG4gICAgdGV4dC10cmFuc2Zvcm06IG5vcm1hbDtcbiAgICBjb2xvcjogIzYzNzU4YjtcbiAgICBwYWRkaW5nOiAwIDE2cHg7XG4gICAgYm9yZGVyLXN0eWxlOiBzb2xpZDtcbiAgICBib3JkZXItd2lkdGg6IDFweDtcbiAgICBib3JkZXItY29sb3I6ICNjY2RhZWI7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogI2Y5ZmJmYztcbiAgICBqdXN0aWZ5LWNvbnRlbnQ6IGNlbnRlcjtcbiAgICBkaXNwbGF5OiBmbGV4O1xuICAgIGZsZXgtZGlyZWN0aW9uOiBjb2x1bW47IH1cbiAgICAuZmQtaW5wdXQtZ3JvdXBfX2FkZG9uOmZpcnN0LWNoaWxkIHtcbiAgICAgIGJvcmRlci1yaWdodC13aWR0aDogMDsgfVxuICAgIC5mZC1pbnB1dC1ncm91cF9fYWRkb246bGFzdC1jaGlsZCB7XG4gICAgICBib3JkZXItbGVmdC13aWR0aDogMDsgfVxuICAgIC5mZC1pbnB1dC1ncm91cF9fYWRkb24tLWJ1dHRvbiB7XG4gICAgICBwYWRkaW5nOiAwOyB9XG4gICAgW3JlYWRvbmx5XSArIC5mZC1pbnB1dC1ncm91cF9fYWRkb24ge1xuICAgICAgYm9yZGVyLXRvcC1jb2xvcjogdHJhbnNwYXJlbnQ7XG4gICAgICBib3JkZXItcmlnaHQtY29sb3I6IHRyYW5zcGFyZW50OyB9XG4gICAgW3R5cGU9XCJzZWFyY2hcIl0gKyAuZmQtaW5wdXQtZ3JvdXBfX2FkZG9uIHtcbiAgICAgIGJvcmRlcjogMDtcbiAgICAgIHdpZHRoOiAwOyB9XG4gIC5mZC1pbnB1dC1ncm91cF9fYnV0dG9uIHtcbiAgICBtYXJnaW46IDA7XG4gICAgcGFkZGluZzogMDtcbiAgICBmb250LXNtb290aGluZzogYW50aWFsaWFzZWQ7XG4gICAgYXBwZWFyYW5jZTogbm9uZTtcbiAgICBvdXRsaW5lOiAwO1xuICAgIGJvcmRlcjogMDtcbiAgICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gICAgdGV4dC1kZWNvcmF0aW9uOiBub25lO1xuICAgIGN1cnNvcjogcG9pbnRlcjtcbiAgICB1c2VyLXNlbGVjdDogbm9uZTtcbiAgICB2ZXJ0aWNhbC1hbGlnbjogbWlkZGxlO1xuICAgIHdoaXRlLXNwYWNlOiBub3dyYXA7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogdHJhbnNwYXJlbnQ7XG4gICAgZmxleDogMTtcbiAgICB3aWR0aDogMTAwJTtcbiAgICBkaXNwbGF5OiBibG9jaztcbiAgICBtaW4td2lkdGg6IDQ4cHg7IH1cbiAgICAuZmQtaW5wdXQtZ3JvdXBfX2J1dHRvbi0tc3RlcC11cCwgLmZkLWlucHV0LWdyb3VwX19idXR0b24tLXN0ZXAtZG93biB7XG4gICAgICBmb250LXNpemU6IDEwcHg7IH1cbiAgICAgIC5mZC1pbnB1dC1ncm91cF9fYnV0dG9uLS1zdGVwLXVwOjphZnRlciwgLmZkLWlucHV0LWdyb3VwX19idXR0b24tLXN0ZXAtZG93bjo6YWZ0ZXIge1xuICAgICAgICBjb250ZW50OiBcIlwiO1xuICAgICAgICBwb3NpdGlvbjogcmVsYXRpdmU7IH1cbiAgICAuZmQtaW5wdXQtZ3JvdXBfX2J1dHRvbi0tc3RlcC11cCB7XG4gICAgICBib3JkZXItYm90dG9tOiBzb2xpZCAxcHggI2NjZGFlYjsgfVxuICAgICAgLmZkLWlucHV0LWdyb3VwX19idXR0b24tLXN0ZXAtdXA6OmFmdGVyIHtcbiAgICAgICAgaGVpZ2h0OiAwO1xuICAgICAgICB3aWR0aDogMDtcbiAgICAgICAgYm9yZGVyLWJvdHRvbTogOHB4IHNvbGlkIGJsYWNrO1xuICAgICAgICBib3JkZXItbGVmdDogNi41cHggc29saWQgdHJhbnNwYXJlbnQ7XG4gICAgICAgIGJvcmRlci1yaWdodDogNi41cHggc29saWQgdHJhbnNwYXJlbnQ7XG4gICAgICAgIHRvcDogLTEwcHg7IH1cbiAgICAuZmQtaW5wdXQtZ3JvdXBfX2J1dHRvbi0tc3RlcC1kb3duOjphZnRlciB7XG4gICAgICBoZWlnaHQ6IDA7XG4gICAgICB3aWR0aDogMDtcbiAgICAgIGJvcmRlci1sZWZ0OiA2LjVweCBzb2xpZCB0cmFuc3BhcmVudDtcbiAgICAgIGJvcmRlci1yaWdodDogNi41cHggc29saWQgdHJhbnNwYXJlbnQ7XG4gICAgICBib3JkZXItdG9wOiA4cHggc29saWQgYmxhY2s7XG4gICAgICB0b3A6IDEwcHg7IH1cbiAgICAuZmQtaW5wdXQtZ3JvdXBfX2J1dHRvbi0tY2xlYXIge1xuICAgICAgYmFja2dyb3VuZC1pbWFnZTogdXJsKFwiZGF0YTppbWFnZS9zdmcreG1sO2Jhc2U2NCxQSE4yWnlCNGJXeHVjejBpYUhSMGNEb3ZMM2QzZHk1M015NXZjbWN2TWpBd01DOXpkbWNpSUhkcFpIUm9QU0l5TmlJZ2FHVnBaMmgwUFNJeU5pSStQSEJoZEdnZ1ptbHNiQzF5ZFd4bFBTSmxkbVZ1YjJSa0lpQm1hV3hzUFNJak1EQTVRMFJHSWlCa1BTSk5NVE1nTUVNMUxqZ3lJREFnTUNBMUxqZ3lJREFnTVROek5TNDRNaUF4TXlBeE15QXhNeUF4TXkwMUxqZ3lJREV6TFRFelV6SXdMakU0SURBZ01UTWdNSHB0TlM0eE9UVWdNVGN1TXprMllTNDFOalF1TlRZMElEQWdNU0F4TFM0M09Ua3VOems1VERFeklERXpMamM1T1d3dE5DNHpPVFlnTkM0ek9UWmhMalUyTkM0MU5qUWdNQ0F4SURFdExqYzVPUzB1TnprNVRERXlMakl3TVNBeE15QTNMamd3TlNBNExqWXdOR0V1TlRZMExqVTJOQ0F3SURFZ01TQXVOems1TFM0M09UbE1NVE1nTVRJdU1qQXhiRFF1TXprMkxUUXVNemsyWVM0MU5qUXVOVFkwSURBZ01TQXhJQzQzT1RrdU56azVUREV6TGpjNU9TQXhNMncwTGpNNU5pQTBMak01Tm5vaUx6NDhMM04yWno0PVwiKTtcbiAgICAgIGJhY2tncm91bmQtcmVwZWF0OiBuby1yZXBlYXQ7XG4gICAgICBiYWNrZ3JvdW5kLXBvc2l0aW9uOiBjZW50ZXI7XG4gICAgICBwb3NpdGlvbjogcmVsYXRpdmU7XG4gICAgICBsZWZ0OiAtNTJweDsgfVxuXG4vKiFcbi5mZC1sYWJlbCsoLS1zdWNjZXNzIHwgLS13YXJuaW5nIHwgLS1lcnJvcilcbiovXG4uZmQtbGFiZWwge1xuICBmb250LXNpemU6IDFyZW07XG4gIGxpbmUtaGVpZ2h0OiAxLjU7XG4gIGNvbG9yOiAjMjEyNjJjO1xuICBmb250LXNpemU6IDAuNzVyZW07XG4gIGxpbmUtaGVpZ2h0OiAxLjMzMzM0O1xuICBmb250LXdlaWdodDogNzAwO1xuICB0ZXh0LXRyYW5zZm9ybTogdXBwZXJjYXNlOyB9XG4gIC5mZC1sYWJlbC0tc3VjY2VzcyB7XG4gICAgY29sb3I6ICM2MWJmMzM7IH1cbiAgLmZkLWxhYmVsLS13YXJuaW5nIHtcbiAgICBjb2xvcjogI2U5NzMyNjsgfVxuICAuZmQtbGFiZWwtLWVycm9yIHtcbiAgICBjb2xvcjogI2RmMTkxOTsgfVxuXG4vKiFcbi5mZC1idXR0b24rKCAoLS1zbWFsbCB8IC0tbGFyZ2UpLCAtLWljb24sIC0tdGV4dCwgLS1saW5rLCAtLWFjdGlvbi1iYXIpKyggKC5pcy1kaXNhYmxlZCB8IFthcmlhLWRpc2FibGVkPXRydWVdKSB8ICguaXMtc2VsZWN0ZWQgfCBbYXJpYS1zZWxlY3RlZD10cnVlXSB8ICguaXMtcHJlc3NlZCB8IFthcmlhLXByZXNzZWQ9dHJ1ZV0pKVxuKi9cbi5mZC1idXR0b24sIC5mZC1tb2RhbF9fYnV0dG9uLXByaW1hcnksIC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSB7XG4gIG1hcmdpbjogMDtcbiAgcGFkZGluZzogMDtcbiAgZm9udC1zbW9vdGhpbmc6IGFudGlhbGlhc2VkO1xuICBhcHBlYXJhbmNlOiBub25lO1xuICBvdXRsaW5lOiAwO1xuICBib3JkZXI6IDA7XG4gIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgdGV4dC1kZWNvcmF0aW9uOiBub25lO1xuICBjdXJzb3I6IHBvaW50ZXI7XG4gIHVzZXItc2VsZWN0OiBub25lO1xuICB2ZXJ0aWNhbC1hbGlnbjogbWlkZGxlO1xuICB3aGl0ZS1zcGFjZTogbm93cmFwO1xuICBiYWNrZ3JvdW5kLWNvbG9yOiB0cmFuc3BhcmVudDtcbiAgZm9udC1zaXplOiAxLjEyNXJlbTtcbiAgbGluZS1oZWlnaHQ6IDEuMzMzMzQ7XG4gIGZvbnQtZmFtaWx5OiBSb2JvdG8sIHNhbnMtc2VyaWY7XG4gIGZvbnQtd2VpZ2h0OiA1MDA7XG4gIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgYmFja2dyb3VuZC1jb2xvcjogIzAwOWNkZjtcbiAgdHJhbnNpdGlvbjogYmFja2dyb3VuZC1jb2xvciAwLjEyNXMgZWFzZS1pbjtcbiAgY29sb3I6ICNmNmY4Zjk7XG4gIG1heC1oZWlnaHQ6IDUycHg7XG4gIGhlaWdodDogNTJweDtcbiAgbGluZS1oZWlnaHQ6IDUycHg7XG4gIHBhZGRpbmctbGVmdDogMjBweDtcbiAgcGFkZGluZy1yaWdodDogMjBweDtcbiAgdGV4dC1hbGlnbjogY2VudGVyO1xuICB0ZXh0LXRyYW5zZm9ybTogdXBwZXJjYXNlO1xuICBib3JkZXItcmFkaXVzOiAwOyB9XG4gIC5mZC1idXR0b24tLXNtYWxsIHtcbiAgICBmb250LXNpemU6IDFyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuNTtcbiAgICBmb250LXdlaWdodDogNDAwO1xuICAgIGZvbnQtd2VpZ2h0OiA2MDA7XG4gICAgbWF4LWhlaWdodDogNDBweDtcbiAgICBoZWlnaHQ6IDQwcHg7XG4gICAgbGluZS1oZWlnaHQ6IDQwcHg7XG4gICAgcGFkZGluZy1sZWZ0OiAxNnB4O1xuICAgIHBhZGRpbmctcmlnaHQ6IDE2cHg7IH1cbiAgLmZkLWJ1dHRvbi0tbGFyZ2UsIC5mZC1idXR0b24tLWFjdGlvbi1iYXIge1xuICAgIGZvbnQtc2l6ZTogMS4yNXJlbTtcbiAgICBsaW5lLWhlaWdodDogMS40O1xuICAgIGZvbnQtd2VpZ2h0OiA2MDA7XG4gICAgbWF4LWhlaWdodDogNzZweDtcbiAgICBoZWlnaHQ6IDc2cHg7XG4gICAgbGluZS1oZWlnaHQ6IDc2cHg7XG4gICAgcGFkZGluZy1sZWZ0OiAyOHB4O1xuICAgIHBhZGRpbmctcmlnaHQ6IDI4cHg7IH1cbiAgLmZkLWJ1dHRvbjpob3ZlciwgLmZkLW1vZGFsX19idXR0b24tcHJpbWFyeTpob3ZlciwgLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5OmhvdmVyIHtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjMDA4YWM2O1xuICAgIGNvbG9yOiAjZjZmOGY5O1xuICAgIHRleHQtZGVjb3JhdGlvbjogbm9uZTsgfVxuICAuZmQtYnV0dG9uOmZvY3VzLCAuZmQtbW9kYWxfX2J1dHRvbi1wcmltYXJ5OmZvY3VzLCAuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnk6Zm9jdXMge1xuICAgIGNvbG9yOiAjZjZmOGY5O1xuICAgIGJveC1zaGFkb3c6IDAgMCA0cHggMXB4ICM4YThmYTE7XG4gICAgb3V0bGluZTogc29saWQgMnB4ICMyZGMwZmY7IH1cbiAgLmZkLWJ1dHRvbjphY3RpdmUsIC5mZC1tb2RhbF9fYnV0dG9uLXByaW1hcnk6YWN0aXZlLCAuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnk6YWN0aXZlLCAuZmQtYnV0dG9uLmlzLWFjdGl2ZSwgLmlzLWFjdGl2ZS5mZC1tb2RhbF9fYnV0dG9uLXByaW1hcnksIC5pcy1hY3RpdmUuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b25bYXJpYS1zZWxlY3RlZD1cInRydWVcIl0sIFthcmlhLXNlbGVjdGVkPVwidHJ1ZVwiXS5mZC1tb2RhbF9fYnV0dG9uLXByaW1hcnksIFthcmlhLXNlbGVjdGVkPVwidHJ1ZVwiXS5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvbi5pcy1zZWxlY3RlZCwgLmlzLXNlbGVjdGVkLmZkLW1vZGFsX19idXR0b24tcHJpbWFyeSwgLmlzLXNlbGVjdGVkLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uW2FyaWEtcHJlc3NlZD1cInRydWVcIl0sIFthcmlhLXByZXNzZWQ9XCJ0cnVlXCJdLmZkLW1vZGFsX19idXR0b24tcHJpbWFyeSwgW2FyaWEtcHJlc3NlZD1cInRydWVcIl0uZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b24uaXMtcHJlc3NlZCwgLmlzLXByZXNzZWQuZmQtbW9kYWxfX2J1dHRvbi1wcmltYXJ5LCAuaXMtcHJlc3NlZC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSB7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogIzAwNzhhYztcbiAgICBjb2xvcjogI2Y2ZjhmOTsgfVxuICAuZmQtYnV0dG9uW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLCBbYXJpYS1kaXNhYmxlZD1cInRydWVcIl0uZmQtbW9kYWxfX2J1dHRvbi1wcmltYXJ5LCBbYXJpYS1kaXNhYmxlZD1cInRydWVcIl0uZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b24uaXMtZGlzYWJsZWQsIC5pcy1kaXNhYmxlZC5mZC1tb2RhbF9fYnV0dG9uLXByaW1hcnksIC5pcy1kaXNhYmxlZC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvbjpkaXNhYmxlZCwgLmZkLW1vZGFsX19idXR0b24tcHJpbWFyeTpkaXNhYmxlZCwgLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5OmRpc2FibGVkIHtcbiAgICBvdXRsaW5lOiBzb2xpZCAxcHggI2Q3ZDdkNztcbiAgICBjb2xvcjogIzdmOTBhNDtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjZjlmYmZjO1xuICAgIGN1cnNvcjogbm90LWFsbG93ZWQ7IH1cbiAgLmZkLWJ1dHRvbi0tdGV4dCwgLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uLS1saW5rIHtcbiAgICBjb2xvcjogIzAwOWNkZjtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiB0cmFuc3BhcmVudDsgfVxuICAgIC5mZC1idXR0b24tLXRleHQ6aG92ZXIsIC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeTpob3ZlciwgLmZkLWJ1dHRvbi0tdGV4dDpmb2N1cywgLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5OmZvY3VzLCAuZmQtYnV0dG9uLS1saW5rOmhvdmVyLCAuZmQtYnV0dG9uLS1saW5rOmZvY3VzIHtcbiAgICAgIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50O1xuICAgICAgY29sb3I6ICMwMDhhYzY7IH1cbiAgICAuZmQtYnV0dG9uLS10ZXh0OmFjdGl2ZSwgLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5OmFjdGl2ZSwgLmZkLWJ1dHRvbi0tdGV4dFthcmlhLXNlbGVjdGVkPVwidHJ1ZVwiXSwgW2FyaWEtc2VsZWN0ZWQ9XCJ0cnVlXCJdLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uLS10ZXh0LmlzLXNlbGVjdGVkLCAuaXMtc2VsZWN0ZWQuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b24tLXRleHRbYXJpYS1wcmVzc2VkPVwidHJ1ZVwiXSwgW2FyaWEtcHJlc3NlZD1cInRydWVcIl0uZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b24tLXRleHQuaXMtcHJlc3NlZCwgLmlzLXByZXNzZWQuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b24tLXRleHRbYXJpYS1kaXNhYmxlZD1cInRydWVcIl0sIFthcmlhLWRpc2FibGVkPVwidHJ1ZVwiXS5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvbi0tdGV4dC5pcy1kaXNhYmxlZCwgLmlzLWRpc2FibGVkLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uLS10ZXh0OmRpc2FibGVkLCAuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnk6ZGlzYWJsZWQsIC5mZC1idXR0b24tLWxpbms6YWN0aXZlLCAuZmQtYnV0dG9uLS1saW5rW2FyaWEtc2VsZWN0ZWQ9XCJ0cnVlXCJdLCAuZmQtYnV0dG9uLS1saW5rLmlzLXNlbGVjdGVkLCAuZmQtYnV0dG9uLS1saW5rW2FyaWEtcHJlc3NlZD1cInRydWVcIl0sIC5mZC1idXR0b24tLWxpbmsuaXMtcHJlc3NlZCwgLmZkLWJ1dHRvbi0tbGlua1thcmlhLWRpc2FibGVkPVwidHJ1ZVwiXSwgLmZkLWJ1dHRvbi0tbGluay5pcy1kaXNhYmxlZCwgLmZkLWJ1dHRvbi0tbGluazpkaXNhYmxlZCB7XG4gICAgICBiYWNrZ3JvdW5kLWNvbG9yOiB0cmFuc3BhcmVudDtcbiAgICAgIG91dGxpbmU6IG5vbmU7XG4gICAgICBib3gtc2hhZG93OiBub25lOyB9XG4gICAgLmZkLWJ1dHRvbi0tdGV4dDphY3RpdmUsIC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeTphY3RpdmUsIC5mZC1idXR0b24tLXRleHRbYXJpYS1zZWxlY3RlZD1cInRydWVcIl0sIFthcmlhLXNlbGVjdGVkPVwidHJ1ZVwiXS5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvbi0tdGV4dC5pcy1zZWxlY3RlZCwgLmlzLXNlbGVjdGVkLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uLS10ZXh0W2FyaWEtcHJlc3NlZD1cInRydWVcIl0sIFthcmlhLXByZXNzZWQ9XCJ0cnVlXCJdLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uLS10ZXh0LmlzLXByZXNzZWQsIC5pcy1wcmVzc2VkLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uLS1saW5rOmFjdGl2ZSwgLmZkLWJ1dHRvbi0tbGlua1thcmlhLXNlbGVjdGVkPVwidHJ1ZVwiXSwgLmZkLWJ1dHRvbi0tbGluay5pcy1zZWxlY3RlZCwgLmZkLWJ1dHRvbi0tbGlua1thcmlhLXByZXNzZWQ9XCJ0cnVlXCJdLCAuZmQtYnV0dG9uLS1saW5rLmlzLXByZXNzZWQge1xuICAgICAgY29sb3I6ICMwMDc4YWM7IH1cbiAgICAuZmQtYnV0dG9uLS10ZXh0W2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLCBbYXJpYS1kaXNhYmxlZD1cInRydWVcIl0uZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b24tLXRleHQuaXMtZGlzYWJsZWQsIC5pcy1kaXNhYmxlZC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvbi0tdGV4dDpkaXNhYmxlZCwgLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5OmRpc2FibGVkLCAuZmQtYnV0dG9uLS1saW5rW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLCAuZmQtYnV0dG9uLS1saW5rLmlzLWRpc2FibGVkLCAuZmQtYnV0dG9uLS1saW5rOmRpc2FibGVkIHtcbiAgICAgIGNvbG9yOiAjN2Y5MGE0OyB9XG4gIC5mZC1idXR0b24tLWxpbmsge1xuICAgIGhlaWdodDogMjhweDtcbiAgICBsaW5lLWhlaWdodDogMjhweDtcbiAgICBwYWRkaW5nLWxlZnQ6IDE2cHg7XG4gICAgcGFkZGluZy1yaWdodDogMTZweDtcbiAgICBwb3NpdGlvbjogcmVsYXRpdmU7IH1cbiAgICAuZmQtYnV0dG9uLS1saW5rLmZkLWJ1dHRvbi0tc21hbGwge1xuICAgICAgaGVpZ2h0OiAyNHB4O1xuICAgICAgbGluZS1oZWlnaHQ6IDI0cHg7IH1cbiAgICAuZmQtYnV0dG9uLS1saW5rOjphZnRlciB7XG4gICAgICBjb250ZW50OiBcIlwiO1xuICAgICAgYm9yZGVyLWJvdHRvbTogc29saWQgMnB4IHRyYW5zcGFyZW50O1xuICAgICAgd2lkdGg6IGNhbGMoMTAwJSAtIDE2cHgqMik7XG4gICAgICBoZWlnaHQ6IDJweDtcbiAgICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICAgIGJvdHRvbTogMXB4O1xuICAgICAgbGVmdDogMDtcbiAgICAgIG1hcmdpbi1sZWZ0OiAxNnB4O1xuICAgICAgdHJhbnNpdGlvbjogYm9yZGVyLWJvdHRvbS1jb2xvciAwLjEyNXMgZWFzZS1pbjsgfVxuICAgIC5mZC1idXR0b24tLWxpbms6Zm9jdXMge1xuICAgICAgb3V0bGluZTogbm9uZTtcbiAgICAgIGJveC1zaGFkb3c6IG5vbmU7IH1cbiAgICAuZmQtYnV0dG9uLS1saW5rOmhvdmVyOjphZnRlciwgLmZkLWJ1dHRvbi0tbGluazpmb2N1czo6YWZ0ZXIsIC5mZC1idXR0b24tLWxpbms6YWN0aXZlOjphZnRlciwgLmZkLWJ1dHRvbi0tbGlua1thcmlhLXNlbGVjdGVkPVwidHJ1ZVwiXTo6YWZ0ZXIsIC5mZC1idXR0b24tLWxpbmsuaXMtc2VsZWN0ZWQ6OmFmdGVyLCAuZmQtYnV0dG9uLS1saW5rW2FyaWEtcHJlc3NlZD1cInRydWVcIl06OmFmdGVyLCAuZmQtYnV0dG9uLS1saW5rLmlzLXByZXNzZWQ6OmFmdGVyIHtcbiAgICAgIGJvcmRlci1ib3R0b20tY29sb3I6ICMwMDljZGY7IH1cbiAgICAuZmQtYnV0dG9uLS1saW5rW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdOjphZnRlciwgLmZkLWJ1dHRvbi0tbGluay5pcy1kaXNhYmxlZDo6YWZ0ZXIsIC5mZC1idXR0b24tLWxpbms6ZGlzYWJsZWQ6OmFmdGVyIHtcbiAgICAgIGRpc3BsYXk6IG5vbmU7IH1cbiAgLmZkLWJ1dHRvbiA+ICosIC5mZC1tb2RhbF9fYnV0dG9uLXByaW1hcnkgPiAqLCAuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnkgPiAqIHtcbiAgICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gICAgdmVydGljYWwtYWxpZ246IHRvcDtcbiAgICBtYXJnaW4tcmlnaHQ6IDEycHg7XG4gICAgbWFyZ2luLXRvcDogMTNweDsgfVxuICAgIC5mZC1idXR0b24tLWljb24gPiAqIHtcbiAgICAgIG1hcmdpbi1sZWZ0OiBhdXRvO1xuICAgICAgbWFyZ2luLXJpZ2h0OiBhdXRvOyB9XG4gICAgLmZkLWJ1dHRvbi0tc21hbGwgPiAqIHtcbiAgICAgIG1hcmdpbi10b3A6IDExcHg7IH1cbiAgICAuZmQtYnV0dG9uLS1sYXJnZSA+ICosIC5mZC1idXR0b24tLWFjdGlvbi1iYXIgPiAqIHtcbiAgICAgIG1hcmdpbi10b3A6IDIycHg7IH1cbiAgLmZkLWJ1dHRvbi0tYWN0aW9uLWJhciB7XG4gICAgZm9udC1zaXplOiAwLjc1cmVtO1xuICAgIGxpbmUtaGVpZ2h0OiAxLjMzMzM0O1xuICAgIGZvbnQtd2VpZ2h0OiA3MDA7XG4gICAgdGV4dC10cmFuc2Zvcm06IHVwcGVyY2FzZTtcbiAgICBtaW4td2lkdGg6IDEzNXB4O1xuICAgIGxpbmUtaGVpZ2h0OiAzMnB4O1xuICAgIHZlcnRpY2FsLWFsaWduOiBtaWRkbGU7IH1cbiAgICAuZmQtYnV0dG9uLS1hY3Rpb24tYmFyID4gKiB7XG4gICAgICBkaXNwbGF5OiBibG9jayAhaW1wb3J0YW50O1xuICAgICAgbWFyZ2luLXRvcDogMTJweDtcbiAgICAgIG1hcmdpbi1sZWZ0OiBhdXRvO1xuICAgICAgbWFyZ2luLXJpZ2h0OiBhdXRvOyB9XG5cbi8qIVxuLmZkLWRyb3Bkb3duKygpXG4gICAgLmZkLWRyb3Bkb3duX19jb250cm9sKyhbZGlzYWJsZWRdKVxuICAgIC5mZC1kcm9wZG93bl9fbWVudSsoKVxuKi9cbi5mZC1kcm9wZG93biB7XG4gIGZvbnQtc2l6ZTogMXJlbTtcbiAgbGluZS1oZWlnaHQ6IDEuNTtcbiAgY29sb3I6ICMyMTI2MmM7XG4gIHBvc2l0aW9uOiByZWxhdGl2ZTtcbiAgZGlzcGxheTogaW5saW5lLWJsb2NrOyB9XG4gIC5mZC1kcm9wZG93bl9fY29udHJvbCB7XG4gICAgbWFyZ2luOiAwO1xuICAgIHBhZGRpbmc6IDA7XG4gICAgZm9udC1zbW9vdGhpbmc6IGFudGlhbGlhc2VkO1xuICAgIGFwcGVhcmFuY2U6IG5vbmU7XG4gICAgb3V0bGluZTogMDtcbiAgICBib3JkZXI6IDA7XG4gICAgZGlzcGxheTogaW5saW5lLWJsb2NrO1xuICAgIHRleHQtZGVjb3JhdGlvbjogbm9uZTtcbiAgICBjdXJzb3I6IHBvaW50ZXI7XG4gICAgdXNlci1zZWxlY3Q6IG5vbmU7XG4gICAgdmVydGljYWwtYWxpZ246IG1pZGRsZTtcbiAgICB3aGl0ZS1zcGFjZTogbm93cmFwO1xuICAgIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50O1xuICAgIGZvbnQtc2l6ZTogMXJlbTtcbiAgICBsaW5lLWhlaWdodDogMS41O1xuICAgIGNvbG9yOiAjMjEyNjJjO1xuICAgIGZvbnQtc2l6ZTogMXJlbTtcbiAgICBsaW5lLWhlaWdodDogMS41O1xuICAgIGZvbnQtZmFtaWx5OiAnT3BlbiBTYW5zJywgc2Fucy1zZXJpZjtcbiAgICBmb250LXdlaWdodDogNDAwO1xuICAgIGFwcGVhcmFuY2U6IG5vbmU7XG4gICAgLXdlYmtpdC1hcHBlYXJhbmNlOiB0ZXh0ZmllbGQ7XG4gICAgLW1vei1hcHBlYXJhbmNlOiB0ZXh0ZmllbGQ7XG4gICAgZm9udC1zaXplOiBpbmhlcml0O1xuICAgIGJveC1zaXppbmc6IGJvcmRlci1ib3g7XG4gICAgb3V0bGluZTogbm9uZTtcbiAgICBib3JkZXItc3R5bGU6IHNvbGlkO1xuICAgIGJvcmRlci13aWR0aDogMXB4O1xuICAgIGJvcmRlci1jb2xvcjogI2NjZGFlYjtcbiAgICBib3JkZXItcmFkaXVzOiAwO1xuICAgIGNvbG9yOiAjMjEyNjJjO1xuICAgIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50O1xuICAgIHRyYW5zaXRpb246IGJvcmRlci1jb2xvciAwLjEyNXM7XG4gICAgaGVpZ2h0OiA1MnB4O1xuICAgIHBhZGRpbmctbGVmdDogMTZweDtcbiAgICBwYWRkaW5nLXJpZ2h0OiAxNnB4O1xuICAgIGFwcGVhcmFuY2U6IG5vbmU7XG4gICAgLW1vei1hcHBlYXJhbmNlOiBub25lO1xuICAgIGJhY2tncm91bmQtaW1hZ2U6IHVybChkYXRhOmltYWdlL3N2Zyt4bWw7YmFzZTY0LFBITjJaeUI0Yld4dWN6MGlhSFIwY0RvdkwzZDNkeTUzTXk1dmNtY3ZNakF3TUM5emRtY2lJSGRwWkhSb1BTSXhNaUlnYUdWcFoyaDBQU0k1SWo0OGNHRjBhQ0JtYVd4c0xYSjFiR1U5SW1WMlpXNXZaR1FpSUdacGJHdzlJaU15TVRJMk1rTWlJR1E5SWsweE1TNDVNelVnTVM0ME56Vk1OaTR4T0RnZ055NDVNamRoTGpJMk5DNHlOalFnTUNBd0lERXRMak0zT0NBd1RDNHdOalVnTVM0ME56VmhMakl6Tmk0eU16WWdNQ0F3SURFZ0xqQXlOaTB1TXpRelRERXVNemd4TGpBMU9HRXVNalV6TGpJMU15QXdJREFnTVNBdU1UWXpMUzR3TlRsTU1TNDFOak1nTUdFdU1qVXlMakkxTWlBd0lEQWdNU0F1TVRjeExqQTROV3cwTGpJMk5TQTBMamc0SURRdU1qWTNMVFF1T0RoaExqSTFNaTR5TlRJZ01DQXdJREVnTGpNMU1pMHVNREkzYkRFdU1qa3hJREV1TURjMFl5NHdOUzR3TkRJdU1EZ3hMakV3TWk0d09EWXVNVFkyWVM0eU16WXVNak0ySURBZ01DQXhMUzR3Tmk0eE56ZDZJaTgrUEM5emRtYyspO1xuICAgIGJhY2tncm91bmQtcmVwZWF0OiBuby1yZXBlYXQ7XG4gICAgYmFja2dyb3VuZC1wb3NpdGlvbjogY2FsYygxMDAlIC0gMTJweCkgY2VudGVyO1xuICAgIHBhZGRpbmctcmlnaHQ6IDQ0cHg7XG4gICAgcG9zaXRpb246IHJlbGF0aXZlO1xuICAgIGxpbmUtaGVpZ2h0OiA1MnB4OyB9XG4gICAgLmZkLWRyb3Bkb3duX19jb250cm9sOmZvY3VzLCAuZmQtZHJvcGRvd25fX2NvbnRyb2w6aG92ZXIge1xuICAgICAgYm9yZGVyLWNvbG9yOiAjMDA5Y2RmOyB9XG4gICAgLmZkLWRyb3Bkb3duX19jb250cm9sLmlzLWludmFsaWQge1xuICAgICAgYm9yZGVyLWNvbG9yOiAjZGYxOTE5OyB9XG4gICAgLmZkLWRyb3Bkb3duX19jb250cm9sLmlzLXZhbGlkIHtcbiAgICAgIGJvcmRlci1jb2xvcjogIzYxYmYzMzsgfVxuICAgIC5mZC1kcm9wZG93bl9fY29udHJvbC5pcy13YXJuaW5nIHtcbiAgICAgIGJvcmRlci1jb2xvcjogI2U5NzMyNjsgfVxuICAgIC5mZC1kcm9wZG93bl9fY29udHJvbDpkaXNhYmxlZCwgLmZkLWRyb3Bkb3duX19jb250cm9sW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLCAuZmQtZHJvcGRvd25fX2NvbnRyb2wuaXMtZGlzYWJsZWQge1xuICAgICAgY3Vyc29yOiBub3QtYWxsb3dlZDtcbiAgICAgIGNvbG9yOiAjNjM3NThiO1xuICAgICAgYm9yZGVyLWNvbG9yOiAjZTRlNGU0O1xuICAgICAgYmFja2dyb3VuZC1jb2xvcjogI2Y5ZmJmYzsgfVxuICAgIC5mZC1kcm9wZG93bl9fY29udHJvbFtyZWFkb25seV0sIC5mZC1kcm9wZG93bl9fY29udHJvbC5pcy1yZWFkb25seSB7XG4gICAgICBjb2xvcjogIzIxMjYyYztcbiAgICAgIGJvcmRlci1jb2xvcjogI2U0ZTRlNDtcbiAgICAgIGJvcmRlci13aWR0aDogMCAwIDFweDsgfVxuICAgIC5mZC1kcm9wZG93bl9fY29udHJvbDpmb2N1cywgLmZkLWRyb3Bkb3duX19jb250cm9sOmhvdmVyIHtcbiAgICAgIGJhY2tncm91bmQtaW1hZ2U6IHVybChkYXRhOmltYWdlL3N2Zyt4bWw7YmFzZTY0LFBITjJaeUI0Yld4dWN6MGlhSFIwY0RvdkwzZDNkeTUzTXk1dmNtY3ZNakF3TUM5emRtY2lJSGRwWkhSb1BTSXhNaUlnYUdWcFoyaDBQU0k1SWo0OGNHRjBhQ0JtYVd4c0xYSjFiR1U5SW1WMlpXNXZaR1FpSUdacGJHdzlJaU13TURoR1JESWlJR1E5SWsweE1TNDVNelVnTVM0ME56Vk1OaTR4T0RnZ055NDVNamRoTGpJMk5DNHlOalFnTUNBd0lERXRMak0zT0NBd1RDNHdOalVnTVM0ME56VmhMakl6Tmk0eU16WWdNQ0F3SURFZ0xqQXlOaTB1TXpRelRERXVNemd4TGpBMU9HRXVNalV6TGpJMU15QXdJREFnTVNBdU1UWXpMUzR3TlRsTU1TNDFOak1nTUdFdU1qVXlMakkxTWlBd0lEQWdNU0F1TVRjeExqQTROV3cwTGpJMk5TQTBMamc0SURRdU1qWTNMVFF1T0RoaExqSTFNaTR5TlRJZ01DQXdJREVnTGpNMU1pMHVNREkzYkRFdU1qa3hJREV1TURjMFl5NHdOUzR3TkRJdU1EZ3hMakV3TWk0d09EWXVNVFkyWVM0eU16WXVNak0ySURBZ01DQXhMUzR3Tmk0eE56ZDZJaTgrUEM5emRtYyspOyB9XG4gICAgLmZkLWRyb3Bkb3duX19jb250cm9sW2FyaWEtZXhwYW5kZWQ9XCJ0cnVlXCJdLCAuZmQtZHJvcGRvd25fX2NvbnRyb2wuaXMtZXhwYW5kZWQge1xuICAgICAgYmFja2dyb3VuZC1pbWFnZTogdXJsKGRhdGE6aW1hZ2Uvc3ZnK3htbDtiYXNlNjQsUEhOMlp5QjRiV3h1Y3owaWFIUjBjRG92TDNkM2R5NTNNeTV2Y21jdk1qQXdNQzl6ZG1jaUlIZHBaSFJvUFNJeE1pSWdhR1ZwWjJoMFBTSTRJajQ4Y0dGMGFDQm1hV3hzTFhKMWJHVTlJbVYyWlc1dlpHUWlJR1pwYkd3OUlpTXdNRGhHUkRJaUlHUTlJazB4TVM0NU16VWdOaTQxTTB3MkxqRTRPQzR4TURSaExqSTJOQzR5TmpRZ01DQXdJREF0TGpNM09DQXdUQzR3TmpVZ05pNDFNMkV1TWpRdU1qUWdNQ0F3SURBdExqQTJNUzR4TnpjdU1qTTNMakl6TnlBd0lEQWdNQ0F1TURnM0xqRTJOV3d4TGpJNUlERXVNRGN4WVM0eU5UZ3VNalU0SURBZ01DQXdJQzR4TmpNdU1EVTRUREV1TlRZeklEaGhMakkxTWk0eU5USWdNQ0F3SURBZ0xqRTNNUzB1TURnMWJEUXVNalkxTFRRdU9EWXhJRFF1TWpZM0lEUXVPRFl4WXk0d05ETXVNRFE1TGpFd05DNHdPQzR4Tnk0d09EVmhMakkyTVM0eU5qRWdNQ0F3SURBZ0xqRTRNaTB1TURVM2JERXVNamt4TFRFdU1EY3hZUzR5TXpZdU1qTTJJREFnTUNBd0lDNHdNall0TGpNME1ub2lMejQ4TDNOMlp6ND0pOyB9XG4gICAgLmZkLWRyb3Bkb3duX19jb250cm9sW2Rpc2FibGVkXSwgLmZkLWRyb3Bkb3duX19jb250cm9sW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLCAuZmQtZHJvcGRvd25fX2NvbnRyb2wuaXMtZGlzYWJsZWQge1xuICAgICAgYmFja2dyb3VuZC1pbWFnZTogdXJsKGRhdGE6aW1hZ2Uvc3ZnK3htbDtiYXNlNjQsUEhOMlp5QjRiV3h1Y3owaWFIUjBjRG92TDNkM2R5NTNNeTV2Y21jdk1qQXdNQzl6ZG1jaUlIZHBaSFJvUFNJeE1pSWdhR1ZwWjJoMFBTSTVJajQ4Y0dGMGFDQm1hV3hzTFhKMWJHVTlJbVYyWlc1dlpHUWlJR1pwYkd3OUlpTTJNemMxT0VJaUlHUTlJazB4TVM0NU16VWdNUzQwTnpWTU5pNHhPRGdnTnk0NU1qZGhMakkyTkM0eU5qUWdNQ0F3SURFdExqTTNPQ0F3VEM0d05qVWdNUzQwTnpWaExqSXpOUzR5TXpVZ01DQXdJREVnTGpBeU5pMHVNelF6VERFdU16Z3hMakExT0dFdU1qVXpMakkxTXlBd0lEQWdNU0F1TVRZekxTNHdOVGxNTVM0MU5qTWdNR0V1TWpVeUxqSTFNaUF3SURBZ01TQXVNVGN4TGpBNE5XdzBMakkyTlNBMExqZzRJRFF1TWpZM0xUUXVPRGhoTGpJMU1pNHlOVElnTUNBd0lERWdMak0xTWkwdU1ESTNiREV1TWpreElERXVNRGMwWXk0d05TNHdOREl1TURneExqRXdNaTR3T0RZdU1UWTJZUzR5TXpRdU1qTTBJREFnTUNBeExTNHdOaTR4TnpkNklpOCtQQzl6ZG1jKyk7IH1cbiAgICAuZmQtZHJvcGRvd25fX2NvbnRyb2xbYXJpYS1leHBhbmRlZD1cInRydWVcIl0sIC5mZC1kcm9wZG93bl9fY29udHJvbC5pcy1leHBhbmRlZCB7XG4gICAgICBib3JkZXItY29sb3I6ICMwMDljZGY7XG4gICAgICB6LWluZGV4OiAzO1xuICAgICAgYm94LXNoYWRvdzogMCAwIDRweCAxcHggcmdiYSgxMzgsIDE0MywgMTYxLCAwLjIpOyB9XG4gICAgLmZkLWRyb3Bkb3duX19jb250cm9sLS1uby1ib3JkZXIge1xuICAgICAgYm9yZGVyLWNvbG9yOiB0cmFuc3BhcmVudDsgfVxuICAgICAgLmZkLWRyb3Bkb3duX19jb250cm9sLS1uby1ib3JkZXJbYXJpYS1kaXNhYmxlZD1cInRydWVcIl0sIC5mZC1kcm9wZG93bl9fY29udHJvbC0tbm8tYm9yZGVyLmlzLWRpc2FibGVkLCAuZmQtZHJvcGRvd25fX2NvbnRyb2wtLW5vLWJvcmRlcjpkaXNhYmxlZCB7XG4gICAgICAgIGJvcmRlci1jb2xvcjogdHJhbnNwYXJlbnQ7IH1cbiAgLmZkLWRyb3Bkb3duX19pY29uIHtcbiAgICBtYXJnaW4tcmlnaHQ6IDEycHg7XG4gICAgdmVydGljYWwtYWxpZ246IG1pZGRsZTtcbiAgICB0cmFuc2Zvcm06IHRyYW5zbGF0ZVkoLTJweCk7IH1cbiAgLmZkLWRyb3Bkb3duX19tZW51LCAuZmQtZHJvcGRvd25fX29wdGlvbnMge1xuICAgIG1hcmdpbi1sZWZ0OiAwO1xuICAgIHBhZGRpbmctbGVmdDogMDtcbiAgICBsaXN0LXN0eWxlOiBub25lO1xuICAgIG1pbi13aWR0aDogMTAwJTtcbiAgICBib3JkZXI6IHNvbGlkIDFweCAjY2NkYWViO1xuICAgIGJhY2tncm91bmQ6ICNmZmZmZmY7XG4gICAgcG9zaXRpb246IGFic29sdXRlO1xuICAgIHdoaXRlLXNwYWNlOiBub3dyYXA7XG4gICAgei1pbmRleDogMjtcbiAgICB0cmFuc2Zvcm06IHRyYW5zbGF0ZVkoLTFweCk7XG4gICAgYm94LXNoYWRvdzogMCAwIDRweCAxcHggcmdiYSgxMzgsIDE0MywgMTYxLCAwLjIpO1xuICAgIG9wYWNpdHk6IDE7XG4gICAgdmlzaWJpbGl0eTogdmlzaWJsZTtcbiAgICB0cmFuc2l0aW9uOiBvcGFjaXR5IDAuMTI1cyBlYXNlLWluOyB9XG4gICAgLmZkLWRyb3Bkb3duX19tZW51W2FyaWEtaGlkZGVuPVwidHJ1ZVwiXSwgLmZkLWRyb3Bkb3duX19tZW51LmlzLWhpZGRlbiwgLmZkLWRyb3Bkb3duX19vcHRpb25zW2FyaWEtaGlkZGVuPVwidHJ1ZVwiXSwgLmZkLWRyb3Bkb3duX19vcHRpb25zLmlzLWhpZGRlbiB7XG4gICAgICBvcGFjaXR5OiAwO1xuICAgICAgdmlzaWJpbGl0eTogaGlkZGVuOyB9XG4gIC5mZC1kcm9wZG93bl9fZ3JvdXAge1xuICAgIG1hcmdpbi1sZWZ0OiAwO1xuICAgIHBhZGRpbmctbGVmdDogMDtcbiAgICBsaXN0LXN0eWxlOiBub25lOyB9XG4gIC5mZC1kcm9wZG93bl9faXRlbSwgLmZkLWRyb3Bkb3duX19vcHRpb24ge1xuICAgIGZvbnQtc2l6ZTogMXJlbTtcbiAgICBsaW5lLWhlaWdodDogMS41O1xuICAgIGNvbG9yOiAjMjEyNjJjO1xuICAgIGZvbnQtc2l6ZTogMC44NzVyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuNDI4NTg7XG4gICAgZm9udC1mYW1pbHk6ICdPcGVuIFNhbnMnLCBzYW5zLXNlcmlmO1xuICAgIGZvbnQtd2VpZ2h0OiA0MDA7XG4gICAgZGlzcGxheTogYmxvY2s7XG4gICAgcGFkZGluZy1sZWZ0OiAwO1xuICAgIGxpc3Qtc3R5bGU6IG5vbmU7XG4gICAgcGFkZGluZzogMTJweCAxNnB4OyB9XG4gICAgLmZkLWRyb3Bkb3duX19pdGVtOmhvdmVyLCAuZmQtZHJvcGRvd25fX29wdGlvbjpob3ZlciB7XG4gICAgICBjb2xvcjogI2ZmZmZmZjtcbiAgICAgIGJhY2tncm91bmQtY29sb3I6ICMwMDhhYzY7XG4gICAgICB0ZXh0LWRlY29yYXRpb246IG5vbmU7IH1cbiAgLmZkLWRyb3Bkb3duX19zZXBhcmF0b3Ige1xuICAgIGZvbnQtc2l6ZTogMXJlbTtcbiAgICBsaW5lLWhlaWdodDogMS41O1xuICAgIGNvbG9yOiAjMjEyNjJjO1xuICAgIGZvbnQtc2l6ZTogMC43NXJlbTtcbiAgICBsaW5lLWhlaWdodDogMS4zMzMzNDtcbiAgICBmb250LWZhbWlseTogJ09wZW4gU2FucycsIHNhbnMtc2VyaWY7XG4gICAgZm9udC13ZWlnaHQ6IDQwMDtcbiAgICB0ZXh0LXRyYW5zZm9ybTogbm9uZTtcbiAgICBkaXNwbGF5OiBibG9jaztcbiAgICBjb2xvcjogIzdmOTBhNDtcbiAgICBwYWRkaW5nOiAxMnB4IDE2cHg7XG4gICAgcGFkZGluZy10b3A6IDE2cHg7XG4gICAgYm9yZGVyLXRvcDogc29saWQgMXB4ICNjY2RhZWI7IH1cblxuLyohXG4uZmQtdG9vbGJhcisoKVxuICAgIC5mZC10b29sYmFyX19yb3dcbiAgICAgICAgLmZkLXRvb2xiYXJfX2dyb3VwXG4gICAgICAgIC5mZC10b29sYmFyX19pdGVtXG4qL1xuLmZkLXRvb2xiYXIge1xuICBmb250LXNpemU6IDFyZW07XG4gIGxpbmUtaGVpZ2h0OiAxLjU7XG4gIGNvbG9yOiAjMjEyNjJjO1xuICBtaW4taGVpZ2h0OiA1MnB4O1xuICBiYWNrZ3JvdW5kLWNvbG9yOiAjZjBmNWZmO1xuICBib3JkZXItY29sb3I6ICNjY2RhZWI7XG4gIGJvcmRlci1zdHlsZTogc29saWQ7XG4gIGJvcmRlci13aWR0aDogMXB4IDA7XG4gIGRpc3BsYXk6IGZsZXg7XG4gIGZsZXgtd3JhcDogd3JhcDsgfVxuICAuZmQtdG9vbGJhciBbcm9sZT1cInNlcGFyYXRvclwiXSB7XG4gICAgZGlzcGxheTogaW5saW5lLWJsb2NrO1xuICAgIHZlcnRpY2FsLWFsaWduOiBtaWRkbGU7XG4gICAgbWF4LXdpZHRoOiAxcHg7XG4gICAgaGVpZ2h0OiA1MnB4O1xuICAgIGJvcmRlci1sZWZ0OiBzb2xpZCAxcHggI2NjZGFlYjsgfVxuICAuZmQtdG9vbGJhcl9fZ3JvdXAge1xuICAgIG1pbi1oZWlnaHQ6IDUycHg7XG4gICAgb3ZlcmZsb3c6IHZpc2libGU7XG4gICAgdHJhbnNpdGlvbjogYWxsIDAuMTVzIGVhc2UtaW47XG4gICAgd2lkdGg6IDEwMCU7IH1cbiAgICAuZmQtdG9vbGJhcl9fZ3JvdXAtLXZpZXcge1xuICAgICAgb3JkZXI6IDU7XG4gICAgICBkaXNwbGF5OiBmbGV4O1xuICAgICAgYWxpZ24taXRlbXM6IGNlbnRlcjtcbiAgICAgIGJvcmRlci10b3A6IHNvbGlkIDFweCAjY2NkYWViOyB9XG4gICAgICBAbWVkaWEgKG1pbi13aWR0aDogODAwcHgpIHtcbiAgICAgICAgLmZkLXRvb2xiYXJfX2dyb3VwLS12aWV3IHtcbiAgICAgICAgICBib3JkZXItdG9wOiBub25lOyB9IH1cbiAgICAuZmQtdG9vbGJhcl9fZ3JvdXAtLWZpbHRlciB7XG4gICAgICBkaXNwbGF5OiBmbGV4OyB9XG4gICAgLmZkLXRvb2xiYXJfX2dyb3VwLS1maWx0ZXItb3B0aW9ucyB7XG4gICAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjZmZmZmZmO1xuICAgICAgYm9yZGVyLXRvcDogc29saWQgMXB4ICNjY2RhZWI7IH1cbiAgICAuZmQtdG9vbGJhcl9fZ3JvdXAtLWFwcGxpZWQtZmlsdGVycyB7XG4gICAgICBib3JkZXItdG9wOiBzb2xpZCAxcHggI2NjZGFlYjtcbiAgICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgICBhbGlnbi1pdGVtczogY2VudGVyOyB9XG4gICAgQG1lZGlhIChtaW4td2lkdGg6IDgwMHB4KSB7XG4gICAgICAuZmQtdG9vbGJhcl9fZ3JvdXAtLWZpbHRlciB7XG4gICAgICAgIHdpZHRoOiBhdXRvOyB9XG4gICAgICAuZmQtdG9vbGJhcl9fZ3JvdXAtLXZpZXcge1xuICAgICAgICB3aWR0aDogYXV0bztcbiAgICAgICAgb3JkZXI6IDA7XG4gICAgICAgIG1hcmdpbi1sZWZ0OiBhdXRvOyB9XG4gICAgICAuZmQtdG9vbGJhcl9fZ3JvdXAtLXZpZXctYXMge1xuICAgICAgICBkaXNwbGF5OiBibG9jaztcbiAgICAgICAgbWFyZ2luLWxlZnQ6IGF1dG87IH0gfVxuICAgIC5mZC10b29sYmFyX19ncm91cFthcmlhLWhpZGRlbj1cInRydWVcIl0ge1xuICAgICAgZGlzcGxheTogbm9uZTtcbiAgICAgIGJvcmRlcjogbm9uZTsgfVxuICAuZmQtdG9vbGJhcl9fcGFnaW5hdGlvbiB7XG4gICAgbWFyZ2luOiAwIGF1dG87IH1cbiAgICBAbWVkaWEgKG1pbi13aWR0aDogODAwcHgpIHtcbiAgICAgIC5mZC10b29sYmFyX19wYWdpbmF0aW9uIHtcbiAgICAgICAgbWFyZ2luLXJpZ2h0OiAyMHB4OyB9IH1cbiAgLmZkLXRvb2xiYXJfX3ZpZXctYXMge1xuICAgIGRpc3BsYXk6IG5vbmU7IH1cbiAgICBAbWVkaWEgKG1pbi13aWR0aDogODAwcHgpIHtcbiAgICAgIC5mZC10b29sYmFyX192aWV3LWFzIHtcbiAgICAgICAgZGlzcGxheTogYmxvY2s7XG4gICAgICAgIGJvcmRlci1sZWZ0OiBzb2xpZCAxcHggI2NjZGFlYjsgfSB9XG4gIC5mZC10b29sYmFyX19idXR0b25bYXJpYS1leHBhbmRlZD1cInRydWVcIl0ge1xuICAgIGJhY2tncm91bmQtY29sb3I6ICNmZmZmZmY7IH1cbiAgLmZkLXRvb2xiYXJfX2FwcGxpZWQtZmlsdGVyLWxpc3Qge1xuICAgIG1hcmdpbi1sZWZ0OiAyMHB4O1xuICAgIGxpc3Qtc3R5bGU6IG5vbmU7XG4gICAgbWFyZ2luLWJvdHRvbTogMDtcbiAgICBmbGV4LXdyYXA6IHdyYXA7IH1cbiAgICBAbWVkaWEgKG1pbi13aWR0aDogMzIwcHgpIHtcbiAgICAgIC5mZC10b29sYmFyX19hcHBsaWVkLWZpbHRlci1saXN0IHtcbiAgICAgICAgZGlzcGxheTogaW5saW5lLWZsZXg7XG4gICAgICAgIGFsaWduLWl0ZW1zOiBjZW50ZXI7IH0gfVxuICAuZmQtdG9vbGJhcl9fYXBwbGllZC1maWx0ZXItaXRlbSB7XG4gICAgZm9udC1zaXplOiAwLjc1cmVtO1xuICAgIGxpbmUtaGVpZ2h0OiAxLjMzMzM0O1xuICAgIGZvbnQtZmFtaWx5OiAnT3BlbiBTYW5zJywgc2Fucy1zZXJpZjtcbiAgICBmb250LXdlaWdodDogNDAwO1xuICAgIHRleHQtdHJhbnNmb3JtOiBub25lO1xuICAgIGxpbmUtaGVpZ2h0OiBpbmhlcml0O1xuICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgYWxpZ24taXRlbXM6IGNlbnRlcjtcbiAgICBtYXJnaW4tcmlnaHQ6IDIwcHg7IH1cbiAgICBAbWVkaWEgKG1pbi13aWR0aDogMzIwcHgpIHtcbiAgICAgIC5mZC10b29sYmFyX19hcHBsaWVkLWZpbHRlci1pdGVtIHtcbiAgICAgICAgZGlzcGxheTogaW5saW5lLWZsZXg7IH0gfVxuICAgIC5mZC10b29sYmFyX19hcHBsaWVkLWZpbHRlci1pdGVtOjphZnRlciB7XG4gICAgICBjb250ZW50OiBcIuKAolwiOyB9XG4gICAgLmZkLXRvb2xiYXJfX2FwcGxpZWQtZmlsdGVyLWl0ZW06bGFzdC1jaGlsZDo6YWZ0ZXIge1xuICAgICAgZGlzcGxheTogbm9uZTsgfVxuICAuZmQtdG9vbGJhcl9fYXBwbGllZC1maWx0ZXItY2xlYXIge1xuICAgIGZvbnQtc2l6ZTogMC43NXJlbTtcbiAgICBsaW5lLWhlaWdodDogMS4zMzMzNDtcbiAgICBmb250LWZhbWlseTogJ09wZW4gU2FucycsIHNhbnMtc2VyaWY7XG4gICAgZm9udC13ZWlnaHQ6IDYwMDtcbiAgICB0ZXh0LXRyYW5zZm9ybTogdXBwZXJjYXNlOyB9XG5cbi8qIVxuLmZkLWJ1dHRvbisoICgtLXNtYWxsIHwgLS1sYXJnZSksIC0taWNvbiwgLS10ZXh0LCAtLWxpbmssIC0tYWN0aW9uLWJhcikrKCAoLmlzLWRpc2FibGVkIHwgW2FyaWEtZGlzYWJsZWQ9dHJ1ZV0pIHwgKC5pcy1zZWxlY3RlZCB8IFthcmlhLXNlbGVjdGVkPXRydWVdIHwgKC5pcy1wcmVzc2VkIHwgW2FyaWEtcHJlc3NlZD10cnVlXSkpXG4qL1xuLmZkLWJ1dHRvbiwgLmZkLW1vZGFsX19idXR0b24tcHJpbWFyeSwgLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5IHtcbiAgbWFyZ2luOiAwO1xuICBwYWRkaW5nOiAwO1xuICBmb250LXNtb290aGluZzogYW50aWFsaWFzZWQ7XG4gIGFwcGVhcmFuY2U6IG5vbmU7XG4gIG91dGxpbmU6IDA7XG4gIGJvcmRlcjogMDtcbiAgZGlzcGxheTogaW5saW5lLWJsb2NrO1xuICB0ZXh0LWRlY29yYXRpb246IG5vbmU7XG4gIGN1cnNvcjogcG9pbnRlcjtcbiAgdXNlci1zZWxlY3Q6IG5vbmU7XG4gIHZlcnRpY2FsLWFsaWduOiBtaWRkbGU7XG4gIHdoaXRlLXNwYWNlOiBub3dyYXA7XG4gIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50O1xuICBmb250LXNpemU6IDEuMTI1cmVtO1xuICBsaW5lLWhlaWdodDogMS4zMzMzNDtcbiAgZm9udC1mYW1pbHk6IFJvYm90bywgc2Fucy1zZXJpZjtcbiAgZm9udC13ZWlnaHQ6IDUwMDtcbiAgZGlzcGxheTogaW5saW5lLWJsb2NrO1xuICBiYWNrZ3JvdW5kLWNvbG9yOiAjMDA5Y2RmO1xuICB0cmFuc2l0aW9uOiBiYWNrZ3JvdW5kLWNvbG9yIDAuMTI1cyBlYXNlLWluO1xuICBjb2xvcjogI2Y2ZjhmOTtcbiAgbWF4LWhlaWdodDogNTJweDtcbiAgaGVpZ2h0OiA1MnB4O1xuICBsaW5lLWhlaWdodDogNTJweDtcbiAgcGFkZGluZy1sZWZ0OiAyMHB4O1xuICBwYWRkaW5nLXJpZ2h0OiAyMHB4O1xuICB0ZXh0LWFsaWduOiBjZW50ZXI7XG4gIHRleHQtdHJhbnNmb3JtOiB1cHBlcmNhc2U7XG4gIGJvcmRlci1yYWRpdXM6IDA7IH1cbiAgLmZkLWJ1dHRvbi0tc21hbGwge1xuICAgIGZvbnQtc2l6ZTogMXJlbTtcbiAgICBsaW5lLWhlaWdodDogMS41O1xuICAgIGZvbnQtd2VpZ2h0OiA0MDA7XG4gICAgZm9udC13ZWlnaHQ6IDYwMDtcbiAgICBtYXgtaGVpZ2h0OiA0MHB4O1xuICAgIGhlaWdodDogNDBweDtcbiAgICBsaW5lLWhlaWdodDogNDBweDtcbiAgICBwYWRkaW5nLWxlZnQ6IDE2cHg7XG4gICAgcGFkZGluZy1yaWdodDogMTZweDsgfVxuICAuZmQtYnV0dG9uLS1sYXJnZSwgLmZkLWJ1dHRvbi0tYWN0aW9uLWJhciB7XG4gICAgZm9udC1zaXplOiAxLjI1cmVtO1xuICAgIGxpbmUtaGVpZ2h0OiAxLjQ7XG4gICAgZm9udC13ZWlnaHQ6IDYwMDtcbiAgICBtYXgtaGVpZ2h0OiA3NnB4O1xuICAgIGhlaWdodDogNzZweDtcbiAgICBsaW5lLWhlaWdodDogNzZweDtcbiAgICBwYWRkaW5nLWxlZnQ6IDI4cHg7XG4gICAgcGFkZGluZy1yaWdodDogMjhweDsgfVxuICAuZmQtYnV0dG9uOmhvdmVyLCAuZmQtbW9kYWxfX2J1dHRvbi1wcmltYXJ5OmhvdmVyLCAuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnk6aG92ZXIge1xuICAgIGJhY2tncm91bmQtY29sb3I6ICMwMDhhYzY7XG4gICAgY29sb3I6ICNmNmY4Zjk7XG4gICAgdGV4dC1kZWNvcmF0aW9uOiBub25lOyB9XG4gIC5mZC1idXR0b246Zm9jdXMsIC5mZC1tb2RhbF9fYnV0dG9uLXByaW1hcnk6Zm9jdXMsIC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeTpmb2N1cyB7XG4gICAgY29sb3I6ICNmNmY4Zjk7XG4gICAgYm94LXNoYWRvdzogMCAwIDRweCAxcHggIzhhOGZhMTtcbiAgICBvdXRsaW5lOiBzb2xpZCAycHggIzJkYzBmZjsgfVxuICAuZmQtYnV0dG9uOmFjdGl2ZSwgLmZkLW1vZGFsX19idXR0b24tcHJpbWFyeTphY3RpdmUsIC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeTphY3RpdmUsIC5mZC1idXR0b24uaXMtYWN0aXZlLCAuaXMtYWN0aXZlLmZkLW1vZGFsX19idXR0b24tcHJpbWFyeSwgLmlzLWFjdGl2ZS5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvblthcmlhLXNlbGVjdGVkPVwidHJ1ZVwiXSwgW2FyaWEtc2VsZWN0ZWQ9XCJ0cnVlXCJdLmZkLW1vZGFsX19idXR0b24tcHJpbWFyeSwgW2FyaWEtc2VsZWN0ZWQ9XCJ0cnVlXCJdLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uLmlzLXNlbGVjdGVkLCAuaXMtc2VsZWN0ZWQuZmQtbW9kYWxfX2J1dHRvbi1wcmltYXJ5LCAuaXMtc2VsZWN0ZWQuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b25bYXJpYS1wcmVzc2VkPVwidHJ1ZVwiXSwgW2FyaWEtcHJlc3NlZD1cInRydWVcIl0uZmQtbW9kYWxfX2J1dHRvbi1wcmltYXJ5LCBbYXJpYS1wcmVzc2VkPVwidHJ1ZVwiXS5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvbi5pcy1wcmVzc2VkLCAuaXMtcHJlc3NlZC5mZC1tb2RhbF9fYnV0dG9uLXByaW1hcnksIC5pcy1wcmVzc2VkLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5IHtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjMDA3OGFjO1xuICAgIGNvbG9yOiAjZjZmOGY5OyB9XG4gIC5mZC1idXR0b25bYXJpYS1kaXNhYmxlZD1cInRydWVcIl0sIFthcmlhLWRpc2FibGVkPVwidHJ1ZVwiXS5mZC1tb2RhbF9fYnV0dG9uLXByaW1hcnksIFthcmlhLWRpc2FibGVkPVwidHJ1ZVwiXS5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvbi5pcy1kaXNhYmxlZCwgLmlzLWRpc2FibGVkLmZkLW1vZGFsX19idXR0b24tcHJpbWFyeSwgLmlzLWRpc2FibGVkLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uOmRpc2FibGVkLCAuZmQtbW9kYWxfX2J1dHRvbi1wcmltYXJ5OmRpc2FibGVkLCAuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnk6ZGlzYWJsZWQge1xuICAgIG91dGxpbmU6IHNvbGlkIDFweCAjZDdkN2Q3O1xuICAgIGNvbG9yOiAjN2Y5MGE0O1xuICAgIGJhY2tncm91bmQtY29sb3I6ICNmOWZiZmM7XG4gICAgY3Vyc29yOiBub3QtYWxsb3dlZDsgfVxuICAuZmQtYnV0dG9uLS10ZXh0LCAuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b24tLWxpbmsge1xuICAgIGNvbG9yOiAjMDA5Y2RmO1xuICAgIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50OyB9XG4gICAgLmZkLWJ1dHRvbi0tdGV4dDpob3ZlciwgLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5OmhvdmVyLCAuZmQtYnV0dG9uLS10ZXh0OmZvY3VzLCAuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnk6Zm9jdXMsIC5mZC1idXR0b24tLWxpbms6aG92ZXIsIC5mZC1idXR0b24tLWxpbms6Zm9jdXMge1xuICAgICAgYmFja2dyb3VuZC1jb2xvcjogdHJhbnNwYXJlbnQ7XG4gICAgICBjb2xvcjogIzAwOGFjNjsgfVxuICAgIC5mZC1idXR0b24tLXRleHQ6YWN0aXZlLCAuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnk6YWN0aXZlLCAuZmQtYnV0dG9uLS10ZXh0W2FyaWEtc2VsZWN0ZWQ9XCJ0cnVlXCJdLCBbYXJpYS1zZWxlY3RlZD1cInRydWVcIl0uZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b24tLXRleHQuaXMtc2VsZWN0ZWQsIC5pcy1zZWxlY3RlZC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvbi0tdGV4dFthcmlhLXByZXNzZWQ9XCJ0cnVlXCJdLCBbYXJpYS1wcmVzc2VkPVwidHJ1ZVwiXS5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvbi0tdGV4dC5pcy1wcmVzc2VkLCAuaXMtcHJlc3NlZC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvbi0tdGV4dFthcmlhLWRpc2FibGVkPVwidHJ1ZVwiXSwgW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uLS10ZXh0LmlzLWRpc2FibGVkLCAuaXMtZGlzYWJsZWQuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b24tLXRleHQ6ZGlzYWJsZWQsIC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeTpkaXNhYmxlZCwgLmZkLWJ1dHRvbi0tbGluazphY3RpdmUsIC5mZC1idXR0b24tLWxpbmtbYXJpYS1zZWxlY3RlZD1cInRydWVcIl0sIC5mZC1idXR0b24tLWxpbmsuaXMtc2VsZWN0ZWQsIC5mZC1idXR0b24tLWxpbmtbYXJpYS1wcmVzc2VkPVwidHJ1ZVwiXSwgLmZkLWJ1dHRvbi0tbGluay5pcy1wcmVzc2VkLCAuZmQtYnV0dG9uLS1saW5rW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLCAuZmQtYnV0dG9uLS1saW5rLmlzLWRpc2FibGVkLCAuZmQtYnV0dG9uLS1saW5rOmRpc2FibGVkIHtcbiAgICAgIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50O1xuICAgICAgb3V0bGluZTogbm9uZTtcbiAgICAgIGJveC1zaGFkb3c6IG5vbmU7IH1cbiAgICAuZmQtYnV0dG9uLS10ZXh0OmFjdGl2ZSwgLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5OmFjdGl2ZSwgLmZkLWJ1dHRvbi0tdGV4dFthcmlhLXNlbGVjdGVkPVwidHJ1ZVwiXSwgW2FyaWEtc2VsZWN0ZWQ9XCJ0cnVlXCJdLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uLS10ZXh0LmlzLXNlbGVjdGVkLCAuaXMtc2VsZWN0ZWQuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b24tLXRleHRbYXJpYS1wcmVzc2VkPVwidHJ1ZVwiXSwgW2FyaWEtcHJlc3NlZD1cInRydWVcIl0uZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b24tLXRleHQuaXMtcHJlc3NlZCwgLmlzLXByZXNzZWQuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b24tLWxpbms6YWN0aXZlLCAuZmQtYnV0dG9uLS1saW5rW2FyaWEtc2VsZWN0ZWQ9XCJ0cnVlXCJdLCAuZmQtYnV0dG9uLS1saW5rLmlzLXNlbGVjdGVkLCAuZmQtYnV0dG9uLS1saW5rW2FyaWEtcHJlc3NlZD1cInRydWVcIl0sIC5mZC1idXR0b24tLWxpbmsuaXMtcHJlc3NlZCB7XG4gICAgICBjb2xvcjogIzAwNzhhYzsgfVxuICAgIC5mZC1idXR0b24tLXRleHRbYXJpYS1kaXNhYmxlZD1cInRydWVcIl0sIFthcmlhLWRpc2FibGVkPVwidHJ1ZVwiXS5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvbi0tdGV4dC5pcy1kaXNhYmxlZCwgLmlzLWRpc2FibGVkLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uLS10ZXh0OmRpc2FibGVkLCAuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnk6ZGlzYWJsZWQsIC5mZC1idXR0b24tLWxpbmtbYXJpYS1kaXNhYmxlZD1cInRydWVcIl0sIC5mZC1idXR0b24tLWxpbmsuaXMtZGlzYWJsZWQsIC5mZC1idXR0b24tLWxpbms6ZGlzYWJsZWQge1xuICAgICAgY29sb3I6ICM3ZjkwYTQ7IH1cbiAgLmZkLWJ1dHRvbi0tbGluayB7XG4gICAgaGVpZ2h0OiAyOHB4O1xuICAgIGxpbmUtaGVpZ2h0OiAyOHB4O1xuICAgIHBhZGRpbmctbGVmdDogMTZweDtcbiAgICBwYWRkaW5nLXJpZ2h0OiAxNnB4O1xuICAgIHBvc2l0aW9uOiByZWxhdGl2ZTsgfVxuICAgIC5mZC1idXR0b24tLWxpbmsuZmQtYnV0dG9uLS1zbWFsbCB7XG4gICAgICBoZWlnaHQ6IDI0cHg7XG4gICAgICBsaW5lLWhlaWdodDogMjRweDsgfVxuICAgIC5mZC1idXR0b24tLWxpbms6OmFmdGVyIHtcbiAgICAgIGNvbnRlbnQ6IFwiXCI7XG4gICAgICBib3JkZXItYm90dG9tOiBzb2xpZCAycHggdHJhbnNwYXJlbnQ7XG4gICAgICB3aWR0aDogY2FsYygxMDAlIC0gMTZweCoyKTtcbiAgICAgIGhlaWdodDogMnB4O1xuICAgICAgcG9zaXRpb246IGFic29sdXRlO1xuICAgICAgYm90dG9tOiAxcHg7XG4gICAgICBsZWZ0OiAwO1xuICAgICAgbWFyZ2luLWxlZnQ6IDE2cHg7XG4gICAgICB0cmFuc2l0aW9uOiBib3JkZXItYm90dG9tLWNvbG9yIDAuMTI1cyBlYXNlLWluOyB9XG4gICAgLmZkLWJ1dHRvbi0tbGluazpmb2N1cyB7XG4gICAgICBvdXRsaW5lOiBub25lO1xuICAgICAgYm94LXNoYWRvdzogbm9uZTsgfVxuICAgIC5mZC1idXR0b24tLWxpbms6aG92ZXI6OmFmdGVyLCAuZmQtYnV0dG9uLS1saW5rOmZvY3VzOjphZnRlciwgLmZkLWJ1dHRvbi0tbGluazphY3RpdmU6OmFmdGVyLCAuZmQtYnV0dG9uLS1saW5rW2FyaWEtc2VsZWN0ZWQ9XCJ0cnVlXCJdOjphZnRlciwgLmZkLWJ1dHRvbi0tbGluay5pcy1zZWxlY3RlZDo6YWZ0ZXIsIC5mZC1idXR0b24tLWxpbmtbYXJpYS1wcmVzc2VkPVwidHJ1ZVwiXTo6YWZ0ZXIsIC5mZC1idXR0b24tLWxpbmsuaXMtcHJlc3NlZDo6YWZ0ZXIge1xuICAgICAgYm9yZGVyLWJvdHRvbS1jb2xvcjogIzAwOWNkZjsgfVxuICAgIC5mZC1idXR0b24tLWxpbmtbYXJpYS1kaXNhYmxlZD1cInRydWVcIl06OmFmdGVyLCAuZmQtYnV0dG9uLS1saW5rLmlzLWRpc2FibGVkOjphZnRlciwgLmZkLWJ1dHRvbi0tbGluazpkaXNhYmxlZDo6YWZ0ZXIge1xuICAgICAgZGlzcGxheTogbm9uZTsgfVxuICAuZmQtYnV0dG9uID4gKiwgLmZkLW1vZGFsX19idXR0b24tcHJpbWFyeSA+ICosIC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSA+ICoge1xuICAgIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgICB2ZXJ0aWNhbC1hbGlnbjogdG9wO1xuICAgIG1hcmdpbi1yaWdodDogMTJweDtcbiAgICBtYXJnaW4tdG9wOiAxM3B4OyB9XG4gICAgLmZkLWJ1dHRvbi0taWNvbiA+ICoge1xuICAgICAgbWFyZ2luLWxlZnQ6IGF1dG87XG4gICAgICBtYXJnaW4tcmlnaHQ6IGF1dG87IH1cbiAgICAuZmQtYnV0dG9uLS1zbWFsbCA+ICoge1xuICAgICAgbWFyZ2luLXRvcDogMTFweDsgfVxuICAgIC5mZC1idXR0b24tLWxhcmdlID4gKiwgLmZkLWJ1dHRvbi0tYWN0aW9uLWJhciA+ICoge1xuICAgICAgbWFyZ2luLXRvcDogMjJweDsgfVxuICAuZmQtYnV0dG9uLS1hY3Rpb24tYmFyIHtcbiAgICBmb250LXNpemU6IDAuNzVyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuMzMzMzQ7XG4gICAgZm9udC13ZWlnaHQ6IDcwMDtcbiAgICB0ZXh0LXRyYW5zZm9ybTogdXBwZXJjYXNlO1xuICAgIG1pbi13aWR0aDogMTM1cHg7XG4gICAgbGluZS1oZWlnaHQ6IDMycHg7XG4gICAgdmVydGljYWwtYWxpZ246IG1pZGRsZTsgfVxuICAgIC5mZC1idXR0b24tLWFjdGlvbi1iYXIgPiAqIHtcbiAgICAgIGRpc3BsYXk6IGJsb2NrICFpbXBvcnRhbnQ7XG4gICAgICBtYXJnaW4tdG9wOiAxMnB4O1xuICAgICAgbWFyZ2luLWxlZnQ6IGF1dG87XG4gICAgICBtYXJnaW4tcmlnaHQ6IGF1dG87IH1cblxuQGZvbnQtZmFjZSB7XG4gIGZvbnQtZmFtaWx5OiBcIkZ1bmRhbWVudGFsSWNvbnNcIjtcbiAgc3JjOiB1cmwoXCJGdW5kYW1lbnRhbEljb25zLndvZmYyXCIpIGZvcm1hdChcIndvZmYyXCIpLCB1cmwoXCJGdW5kYW1lbnRhbEljb25zLndvZmZcIikgZm9ybWF0KFwid29mZlwiKTtcbiAgZm9udC13ZWlnaHQ6IG5vcm1hbDtcbiAgZm9udC1zdHlsZTogbm9ybWFsOyB9XG5cbi5mZC1pY29uIHtcbiAgZm9udC1zaXplOiAxLjEyNXJlbTtcbiAgZm9udC1mYW1pbHk6IFwiRnVuZGFtZW50YWxJY29uc1wiO1xuICBsaW5lLWhlaWdodDogMTtcbiAgZm9udC1zdHlsZTogbm9ybWFsO1xuICBmb250LXdlaWdodDogbm9ybWFsO1xuICB0ZXh0LWFsaWduOiBjZW50ZXI7XG4gIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgdGV4dC1kZWNvcmF0aW9uOiBpbmhlcml0O1xuICB0ZXh0LXRyYW5zZm9ybTogbm9uZTtcbiAgdGV4dC1yZW5kZXJpbmc6IG9wdGltaXplTGVnaWJpbGl0eTtcbiAgLXdlYmtpdC1mb250LXNtb290aGluZzogYW50aWFsaWFzZWQ7XG4gIC1tb3otb3N4LWZvbnQtc21vb3RoaW5nOiBncmF5c2NhbGU7IH1cbiAgLmZkLWljb24tLW1lZGl1bSB7XG4gICAgZm9udC1zaXplOiAxLjYyNXJlbTsgfVxuICAuZmQtaWNvbi0tbGFyZ2Uge1xuICAgIGZvbnQtc2l6ZTogMnJlbTsgfVxuICAuZmQtaWNvbjo6YmVmb3JlIHtcbiAgICBkaXNwbGF5OiBpbmxpbmU7XG4gICAgdGV4dC1hbGlnbjogY2VudGVyOyB9XG4gIC5mZC1pY29uLS1hZGQ6OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqIFcIjsgfVxuICAuZmQtaWNvbi0tYXJyb3c6OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqIJcIjsgfVxuICAuZmQtaWNvbi0tYmFja2Fycm93OjpiZWZvcmUge1xuICAgIGNvbnRlbnQ6IFwi7qiDXCI7IH1cbiAgLmZkLWljb24tLWNhdXRpb246OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqIRcIjsgfVxuICAuZmQtaWNvbi0tY2hhbmdlOjpiZWZvcmUge1xuICAgIGNvbnRlbnQ6IFwi7qiFXCI7IH1cbiAgLmZkLWljb24tLWNoZWNrZWQ6OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqIZcIjsgfVxuICAuZmQtaWNvbi0tY2hldnJvbjo6YmVmb3JlLCAuZmQtcGFnaW5hdGlvbl9faXRlbSAuZmQtaWNvbi0tY2hldnJvbi1iYWNrOjpiZWZvcmUge1xuICAgIGNvbnRlbnQ6IFwi7qiHXCI7IH1cbiAgLmZkLWljb24tLWNsb25lOjpiZWZvcmUge1xuICAgIGNvbnRlbnQ6IFwi7qiIXCI7IH1cbiAgLmZkLWljb24tLWNsb3NlOjpiZWZvcmUge1xuICAgIGNvbnRlbnQ6IFwi7qiJXCI7IH1cbiAgLmZkLWljb24tLWNvbGxhcHNlOjpiZWZvcmUge1xuICAgIGNvbnRlbnQ6IFwi7qiKXCI7IH1cbiAgLmZkLWljb24tLWRlbGV0ZTo6YmVmb3JlIHtcbiAgICBjb250ZW50OiBcIu6oi1wiOyB9XG4gIC5mZC1pY29uLS1kb25lOjpiZWZvcmUge1xuICAgIGNvbnRlbnQ6IFwi7qiMXCI7IH1cbiAgLmZkLWljb24tLWRvdWJsZWNoZXZyb246OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqI1cIjsgfVxuICAuZmQtaWNvbi0tZHJhZ2Ryb3BsaXN0OjpiZWZvcmUge1xuICAgIGNvbnRlbnQ6IFwi7qiOXCI7IH1cbiAgLmZkLWljb24tLWRyYWdkcm9wb2JqZWN0OjpiZWZvcmUge1xuICAgIGNvbnRlbnQ6IFwi7qiPXCI7IH1cbiAgLmZkLWljb24tLWVkaXQ6OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqJBcIjsgfVxuICAuZmQtaWNvbi0tZXhwYW5kOjpiZWZvcmUge1xuICAgIGNvbnRlbnQ6IFwi7qiRXCI7IH1cbiAgLmZkLWljb24tLWZlZWRiYWNrOjpiZWZvcmUge1xuICAgIGNvbnRlbnQ6IFwi7qiSXCI7IH1cbiAgLmZkLWljb24tLWZpbHRlcjo6YmVmb3JlIHtcbiAgICBjb250ZW50OiBcIu6ok1wiOyB9XG4gIC5mZC1pY29uLS1maWx0ZXJyZW1vdmU6OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqJRcIjsgfVxuICAuZmQtaWNvbi0tZ3JpZDo6YmVmb3JlIHtcbiAgICBjb250ZW50OiBcIu6olVwiOyB9XG4gIC5mZC1pY29uLS1oZWxwOjpiZWZvcmUge1xuICAgIGNvbnRlbnQ6IFwi7qiWXCI7IH1cbiAgLmZkLWljb24tLWluZm9vbjo6YmVmb3JlIHtcbiAgICBjb250ZW50OiBcIu6ol1wiOyB9XG4gIC5mZC1pY29uLS1saW5rOjpiZWZvcmUge1xuICAgIGNvbnRlbnQ6IFwi7qiYXCI7IH1cbiAgLmZkLWljb24tLWxpc3Q6OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqJlcIjsgfVxuICAuZmQtaWNvbi0tbG9jYWxpemF0aW9uOjpiZWZvcmUge1xuICAgIGNvbnRlbnQ6IFwi7qiaXCI7IH1cbiAgLmZkLWljb24tLWxvY2s6OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqJtcIjsgfVxuICAuZmQtaWNvbi0tbWF4aW1pemU6OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqJxcIjsgfVxuICAuZmQtaWNvbi0tbWluaW1pemU6OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqJ1cIjsgfVxuICAuZmQtaWNvbi0tbW9yZTo6YmVmb3JlIHtcbiAgICBjb250ZW50OiBcIu6onlwiOyB9XG4gIC5mZC1pY29uLS1ub2ltYWdlOjpiZWZvcmUge1xuICAgIGNvbnRlbnQ6IFwi7qifXCI7IH1cbiAgLmZkLWljb24tLW9wdGlvbnM6OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqKBcIjsgfVxuICAuZmQtaWNvbi0tc2VhcmNoOjpiZWZvcmUge1xuICAgIGNvbnRlbnQ6IFwi7qihXCI7IH1cbiAgLmZkLWljb24tLXNvcnQ6OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqKJcIjsgfVxuICAuZmQtaWNvbi0tc3luYzo6YmVmb3JlIHtcbiAgICBjb250ZW50OiBcIu6oo1wiOyB9XG4gIC5mZC1pY29uLS10b3A6OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqKRcIjsgfVxuICAuZmQtaWNvbi0tdmlzaWJpbGl0eW9mZjo6YmVmb3JlIHtcbiAgICBjb250ZW50OiBcIu6opVwiOyB9XG4gIC5mZC1pY29uLS12aXNpYmlsaXR5b246OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqKZcIjsgfVxuICAuZmQtaWNvbi0td2FybmluZzo6YmVmb3JlIHtcbiAgICBjb250ZW50OiBcIu6op1wiOyB9XG5cbi8qIVxuLmZkLXBhZ2luYXRpb25cbiovXG4uZmQtcGFnaW5hdGlvbiB7XG4gIGZvbnQtc2l6ZTogMXJlbTtcbiAgbGluZS1oZWlnaHQ6IDEuNTtcbiAgY29sb3I6ICMyMTI2MmM7XG4gIGZvbnQtc2l6ZTogMC44NzVyZW07XG4gIGxpbmUtaGVpZ2h0OiAxLjQyODU4O1xuICBmb250LXdlaWdodDogNDAwO1xuICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gIG1hcmdpbi1ib3R0b206IDA7XG4gIHBhZGRpbmctbGVmdDogMDtcbiAgbGlzdC1zdHlsZTogbm9uZTsgfVxuICAuZmQtcGFnaW5hdGlvbl9fbGluayB7XG4gICAgY29sb3I6ICMwMDljZGY7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogdHJhbnNwYXJlbnQ7XG4gICAgcGFkZGluZy1sZWZ0OiAxMnB4O1xuICAgIHBhZGRpbmctcmlnaHQ6IDEycHg7XG4gICAgcG9zaXRpb246IHJlbGF0aXZlOyB9XG4gICAgLmZkLXBhZ2luYXRpb25fX2xpbms6OmFmdGVyIHtcbiAgICAgIGNvbnRlbnQ6IFwiXCI7XG4gICAgICBib3JkZXItYm90dG9tOiBzb2xpZCAycHggdHJhbnNwYXJlbnQ7XG4gICAgICB3aWR0aDogY2FsYygxMDAlIC0gOHB4KjIpO1xuICAgICAgaGVpZ2h0OiAycHg7XG4gICAgICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gICAgICBib3R0b206IC02cHg7XG4gICAgICBsZWZ0OiAwO1xuICAgICAgbWFyZ2luLWxlZnQ6IDhweDsgfVxuICAgIC5mZC1wYWdpbmF0aW9uX19saW5rOmhvdmVyLCAuZmQtcGFnaW5hdGlvbl9fbGluazpmb2N1cyB7XG4gICAgICBjb2xvcjogIzAwOGFjNjtcbiAgICAgIHRleHQtZGVjb3JhdGlvbjogbm9uZTsgfVxuICAgICAgLmZkLXBhZ2luYXRpb25fX2xpbms6aG92ZXI6OmFmdGVyLCAuZmQtcGFnaW5hdGlvbl9fbGluazpmb2N1czo6YWZ0ZXIge1xuICAgICAgICBib3JkZXItYm90dG9tLWNvbG9yOiAjMDA4YWM2OyB9XG4gICAgLmZkLXBhZ2luYXRpb25fX2xpbms6YWN0aXZlLCAuZmQtcGFnaW5hdGlvbl9fbGlua1thcmlhLXNlbGVjdGVkPVwidHJ1ZVwiXSwgLmZkLXBhZ2luYXRpb25fX2xpbmsuaXMtc2VsZWN0ZWQge1xuICAgICAgYmFja2dyb3VuZC1jb2xvcjogdHJhbnNwYXJlbnQ7XG4gICAgICBvdXRsaW5lOiBub25lO1xuICAgICAgYm94LXNoYWRvdzogbm9uZTsgfVxuICAgICAgLmZkLXBhZ2luYXRpb25fX2xpbms6YWN0aXZlOjphZnRlciwgLmZkLXBhZ2luYXRpb25fX2xpbmtbYXJpYS1zZWxlY3RlZD1cInRydWVcIl06OmFmdGVyLCAuZmQtcGFnaW5hdGlvbl9fbGluay5pcy1zZWxlY3RlZDo6YWZ0ZXIge1xuICAgICAgICBib3JkZXItYm90dG9tLWNvbG9yOiB0cmFuc3BhcmVudDsgfVxuICAgIC5mZC1wYWdpbmF0aW9uX19saW5rW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLCAuZmQtcGFnaW5hdGlvbl9fbGluay5pcy1kaXNhYmxlZCB7XG4gICAgICBjb2xvcjogIzdmOTBhNDtcbiAgICAgIHRleHQtZGVjb3JhdGlvbjogbm9uZTtcbiAgICAgIGN1cnNvcjogZGVmYXVsdDsgfVxuICAgICAgLmZkLXBhZ2luYXRpb25fX2xpbmtbYXJpYS1kaXNhYmxlZD1cInRydWVcIl06OmFmdGVyLCAuZmQtcGFnaW5hdGlvbl9fbGluay5pcy1kaXNhYmxlZDo6YWZ0ZXIge1xuICAgICAgICBib3JkZXItYm90dG9tLWNvbG9yOiB0cmFuc3BhcmVudDsgfVxuICAgIC5mZC1wYWdpbmF0aW9uX19saW5rOmFjdGl2ZSwgLmZkLXBhZ2luYXRpb25fX2xpbmtbYXJpYS1zZWxlY3RlZD1cInRydWVcIl0sIC5mZC1wYWdpbmF0aW9uX19saW5rLmlzLXNlbGVjdGVkIHtcbiAgICAgIGNvbG9yOiAjMjEyNjJjO1xuICAgICAgdGV4dC1kZWNvcmF0aW9uOiBub25lO1xuICAgICAgY3Vyc29yOiBkZWZhdWx0OyB9XG4gIC5mZC1wYWdpbmF0aW9uX19pdGVtIHtcbiAgICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7IH1cbiAgICAuZmQtcGFnaW5hdGlvbl9faXRlbSAuZmQtaWNvbi0tY2hldnJvbi1iYWNrIHtcbiAgICAgIC13ZWJraXQtdHJhbnNmb3JtOiByb3RhdGUoMTgwZGVnKTtcbiAgICAgIC1tb3otdHJhbnNmb3JtOiByb3RhdGUoMTgwZGVnKTtcbiAgICAgIC1tcy10cmFuc2Zvcm06IHJvdGF0ZSgxODBkZWcpO1xuICAgICAgLW8tdHJhbnNmb3JtOiByb3RhdGUoMTgwZGVnKTtcbiAgICAgIHRyYW5zZm9ybTogcm90YXRlKDE4MGRlZyk7IH1cbiAgLmZkLXBhZ2luYXRpb25fX21vcmUge1xuICAgIGZvbnQtc2l6ZTogMC43NXJlbTtcbiAgICBsaW5lLWhlaWdodDogMS4zMzMzNDtcbiAgICBmb250LXdlaWdodDogNzAwO1xuICAgIHRleHQtdHJhbnNmb3JtOiB1cHBlcmNhc2U7XG4gICAgY29sb3I6ICMyMTI2MmM7XG4gICAgdmVydGljYWwtYWxpZ246IHN1YjtcbiAgICBwYWRkaW5nLWxlZnQ6IDEycHg7XG4gICAgcGFkZGluZy1yaWdodDogMTJweDsgfVxuICAgIC5mZC1wYWdpbmF0aW9uX19tb3JlOmhvdmVyLCAuZmQtcGFnaW5hdGlvbl9fbW9yZTpmb2N1cyB7XG4gICAgICBiYWNrZ3JvdW5kLWNvbG9yOiB0cmFuc3BhcmVudDtcbiAgICAgIGNvbG9yOiAjMjEyNjJjO1xuICAgICAgY3Vyc29yOiBkZWZhdWx0OyB9XG4gIC5mZC1wYWdpbmF0aW9uX190b3RhbCB7XG4gICAgY29sb3I6ICM3ZjkwYTQ7IH1cblxuLyohXG4uZmQtdGFibGVcbiAgICB0aGVhZFxuICAgIHRib2R5XG4gICAgICAgIHRyKyhbYXJpYS1zZWxlY3RlZF0pXG4qL1xuLmZkLXRhYmxlIHtcbiAgZm9udC1zaXplOiAxcmVtO1xuICBsaW5lLWhlaWdodDogMS41O1xuICBjb2xvcjogIzIxMjYyYztcbiAgd2lkdGg6IDEwMCU7XG4gIG1heC13aWR0aDogMTAwJTtcbiAgYm9yZGVyLWNvbGxhcHNlOiBjb2xsYXBzZTtcbiAgbWFyZ2luLWJvdHRvbTogMjBweDtcbiAgYm9yZGVyLXRvcDogc29saWQgMXB4ICNjY2RhZWI7IH1cbiAgLmZkLXRhYmxlOmxhc3QtY2hpbGQge1xuICAgIG1hcmdpbi1ib3R0b206IDA7XG4gICAgbWFyZ2luLXJpZ2h0OiAwOyB9XG4gIC5mZC10YWJsZSB0ciB7XG4gICAgdHJhbnNpdGlvbjogYmFja2dyb3VuZC1jb2xvciAwLjEyNXMgZWFzZS1pbjsgfVxuICAgIC5mZC10YWJsZSB0cjpob3ZlciB7XG4gICAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjZjFmNWY5OyB9XG4gICAgLmZkLXRhYmxlIHRyLmlzLXNlbGVjdGVkLCAuZmQtdGFibGUgdHJbYXJpYS1zZWxlY3RlZD1cInRydWVcIl0ge1xuICAgICAgYmFja2dyb3VuZC1jb2xvcjogI2RlZTdmMjsgfVxuICAuZmQtdGFibGUgdGhlYWQge1xuICAgIGZvbnQtc2l6ZTogMC44NzVyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuNDI4NTg7XG4gICAgZm9udC13ZWlnaHQ6IDQwMDtcbiAgICBjb2xvcjogIzdmOTBhNDsgfVxuICAgIC5mZC10YWJsZSB0aGVhZCB0cjpob3ZlciB7XG4gICAgICBiYWNrZ3JvdW5kLWNvbG9yOiBpbmhlcml0OyB9XG4gICAgLmZkLXRhYmxlIHRoZWFkIHRkLFxuICAgIC5mZC10YWJsZSB0aGVhZCB0aCB7XG4gICAgICBib3JkZXI6IG5vbmU7IH1cbiAgLmZkLXRhYmxlIHRkLFxuICAuZmQtdGFibGUgdGgge1xuICAgIHRleHQtYWxpZ246IGxlZnQ7XG4gICAgcGFkZGluZzogMTJweCAzMnB4IDEycHggMDtcbiAgICBib3JkZXItc3R5bGU6IHNvbGlkO1xuICAgIGJvcmRlci13aWR0aDogMXB4IDA7XG4gICAgYm9yZGVyLWNvbG9yOiAjY2NkYWViOyB9XG4gICAgLmZkLXRhYmxlIHRkOmZpcnN0LWNoaWxkLFxuICAgIC5mZC10YWJsZSB0aDpmaXJzdC1jaGlsZCB7XG4gICAgICBwYWRkaW5nLWxlZnQ6IDMycHg7IH1cbiAgLmZkLXRhYmxlIGEge1xuICAgIGNvbG9yOiAjMDA5Y2RmOyB9XG4gICAgLmZkLXRhYmxlIGE6aG92ZXIge1xuICAgICAgY29sb3I6ICMwMDljZGY7IH1cblxuLyohXG4uZmQtdGFicysoKVxuICAgIC5mZC10YWJzX19pdGVtP1xuICAgIC5mZC10YWJzX19saW5rKygoLmlzLXNlbGVjdGVkfFthcmlhLXNlbGVjdGVkPXRydWVdKSwoLmlzLWRpc2FibGVkfFthcmlhLWRpc2FibGVkPXRydWVdKSlcbi5mZC10YWJzX19wYW5lbCsoW2FyaWEtZXhwYW5kZWRdfC5pcy1leHBhbmRlZClcbiovXG4uZmQtdGFicyB7XG4gIGZvbnQtc2l6ZTogMXJlbTtcbiAgbGluZS1oZWlnaHQ6IDEuNTtcbiAgY29sb3I6ICMyMTI2MmM7XG4gIGRpc3BsYXk6IGZsZXg7XG4gIGZsZXgtd3JhcDogd3JhcDtcbiAgcGFkZGluZy1sZWZ0OiAwO1xuICBtYXJnaW4tYm90dG9tOiA0MHB4O1xuICBsaXN0LXN0eWxlOiBub25lO1xuICBib3JkZXItYm90dG9tOiBzb2xpZCAxcHggI2NjZGFlYjsgfVxuICAuZmQtdGFic19fbGluayB7XG4gICAgZGlzcGxheTogYmxvY2s7XG4gICAgcGFkZGluZzogMTJweCAyMHB4O1xuICAgIGZvbnQtc2l6ZTogMS4xMjVyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuMzMzMzQ7XG4gICAgZm9udC1mYW1pbHk6IFJvYm90bywgc2Fucy1zZXJpZjtcbiAgICBmb250LXdlaWdodDogNTAwO1xuICAgIHRleHQtdHJhbnNmb3JtOiB1cHBlcmNhc2U7XG4gICAgY29sb3I6ICMwMDljZGY7XG4gICAgYm9yZGVyLWJvdHRvbTogc29saWQgMnB4IHRyYW5zcGFyZW50O1xuICAgIHRyYW5zaXRpb246IGFsbCAwLjEyNXMgZWFzZS1pbjtcbiAgICBjdXJzb3I6IHBvaW50ZXI7IH1cbiAgICAuZmQtdGFic19fbGluazpob3ZlciB7XG4gICAgICBib3JkZXItYm90dG9tOiBzb2xpZCAycHggIzAwOWNkZjtcbiAgICAgIGNvbG9yOiAjMDA4YWM2OyB9XG4gICAgLmZkLXRhYnNfX2xpbmsuaXMtc2VsZWN0ZWQsIC5mZC10YWJzX19saW5rW2FyaWEtc2VsZWN0ZWQ9XCJ0cnVlXCJdIHtcbiAgICAgIGNvbG9yOiAjMjEyNjJjO1xuICAgICAgYm9yZGVyLWJvdHRvbTogc29saWQgMnB4ICMwMDljZGY7IH1cbiAgICAuZmQtdGFic19fbGluay5pcy1kaXNhYmxlZCwgLmZkLXRhYnNfX2xpbmtbYXJpYS1kaXNhYmxlZD1cInRydWVcIl0ge1xuICAgICAgY29sb3I6ICM3ZjkwYTQ7XG4gICAgICBjdXJzb3I6IG5vdC1hbGxvd2VkOyB9XG4gICAgICAuZmQtdGFic19fbGluay5pcy1kaXNhYmxlZDpob3ZlciwgLmZkLXRhYnNfX2xpbmtbYXJpYS1kaXNhYmxlZD1cInRydWVcIl06aG92ZXIge1xuICAgICAgICBib3JkZXItYm90dG9tLWNvbG9yOiB0cmFuc3BhcmVudDsgfVxuICAuZmQtdGFic19fcGFuZWxbYXJpYS1leHBhbmRlZD1cImZhbHNlXCJdIHtcbiAgICBkaXNwbGF5OiBub25lOyB9XG4gIC5mZC10YWJzX19wYW5lbC5pcy1leHBhbmRlZCwgLmZkLXRhYnNfX3BhbmVsW2FyaWEtZXhwYW5kZWQ9XCJ0cnVlXCJdIHtcbiAgICBkaXNwbGF5OiBibG9jazsgfVxuXG4vKiFcbi5mZC1idXR0b24rKCAoLS1zbWFsbCB8IC0tbGFyZ2UpLCAtLWljb24sIC0tdGV4dCwgLS1saW5rLCAtLWFjdGlvbi1iYXIpKyggKC5pcy1kaXNhYmxlZCB8IFthcmlhLWRpc2FibGVkPXRydWVdKSB8ICguaXMtc2VsZWN0ZWQgfCBbYXJpYS1zZWxlY3RlZD10cnVlXSB8ICguaXMtcHJlc3NlZCB8IFthcmlhLXByZXNzZWQ9dHJ1ZV0pKVxuKi9cbi5mZC1idXR0b24sIC5mZC1tb2RhbF9fYnV0dG9uLXByaW1hcnksIC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSB7XG4gIG1hcmdpbjogMDtcbiAgcGFkZGluZzogMDtcbiAgZm9udC1zbW9vdGhpbmc6IGFudGlhbGlhc2VkO1xuICBhcHBlYXJhbmNlOiBub25lO1xuICBvdXRsaW5lOiAwO1xuICBib3JkZXI6IDA7XG4gIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgdGV4dC1kZWNvcmF0aW9uOiBub25lO1xuICBjdXJzb3I6IHBvaW50ZXI7XG4gIHVzZXItc2VsZWN0OiBub25lO1xuICB2ZXJ0aWNhbC1hbGlnbjogbWlkZGxlO1xuICB3aGl0ZS1zcGFjZTogbm93cmFwO1xuICBiYWNrZ3JvdW5kLWNvbG9yOiB0cmFuc3BhcmVudDtcbiAgZm9udC1zaXplOiAxLjEyNXJlbTtcbiAgbGluZS1oZWlnaHQ6IDEuMzMzMzQ7XG4gIGZvbnQtZmFtaWx5OiBSb2JvdG8sIHNhbnMtc2VyaWY7XG4gIGZvbnQtd2VpZ2h0OiA1MDA7XG4gIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgYmFja2dyb3VuZC1jb2xvcjogIzAwOWNkZjtcbiAgdHJhbnNpdGlvbjogYmFja2dyb3VuZC1jb2xvciAwLjEyNXMgZWFzZS1pbjtcbiAgY29sb3I6ICNmNmY4Zjk7XG4gIG1heC1oZWlnaHQ6IDUycHg7XG4gIGhlaWdodDogNTJweDtcbiAgbGluZS1oZWlnaHQ6IDUycHg7XG4gIHBhZGRpbmctbGVmdDogMjBweDtcbiAgcGFkZGluZy1yaWdodDogMjBweDtcbiAgdGV4dC1hbGlnbjogY2VudGVyO1xuICB0ZXh0LXRyYW5zZm9ybTogdXBwZXJjYXNlO1xuICBib3JkZXItcmFkaXVzOiAwOyB9XG4gIC5mZC1idXR0b24tLXNtYWxsIHtcbiAgICBmb250LXNpemU6IDFyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuNTtcbiAgICBmb250LXdlaWdodDogNDAwO1xuICAgIGZvbnQtd2VpZ2h0OiA2MDA7XG4gICAgbWF4LWhlaWdodDogNDBweDtcbiAgICBoZWlnaHQ6IDQwcHg7XG4gICAgbGluZS1oZWlnaHQ6IDQwcHg7XG4gICAgcGFkZGluZy1sZWZ0OiAxNnB4O1xuICAgIHBhZGRpbmctcmlnaHQ6IDE2cHg7IH1cbiAgLmZkLWJ1dHRvbi0tbGFyZ2UsIC5mZC1idXR0b24tLWFjdGlvbi1iYXIge1xuICAgIGZvbnQtc2l6ZTogMS4yNXJlbTtcbiAgICBsaW5lLWhlaWdodDogMS40O1xuICAgIGZvbnQtd2VpZ2h0OiA2MDA7XG4gICAgbWF4LWhlaWdodDogNzZweDtcbiAgICBoZWlnaHQ6IDc2cHg7XG4gICAgbGluZS1oZWlnaHQ6IDc2cHg7XG4gICAgcGFkZGluZy1sZWZ0OiAyOHB4O1xuICAgIHBhZGRpbmctcmlnaHQ6IDI4cHg7IH1cbiAgLmZkLWJ1dHRvbjpob3ZlciwgLmZkLW1vZGFsX19idXR0b24tcHJpbWFyeTpob3ZlciwgLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5OmhvdmVyIHtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjMDA4YWM2O1xuICAgIGNvbG9yOiAjZjZmOGY5O1xuICAgIHRleHQtZGVjb3JhdGlvbjogbm9uZTsgfVxuICAuZmQtYnV0dG9uOmZvY3VzLCAuZmQtbW9kYWxfX2J1dHRvbi1wcmltYXJ5OmZvY3VzLCAuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnk6Zm9jdXMge1xuICAgIGNvbG9yOiAjZjZmOGY5O1xuICAgIGJveC1zaGFkb3c6IDAgMCA0cHggMXB4ICM4YThmYTE7XG4gICAgb3V0bGluZTogc29saWQgMnB4ICMyZGMwZmY7IH1cbiAgLmZkLWJ1dHRvbjphY3RpdmUsIC5mZC1tb2RhbF9fYnV0dG9uLXByaW1hcnk6YWN0aXZlLCAuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnk6YWN0aXZlLCAuZmQtYnV0dG9uLmlzLWFjdGl2ZSwgLmlzLWFjdGl2ZS5mZC1tb2RhbF9fYnV0dG9uLXByaW1hcnksIC5pcy1hY3RpdmUuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b25bYXJpYS1zZWxlY3RlZD1cInRydWVcIl0sIFthcmlhLXNlbGVjdGVkPVwidHJ1ZVwiXS5mZC1tb2RhbF9fYnV0dG9uLXByaW1hcnksIFthcmlhLXNlbGVjdGVkPVwidHJ1ZVwiXS5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvbi5pcy1zZWxlY3RlZCwgLmlzLXNlbGVjdGVkLmZkLW1vZGFsX19idXR0b24tcHJpbWFyeSwgLmlzLXNlbGVjdGVkLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uW2FyaWEtcHJlc3NlZD1cInRydWVcIl0sIFthcmlhLXByZXNzZWQ9XCJ0cnVlXCJdLmZkLW1vZGFsX19idXR0b24tcHJpbWFyeSwgW2FyaWEtcHJlc3NlZD1cInRydWVcIl0uZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b24uaXMtcHJlc3NlZCwgLmlzLXByZXNzZWQuZmQtbW9kYWxfX2J1dHRvbi1wcmltYXJ5LCAuaXMtcHJlc3NlZC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSB7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogIzAwNzhhYztcbiAgICBjb2xvcjogI2Y2ZjhmOTsgfVxuICAuZmQtYnV0dG9uW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLCBbYXJpYS1kaXNhYmxlZD1cInRydWVcIl0uZmQtbW9kYWxfX2J1dHRvbi1wcmltYXJ5LCBbYXJpYS1kaXNhYmxlZD1cInRydWVcIl0uZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b24uaXMtZGlzYWJsZWQsIC5pcy1kaXNhYmxlZC5mZC1tb2RhbF9fYnV0dG9uLXByaW1hcnksIC5pcy1kaXNhYmxlZC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvbjpkaXNhYmxlZCwgLmZkLW1vZGFsX19idXR0b24tcHJpbWFyeTpkaXNhYmxlZCwgLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5OmRpc2FibGVkIHtcbiAgICBvdXRsaW5lOiBzb2xpZCAxcHggI2Q3ZDdkNztcbiAgICBjb2xvcjogIzdmOTBhNDtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjZjlmYmZjO1xuICAgIGN1cnNvcjogbm90LWFsbG93ZWQ7IH1cbiAgLmZkLWJ1dHRvbi0tdGV4dCwgLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uLS1saW5rIHtcbiAgICBjb2xvcjogIzAwOWNkZjtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiB0cmFuc3BhcmVudDsgfVxuICAgIC5mZC1idXR0b24tLXRleHQ6aG92ZXIsIC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeTpob3ZlciwgLmZkLWJ1dHRvbi0tdGV4dDpmb2N1cywgLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5OmZvY3VzLCAuZmQtYnV0dG9uLS1saW5rOmhvdmVyLCAuZmQtYnV0dG9uLS1saW5rOmZvY3VzIHtcbiAgICAgIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50O1xuICAgICAgY29sb3I6ICMwMDhhYzY7IH1cbiAgICAuZmQtYnV0dG9uLS10ZXh0OmFjdGl2ZSwgLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5OmFjdGl2ZSwgLmZkLWJ1dHRvbi0tdGV4dFthcmlhLXNlbGVjdGVkPVwidHJ1ZVwiXSwgW2FyaWEtc2VsZWN0ZWQ9XCJ0cnVlXCJdLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uLS10ZXh0LmlzLXNlbGVjdGVkLCAuaXMtc2VsZWN0ZWQuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b24tLXRleHRbYXJpYS1wcmVzc2VkPVwidHJ1ZVwiXSwgW2FyaWEtcHJlc3NlZD1cInRydWVcIl0uZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b24tLXRleHQuaXMtcHJlc3NlZCwgLmlzLXByZXNzZWQuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b24tLXRleHRbYXJpYS1kaXNhYmxlZD1cInRydWVcIl0sIFthcmlhLWRpc2FibGVkPVwidHJ1ZVwiXS5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvbi0tdGV4dC5pcy1kaXNhYmxlZCwgLmlzLWRpc2FibGVkLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uLS10ZXh0OmRpc2FibGVkLCAuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnk6ZGlzYWJsZWQsIC5mZC1idXR0b24tLWxpbms6YWN0aXZlLCAuZmQtYnV0dG9uLS1saW5rW2FyaWEtc2VsZWN0ZWQ9XCJ0cnVlXCJdLCAuZmQtYnV0dG9uLS1saW5rLmlzLXNlbGVjdGVkLCAuZmQtYnV0dG9uLS1saW5rW2FyaWEtcHJlc3NlZD1cInRydWVcIl0sIC5mZC1idXR0b24tLWxpbmsuaXMtcHJlc3NlZCwgLmZkLWJ1dHRvbi0tbGlua1thcmlhLWRpc2FibGVkPVwidHJ1ZVwiXSwgLmZkLWJ1dHRvbi0tbGluay5pcy1kaXNhYmxlZCwgLmZkLWJ1dHRvbi0tbGluazpkaXNhYmxlZCB7XG4gICAgICBiYWNrZ3JvdW5kLWNvbG9yOiB0cmFuc3BhcmVudDtcbiAgICAgIG91dGxpbmU6IG5vbmU7XG4gICAgICBib3gtc2hhZG93OiBub25lOyB9XG4gICAgLmZkLWJ1dHRvbi0tdGV4dDphY3RpdmUsIC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeTphY3RpdmUsIC5mZC1idXR0b24tLXRleHRbYXJpYS1zZWxlY3RlZD1cInRydWVcIl0sIFthcmlhLXNlbGVjdGVkPVwidHJ1ZVwiXS5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvbi0tdGV4dC5pcy1zZWxlY3RlZCwgLmlzLXNlbGVjdGVkLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uLS10ZXh0W2FyaWEtcHJlc3NlZD1cInRydWVcIl0sIFthcmlhLXByZXNzZWQ9XCJ0cnVlXCJdLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uLS10ZXh0LmlzLXByZXNzZWQsIC5pcy1wcmVzc2VkLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5LCAuZmQtYnV0dG9uLS1saW5rOmFjdGl2ZSwgLmZkLWJ1dHRvbi0tbGlua1thcmlhLXNlbGVjdGVkPVwidHJ1ZVwiXSwgLmZkLWJ1dHRvbi0tbGluay5pcy1zZWxlY3RlZCwgLmZkLWJ1dHRvbi0tbGlua1thcmlhLXByZXNzZWQ9XCJ0cnVlXCJdLCAuZmQtYnV0dG9uLS1saW5rLmlzLXByZXNzZWQge1xuICAgICAgY29sb3I6ICMwMDc4YWM7IH1cbiAgICAuZmQtYnV0dG9uLS10ZXh0W2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLCBbYXJpYS1kaXNhYmxlZD1cInRydWVcIl0uZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnksIC5mZC1idXR0b24tLXRleHQuaXMtZGlzYWJsZWQsIC5pcy1kaXNhYmxlZC5mZC1tb2RhbF9fYnV0dG9uLXNlY29uZGFyeSwgLmZkLWJ1dHRvbi0tdGV4dDpkaXNhYmxlZCwgLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5OmRpc2FibGVkLCAuZmQtYnV0dG9uLS1saW5rW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLCAuZmQtYnV0dG9uLS1saW5rLmlzLWRpc2FibGVkLCAuZmQtYnV0dG9uLS1saW5rOmRpc2FibGVkIHtcbiAgICAgIGNvbG9yOiAjN2Y5MGE0OyB9XG4gIC5mZC1idXR0b24tLWxpbmsge1xuICAgIGhlaWdodDogMjhweDtcbiAgICBsaW5lLWhlaWdodDogMjhweDtcbiAgICBwYWRkaW5nLWxlZnQ6IDE2cHg7XG4gICAgcGFkZGluZy1yaWdodDogMTZweDtcbiAgICBwb3NpdGlvbjogcmVsYXRpdmU7IH1cbiAgICAuZmQtYnV0dG9uLS1saW5rLmZkLWJ1dHRvbi0tc21hbGwge1xuICAgICAgaGVpZ2h0OiAyNHB4O1xuICAgICAgbGluZS1oZWlnaHQ6IDI0cHg7IH1cbiAgICAuZmQtYnV0dG9uLS1saW5rOjphZnRlciB7XG4gICAgICBjb250ZW50OiBcIlwiO1xuICAgICAgYm9yZGVyLWJvdHRvbTogc29saWQgMnB4IHRyYW5zcGFyZW50O1xuICAgICAgd2lkdGg6IGNhbGMoMTAwJSAtIDE2cHgqMik7XG4gICAgICBoZWlnaHQ6IDJweDtcbiAgICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICAgIGJvdHRvbTogMXB4O1xuICAgICAgbGVmdDogMDtcbiAgICAgIG1hcmdpbi1sZWZ0OiAxNnB4O1xuICAgICAgdHJhbnNpdGlvbjogYm9yZGVyLWJvdHRvbS1jb2xvciAwLjEyNXMgZWFzZS1pbjsgfVxuICAgIC5mZC1idXR0b24tLWxpbms6Zm9jdXMge1xuICAgICAgb3V0bGluZTogbm9uZTtcbiAgICAgIGJveC1zaGFkb3c6IG5vbmU7IH1cbiAgICAuZmQtYnV0dG9uLS1saW5rOmhvdmVyOjphZnRlciwgLmZkLWJ1dHRvbi0tbGluazpmb2N1czo6YWZ0ZXIsIC5mZC1idXR0b24tLWxpbms6YWN0aXZlOjphZnRlciwgLmZkLWJ1dHRvbi0tbGlua1thcmlhLXNlbGVjdGVkPVwidHJ1ZVwiXTo6YWZ0ZXIsIC5mZC1idXR0b24tLWxpbmsuaXMtc2VsZWN0ZWQ6OmFmdGVyLCAuZmQtYnV0dG9uLS1saW5rW2FyaWEtcHJlc3NlZD1cInRydWVcIl06OmFmdGVyLCAuZmQtYnV0dG9uLS1saW5rLmlzLXByZXNzZWQ6OmFmdGVyIHtcbiAgICAgIGJvcmRlci1ib3R0b20tY29sb3I6ICMwMDljZGY7IH1cbiAgICAuZmQtYnV0dG9uLS1saW5rW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdOjphZnRlciwgLmZkLWJ1dHRvbi0tbGluay5pcy1kaXNhYmxlZDo6YWZ0ZXIsIC5mZC1idXR0b24tLWxpbms6ZGlzYWJsZWQ6OmFmdGVyIHtcbiAgICAgIGRpc3BsYXk6IG5vbmU7IH1cbiAgLmZkLWJ1dHRvbiA+ICosIC5mZC1tb2RhbF9fYnV0dG9uLXByaW1hcnkgPiAqLCAuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnkgPiAqIHtcbiAgICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gICAgdmVydGljYWwtYWxpZ246IHRvcDtcbiAgICBtYXJnaW4tcmlnaHQ6IDEycHg7XG4gICAgbWFyZ2luLXRvcDogMTNweDsgfVxuICAgIC5mZC1idXR0b24tLWljb24gPiAqIHtcbiAgICAgIG1hcmdpbi1sZWZ0OiBhdXRvO1xuICAgICAgbWFyZ2luLXJpZ2h0OiBhdXRvOyB9XG4gICAgLmZkLWJ1dHRvbi0tc21hbGwgPiAqIHtcbiAgICAgIG1hcmdpbi10b3A6IDExcHg7IH1cbiAgICAuZmQtYnV0dG9uLS1sYXJnZSA+ICosIC5mZC1idXR0b24tLWFjdGlvbi1iYXIgPiAqIHtcbiAgICAgIG1hcmdpbi10b3A6IDIycHg7IH1cbiAgLmZkLWJ1dHRvbi0tYWN0aW9uLWJhciB7XG4gICAgZm9udC1zaXplOiAwLjc1cmVtO1xuICAgIGxpbmUtaGVpZ2h0OiAxLjMzMzM0O1xuICAgIGZvbnQtd2VpZ2h0OiA3MDA7XG4gICAgdGV4dC10cmFuc2Zvcm06IHVwcGVyY2FzZTtcbiAgICBtaW4td2lkdGg6IDEzNXB4O1xuICAgIGxpbmUtaGVpZ2h0OiAzMnB4O1xuICAgIHZlcnRpY2FsLWFsaWduOiBtaWRkbGU7IH1cbiAgICAuZmQtYnV0dG9uLS1hY3Rpb24tYmFyID4gKiB7XG4gICAgICBkaXNwbGF5OiBibG9jayAhaW1wb3J0YW50O1xuICAgICAgbWFyZ2luLXRvcDogMTJweDtcbiAgICAgIG1hcmdpbi1sZWZ0OiBhdXRvO1xuICAgICAgbWFyZ2luLXJpZ2h0OiBhdXRvOyB9XG5cbi8qIVxuLmZkLW1vZGFsXG4gICAgLmZkLW1vZGFsX19oZWFkZXJcbiAgICAgICAgLmZkLWZvcm1fX3RpdGxlXG4gICAgLmZkLWZvcm1fX2JvZHlcbiAgICAuZmQtZm9ybV9fZm9vdGVyLWl0ZW1zXG4gICAgICAuZmQtbW9kYWxfX2J1dHRvbi1wcmltYXJ5XG4gICAgICAuZmQtbW9kYWxfX2J1dHRvbi1zZWNvbmRhcnlcbiovXG4uZmQtbW9kYWwge1xuICB3aWR0aDogNzAwcHg7XG4gIG1hcmdpbjogMzJweCBhdXRvOyB9XG4gIC5mZC1tb2RhbF9fY29udGVudCB7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogI2ZmZmZmZjsgfVxuICAgIC5mZC1tb2RhbF9fY29udGVudCBidXR0b24ge1xuICAgICAgZmxvYXQ6IHJpZ2h0OyB9XG4gIC5mZC1tb2RhbF9faGVhZGVyIHtcbiAgICBib3JkZXItYm90dG9tOiAxcHggc29saWQgI2NjZGFlYjtcbiAgICBwYWRkaW5nLWxlZnQ6IDQwcHg7XG4gICAgcGFkZGluZy10b3A6IDQwcHg7XG4gICAgcGFkZGluZy1yaWdodDogMjBweDsgfVxuICAuZmQtbW9kYWxfX3RpdGxlIHtcbiAgICBmb250LXNpemU6IDIuMTg3NXJlbTtcbiAgICBsaW5lLWhlaWdodDogMS4yNTcxNTtcbiAgICBmb250LWZhbWlseTogUm9ib3RvLCBzYW5zLXNlcmlmO1xuICAgIGZvbnQtd2VpZ2h0OiA1MDA7IH1cbiAgLmZkLW1vZGFsX19ib2R5IHtcbiAgICBwYWRkaW5nOiA0MHB4OyB9XG4gIC5mZC1tb2RhbF9fZm9vdGVyLWl0ZW1zIHtcbiAgICBkaXNwbGF5OiBibG9jaztcbiAgICBvdmVyZmxvdzogYXV0bztcbiAgICBib3JkZXItdG9wOiAxcHggc29saWQgI2NjZGFlYjtcbiAgICBwYWRkaW5nOiA0MHB4O1xuICAgIHBhZGRpbmctdG9wOiAyMHB4OyB9XG5cbi8qIVxuLmZkLXRyZWUrKC0taGVhZGVyKVxuICAgIC5mZC10cmVlX19ncm91cCsoLS1zdWJsZXZlbC0xLi4uLTYsIChbYXJpYS1oaWRkZW5dIHwgLmlzLWhpZGRlbikpXG4gICAgLmZkLXRyZWVfX2l0ZW1cbiAgICAgICAgLmZkLXRyZWVfX3JvdysoLS1oZWFkZXIsIChbYXJpYS1zZWxlY3RlZF0gfCAuaXMtc2VsZWN0ZWQpKVxuICAgICAgICAgICAgLmZkLXRyZWVfX2NvbCsoLS1jb250cm9sLCAtLWFjdGlvbnMpXG4gICAgICAgICAgICAgICAgLmZkLXRyZWVfX2NvbnRyb2wrKFthcmlhLXByZXNzZWRdIHwgLmlzLXByZXNzZWQpXG4qL1xuLmZkLXRyZWUge1xuICBmb250LXNpemU6IDFyZW07XG4gIGxpbmUtaGVpZ2h0OiAxLjU7XG4gIGNvbG9yOiAjMjEyNjJjO1xuICBwb3NpdGlvbjogcmVsYXRpdmU7XG4gIHdpZHRoOiAxMDAlO1xuICBtYXgtd2lkdGg6IDEwMCU7XG4gIGJvcmRlci1ib3R0b206IHNvbGlkIDFweCAjY2NkYWViO1xuICBtYXJnaW4tYm90dG9tOiAyMHB4O1xuICBtYXJnaW4tbGVmdDogMDsgfVxuICAuZmQtdHJlZTpsYXN0LWNoaWxkIHtcbiAgICBtYXJnaW4tYm90dG9tOiAwO1xuICAgIG1hcmdpbi1yaWdodDogMDsgfVxuICAuZmQtdHJlZTpsYXN0LWNoaWxkIHtcbiAgICBtYXJnaW4tYm90dG9tOiAwOyB9XG4gIC5mZC10cmVlLS1oZWFkZXIge1xuICAgIGJvcmRlci1ib3R0b206IDA7XG4gICAgYm9yZGVyLXRvcDogc29saWQgMXB4ICNjY2RhZWI7XG4gICAgbWFyZ2luLWJvdHRvbTogMDsgfVxuICAuZmQtdHJlZV9fZ3JvdXAge1xuICAgIHRyYW5zaXRpb246IG9wYWNpdHkgMC4xMjVzIGxpbmVhcjtcbiAgICBtYXgtaGVpZ2h0OiBhdXRvO1xuICAgIG9wYWNpdHk6IDE7XG4gICAgbWFyZ2luLWJvdHRvbTogMDtcbiAgICBtYXJnaW4tbGVmdDogMDsgfVxuICAgIC5mZC10cmVlX19ncm91cC5pcy1oaWRkZW4sIC5mZC10cmVlX19ncm91cFthcmlhLWhpZGRlbj1cInRydWVcIl0ge1xuICAgICAgbWF4LWhlaWdodDogMDtcbiAgICAgIG9wYWNpdHk6IDA7XG4gICAgICBvdmVyZmxvdzogaGlkZGVuOyB9XG4gIC5mZC10cmVlX19pdGVtIHtcbiAgICBib3JkZXItdG9wOiBzb2xpZCAxcHggI2NjZGFlYjtcbiAgICBtYXJnaW4tYm90dG9tOiAwO1xuICAgIGxpc3Qtc3R5bGU6IG5vbmU7IH1cbiAgLmZkLXRyZWVfX3JvdyB7XG4gICAgcGFkZGluZzogMCAzMnB4O1xuICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgYWxpZ24taXRlbXM6IGNlbnRlcjtcbiAgICBwb3NpdGlvbjogcmVsYXRpdmU7XG4gICAgdHJhbnNpdGlvbjogYmFja2dyb3VuZC1jb2xvciAwLjEyNXMgZWFzZS1pbjsgfVxuICAgIC5mZC10cmVlX19yb3c6aG92ZXIge1xuICAgICAgYmFja2dyb3VuZC1jb2xvcjogI2YxZjVmOTsgfVxuICAgIC5mZC10cmVlX19yb3ctLWhlYWRlciB7XG4gICAgICBmb250LXNpemU6IDAuODc1cmVtO1xuICAgICAgbGluZS1oZWlnaHQ6IDEuNDI4NTg7XG4gICAgICBmb250LXdlaWdodDogNDAwO1xuICAgICAgZm9udC13ZWlnaHQ6IDcwMDtcbiAgICAgIGNvbG9yOiAjN2Y5MGE0OyB9XG4gICAgICAuZmQtdHJlZV9fcm93LS1oZWFkZXI6aG92ZXIge1xuICAgICAgICBiYWNrZ3JvdW5kLWNvbG9yOiB0cmFuc3BhcmVudDsgfVxuICAgIC5mZC10cmVlX19yb3cuaXMtc2VsZWN0ZWQsIC5mZC10cmVlX19yb3dbYXJpYS1zZWxlY3RlZD1cInRydWVcIl0ge1xuICAgICAgYmFja2dyb3VuZC1jb2xvcjogI2RlZTdmMjsgfVxuICAuZmQtdHJlZV9fY29sIHtcbiAgICBmbGV4OiAxO1xuICAgIHBhZGRpbmc6IDEycHggMDtcbiAgICBwYWRkaW5nLWxlZnQ6IDMwcHg7IH1cbiAgICAuZmQtdHJlZV9fY29sLS1jb250cm9sIHtcbiAgICAgIGZsZXg6IGF1dG87XG4gICAgICB3aWR0aDogMjUlOyB9XG4gICAgICAuZmQtdHJlZV9fZ3JvdXAtLXN1YmxldmVsLTEgLmZkLXRyZWVfX2NvbC0tY29udHJvbCB7XG4gICAgICAgIHBhZGRpbmctbGVmdDogNjBweDsgfVxuICAgICAgLmZkLXRyZWVfX2dyb3VwLS1zdWJsZXZlbC0yIC5mZC10cmVlX19jb2wtLWNvbnRyb2wge1xuICAgICAgICBwYWRkaW5nLWxlZnQ6IDkwcHg7IH1cbiAgICAgIC5mZC10cmVlX19ncm91cC0tc3VibGV2ZWwtMyAuZmQtdHJlZV9fY29sLS1jb250cm9sIHtcbiAgICAgICAgcGFkZGluZy1sZWZ0OiAxMjBweDsgfVxuICAgICAgLmZkLXRyZWVfX2dyb3VwLS1zdWJsZXZlbC00IC5mZC10cmVlX19jb2wtLWNvbnRyb2wge1xuICAgICAgICBwYWRkaW5nLWxlZnQ6IDE1MHB4OyB9XG4gICAgICAuZmQtdHJlZV9fZ3JvdXAtLXN1YmxldmVsLTUgLmZkLXRyZWVfX2NvbC0tY29udHJvbCB7XG4gICAgICAgIHBhZGRpbmctbGVmdDogMTgwcHg7IH1cbiAgICAgIC5mZC10cmVlX19ncm91cC0tc3VibGV2ZWwtNiAuZmQtdHJlZV9fY29sLS1jb250cm9sIHtcbiAgICAgICAgcGFkZGluZy1sZWZ0OiAyMTBweDsgfVxuICAgICAgLmZkLXRyZWVfX2dyb3VwLS1zdWJsZXZlbC03IC5mZC10cmVlX19jb2wtLWNvbnRyb2wge1xuICAgICAgICBwYWRkaW5nLWxlZnQ6IDI0MHB4OyB9XG4gICAgICAuZmQtdHJlZV9fZ3JvdXAtLXN1YmxldmVsLTggLmZkLXRyZWVfX2NvbC0tY29udHJvbCB7XG4gICAgICAgIHBhZGRpbmctbGVmdDogMjcwcHg7IH1cbiAgICAuZmQtdHJlZV9fY29sLS1hY3Rpb25zIHtcbiAgICAgIHBhZGRpbmctdG9wOiAwO1xuICAgICAgcGFkZGluZy1ib3R0b206IDA7XG4gICAgICB0ZXh0LWFsaWduOiByaWdodDsgfVxuICAuZmQtdHJlZV9fY29udHJvbCB7XG4gICAgbWFyZ2luOiAwO1xuICAgIHBhZGRpbmc6IDA7XG4gICAgZm9udC1zbW9vdGhpbmc6IGFudGlhbGlhc2VkO1xuICAgIGFwcGVhcmFuY2U6IG5vbmU7XG4gICAgb3V0bGluZTogMDtcbiAgICBib3JkZXI6IDA7XG4gICAgZGlzcGxheTogaW5saW5lLWJsb2NrO1xuICAgIHRleHQtZGVjb3JhdGlvbjogbm9uZTtcbiAgICBjdXJzb3I6IHBvaW50ZXI7XG4gICAgdXNlci1zZWxlY3Q6IG5vbmU7XG4gICAgdmVydGljYWwtYWxpZ246IG1pZGRsZTtcbiAgICB3aGl0ZS1zcGFjZTogbm93cmFwO1xuICAgIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50O1xuICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICB0b3A6IGNhbGMoNTAlIC0gMThweC8yKTtcbiAgICBtYXJnaW4tbGVmdDogLTMwcHg7XG4gICAgd2lkdGg6IDE4cHg7XG4gICAgaGVpZ2h0OiAxOHB4O1xuICAgIG1hcmdpbi1yaWdodDogMTJweDtcbiAgICBiYWNrZ3JvdW5kOiB1cmwoXCJkYXRhOmltYWdlL3N2Zyt4bWw7YmFzZTY0LFBITjJaeUI0Yld4dWN6MGlhSFIwY0RvdkwzZDNkeTUzTXk1dmNtY3ZNakF3TUM5emRtY2lJSGRwWkhSb1BTSXhNaUlnYUdWcFoyaDBQU0k1SWo0OGNHRjBhQ0JtYVd4c0xYSjFiR1U5SW1WMlpXNXZaR1FpSUdacGJHdzlJaU13TURoR1JESWlJR1E5SWsweE1TNDVNelVnTVM0ME56Vk1OaTR4T0RnZ055NDVNamRoTGpJMk5DNHlOalFnTUNBd0lERXRMak0zT0NBd1RDNHdOalVnTVM0ME56VmhMakl6Tmk0eU16WWdNQ0F3SURFZ0xqQXlOaTB1TXpRelRERXVNemd4TGpBMU9HRXVNalV6TGpJMU15QXdJREFnTVNBdU1UWXpMUzR3TlRsTU1TNDFOak1nTUdFdU1qVXlMakkxTWlBd0lEQWdNU0F1TVRjeExqQTROV3cwTGpJMk5TQTBMamc0SURRdU1qWTNMVFF1T0RoaExqSTFNaTR5TlRJZ01DQXdJREVnTGpNMU1pMHVNREkzYkRFdU1qa3hJREV1TURjMFl5NHdOUzR3TkRJdU1EZ3hMakV3TWk0d09EWXVNVFkyWVM0eU16WXVNak0ySURBZ01DQXhMUzR3Tmk0eE56ZDZJaTgrUEM5emRtYytcIikgbm8tcmVwZWF0IDUwJTtcbiAgICBiYWNrZ3JvdW5kLXNpemU6IGNvbnRhaW47XG4gICAgdHJhbnNmb3JtOiByb3RhdGUoLTkwZGVnKTtcbiAgICB2ZXJ0aWNhbC1hbGlnbjogbWlkZGxlO1xuICAgIHRyYW5zaXRpb246IHRyYW5zZm9ybSAwLjEyNXMgbGluZWFyOyB9XG4gICAgLmZkLXRyZWVfX2NvbnRyb2xbYXJpYS1wcmVzc2VkPVwidHJ1ZVwiXSwgLmZkLXRyZWVfX2NvbnRyb2wuaXMtcHJlc3NlZCB7XG4gICAgICB0cmFuc2Zvcm06IHJvdGF0ZSgwKTsgfVxuICAuZmQtdHJlZSBhIHtcbiAgICBjb2xvcjogIzAwOWNkZjsgfVxuICAgIC5mZC10cmVlIGE6aG92ZXIge1xuICAgICAgY29sb3I6ICMwMDljZGY7IH1cblxuLyohXG4uZmQtbGlzdC1ncm91cFxuICAuZmQtbGlzdC1ncm91cF9faXRlbVxuICAgICAgLmZkLWxpc3QtZ3JvdXBfX2FjdGlvblxuKi9cbi5mZC1saXN0LWdyb3VwIHtcbiAgZm9udC1zaXplOiAxcmVtO1xuICBsaW5lLWhlaWdodDogMS41O1xuICBjb2xvcjogIzIxMjYyYztcbiAgbWFyZ2luLWxlZnQ6IDA7IH1cbiAgLmZkLWxpc3QtZ3JvdXBfX2l0ZW0ge1xuICAgIGxpc3Qtc3R5bGU6IG5vbmU7XG4gICAgYm9yZGVyOiAxcHggc29saWQgI2U0ZTRlNDtcbiAgICBib3JkZXItdG9wOiBub25lO1xuICAgIHBhZGRpbmc6IDE2cHg7XG4gICAgZGlzcGxheTogZmxleDtcbiAgICBwb3NpdGlvbjogcmVsYXRpdmU7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogbm9uZTtcbiAgICB0cmFuc2l0aW9uOiBiYWNrZ3JvdW5kLWNvbG9yIDAuMTI1cyBlYXNlLWluOyB9XG4gICAgLmZkLWxpc3QtZ3JvdXBfX2l0ZW06Zmlyc3QtY2hpbGQge1xuICAgICAgYm9yZGVyLXRvcDogMXB4IHNvbGlkICNlNGU0ZTQ7IH1cbiAgICAuZmQtbGlzdC1ncm91cF9faXRlbTpob3ZlciB7XG4gICAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjZjFmNWY5OyB9XG4gIC5mZC1saXN0LWdyb3VwX19hY3Rpb24ge1xuICAgIGZsZXg6IDE7XG4gICAgdGV4dC1hbGlnbjogcmlnaHQ7XG4gICAgcG9zaXRpb246IHJlbGF0aXZlO1xuICAgIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgICBtYXgtaGVpZ2h0OiA0MHB4O1xuICAgIHBhZGRpbmctdG9wOiA0cHg7XG4gICAgdG9wOiAtMTZweDtcbiAgICBtYXJnaW4tYm90dG9tOiAtMzJweDtcbiAgICByaWdodDogLTE2cHg7IH1cblxuLyohXG4uZmQtdG9vbHRpcFxuICAgIC5mZC10b29sdGlwX19jb250ZW50KyhsZWZ0LCByaWdodCwgYm90dG9tLWxlZnQsIGJvdHRvbS1yaWdodClcbiovXG4uZmQtaW5saW5lLWhlbHAge1xuICBmb250LXNpemU6IDAuODc1cmVtO1xuICBsaW5lLWhlaWdodDogMS40Mjg1ODtcbiAgZm9udC13ZWlnaHQ6IDQwMDtcbiAgcG9zaXRpb246IHJlbGF0aXZlO1xuICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gIHdpZHRoOiAxOHB4O1xuICBoZWlnaHQ6IDE4cHg7XG4gIHRvcDogM3B4OyB9XG4gIC5mZC1pbmxpbmUtaGVscDo6YmVmb3JlIHtcbiAgICBjb250ZW50OiBcIj9cIjtcbiAgICB3aWR0aDogMThweDtcbiAgICBoZWlnaHQ6IDE4cHg7XG4gICAgZm9udC1zdHlsZTogbm9ybWFsO1xuICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICBsZWZ0OiAwO1xuICAgIGNvbG9yOiAjZmZmZmZmO1xuICAgIGJvcmRlci1yYWRpdXM6IDUwJTtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjNjM3NThiO1xuICAgIHRleHQtYWxpZ246IGNlbnRlcjsgfVxuICAuZmQtaW5saW5lLWhlbHBfX2NvbnRlbnQge1xuICAgIGZvbnQtc2l6ZTogMC44MTI1cmVtO1xuICAgIGxpbmUtaGVpZ2h0OiAxLjUzODQ3O1xuICAgIGZvbnQtd2VpZ2h0OiA0MDA7XG4gICAgYmFja2dyb3VuZDogIzYzNzU4YjtcbiAgICBwYWRkaW5nOiAxMnB4O1xuICAgIGRpc3BsYXk6IGJsb2NrO1xuICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICBjb2xvcjogI2ZmZmZmZjtcbiAgICB0b3A6IDMwcHg7XG4gICAgcmlnaHQ6IC0xMnB4O1xuICAgIG1pbi13aWR0aDogMzUwcHg7XG4gICAgdmlzaWJpbGl0eTogaGlkZGVuO1xuICAgIG9wYWNpdHk6IDA7XG4gICAgdHJhbnNpdGlvbjogb3BhY2l0eSAwLjEyNXMgZWFzZS1pbjtcbiAgICB0ZXh0LWFsaWduOiBsZWZ0O1xuICAgIHotaW5kZXg6IDE7IH1cbiAgICAuZmQtaW5saW5lLWhlbHBfX2NvbnRlbnQ6OmJlZm9yZSB7XG4gICAgICB3aWR0aDogMDtcbiAgICAgIGhlaWdodDogMDtcbiAgICAgIGJvcmRlci1zdHlsZTogc29saWQ7XG4gICAgICBib3JkZXItd2lkdGg6IDAgMTBweCAxMHB4IDEwcHg7XG4gICAgICBib3JkZXItY29sb3I6IHRyYW5zcGFyZW50IHRyYW5zcGFyZW50ICM2Mzc1OGIgdHJhbnNwYXJlbnQ7XG4gICAgICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gICAgICBjb250ZW50OiBcIlwiO1xuICAgICAgdG9wOiAtMTBweDtcbiAgICAgIHJpZ2h0OiAxMHB4OyB9XG4gICAgLmZkLWlubGluZS1oZWxwX19jb250ZW50LS1sZWZ0IHtcbiAgICAgIHRvcDogLTEycHg7XG4gICAgICBsZWZ0OiAzMHB4OyB9XG4gICAgICAuZmQtaW5saW5lLWhlbHBfX2NvbnRlbnQtLWxlZnQ6OmJlZm9yZSB7XG4gICAgICAgIHRvcDogMTVweDtcbiAgICAgICAgbGVmdDogLTE1cHg7XG4gICAgICAgIHRyYW5zZm9ybTogcm90YXRlKC05MGRlZyk7IH1cbiAgICAuZmQtaW5saW5lLWhlbHBfX2NvbnRlbnQtLXJpZ2h0IHtcbiAgICAgIHRvcDogLTEycHg7XG4gICAgICByaWdodDogMzBweDsgfVxuICAgICAgLmZkLWlubGluZS1oZWxwX19jb250ZW50LS1yaWdodDo6YmVmb3JlIHtcbiAgICAgICAgdG9wOiAxNXB4O1xuICAgICAgICByaWdodDogLTE1cHg7XG4gICAgICAgIHRyYW5zZm9ybTogcm90YXRlKDkwZGVnKTsgfVxuICAgIC5mZC1pbmxpbmUtaGVscF9fY29udGVudC0tYm90dG9tLWxlZnQge1xuICAgICAgbGVmdDogLTEwcHg7IH1cbiAgICAgIC5mZC1pbmxpbmUtaGVscF9fY29udGVudC0tYm90dG9tLWxlZnQ6OmJlZm9yZSB7XG4gICAgICAgIHRvcDogLTEwcHg7XG4gICAgICAgIGxlZnQ6IDEwcHg7IH1cbiAgLmZkLWlubGluZS1oZWxwOmhvdmVyIC5mZC1pbmxpbmUtaGVscF9fY29udGVudCB7XG4gICAgdmlzaWJpbGl0eTogdmlzaWJsZTtcbiAgICBvcGFjaXR5OiAxO1xuICAgIG92ZXJmbG93OiB2aXNpYmxlOyB9XG5cbi8qIVxuLmZkLW5hdisoLS12ZXJ0aWNhbClcbiAgICAuZmQtbmF2X19pdGVtXG4gICAgLmZkLW5hdl9fbGluaysoKC5pcy1zZWxlY3RlZHxbYXJpYS1zZWxlY3RlZD10cnVlXSksKC5pcy1kaXNhYmxlZHxbYXJpYS1kaXNhYmxlZD10cnVlXSkpXG4qL1xuLmZkLW5hdiB7XG4gIGZvbnQtc2l6ZTogMXJlbTtcbiAgbGluZS1oZWlnaHQ6IDEuNTtcbiAgY29sb3I6ICMyMTI2MmM7XG4gIGRpc3BsYXk6IGZsZXg7XG4gIGZsZXgtd3JhcDogd3JhcDtcbiAgcGFkZGluZy1sZWZ0OiAwO1xuICBtYXJnaW4tYm90dG9tOiAwO1xuICBsaXN0LXN0eWxlOiBub25lOyB9XG4gIC5mZC1uYXYtLXZlcnRpY2FsIHtcbiAgICBmbGV4LWRpcmVjdGlvbjogY29sdW1uOyB9XG4gIC5mZC1uYXZfX2xpbmsge1xuICAgIGRpc3BsYXk6IGJsb2NrO1xuICAgIHBhZGRpbmc6IDhweDsgfVxuICAgIC5mZC1uYXZfX2xpbmsuaXMtc2VsZWN0ZWQsIC5mZC1uYXZfX2xpbmtbYXJpYS1zZWxlY3RlZD1cInRydWVcIl0ge1xuICAgICAgY29sb3I6ICMyMTI2MmM7IH1cblxuLyohXG4uZmQtdGFicysoKVxuICAgIC5mZC10YWJzX19pdGVtP1xuICAgIC5mZC10YWJzX19saW5rKygoLmlzLXNlbGVjdGVkfFthcmlhLXNlbGVjdGVkPXRydWVdKSwoLmlzLWRpc2FibGVkfFthcmlhLWRpc2FibGVkPXRydWVdKSlcbi5mZC10YWJzX19wYW5lbCsoW2FyaWEtZXhwYW5kZWRdfC5pcy1leHBhbmRlZClcbiovXG4uZmQtdGFicyB7XG4gIGZvbnQtc2l6ZTogMXJlbTtcbiAgbGluZS1oZWlnaHQ6IDEuNTtcbiAgY29sb3I6ICMyMTI2MmM7XG4gIGRpc3BsYXk6IGZsZXg7XG4gIGZsZXgtd3JhcDogd3JhcDtcbiAgcGFkZGluZy1sZWZ0OiAwO1xuICBtYXJnaW4tYm90dG9tOiA0MHB4O1xuICBsaXN0LXN0eWxlOiBub25lO1xuICBib3JkZXItYm90dG9tOiBzb2xpZCAxcHggI2NjZGFlYjsgfVxuICAuZmQtdGFic19fbGluayB7XG4gICAgZGlzcGxheTogYmxvY2s7XG4gICAgcGFkZGluZzogMTJweCAyMHB4O1xuICAgIGZvbnQtc2l6ZTogMS4xMjVyZW07XG4gICAgbGluZS1oZWlnaHQ6IDEuMzMzMzQ7XG4gICAgZm9udC1mYW1pbHk6IFJvYm90bywgc2Fucy1zZXJpZjtcbiAgICBmb250LXdlaWdodDogNTAwO1xuICAgIHRleHQtdHJhbnNmb3JtOiB1cHBlcmNhc2U7XG4gICAgY29sb3I6ICMwMDljZGY7XG4gICAgYm9yZGVyLWJvdHRvbTogc29saWQgMnB4IHRyYW5zcGFyZW50O1xuICAgIHRyYW5zaXRpb246IGFsbCAwLjEyNXMgZWFzZS1pbjtcbiAgICBjdXJzb3I6IHBvaW50ZXI7IH1cbiAgICAuZmQtdGFic19fbGluazpob3ZlciB7XG4gICAgICBib3JkZXItYm90dG9tOiBzb2xpZCAycHggIzAwOWNkZjtcbiAgICAgIGNvbG9yOiAjMDA4YWM2OyB9XG4gICAgLmZkLXRhYnNfX2xpbmsuaXMtc2VsZWN0ZWQsIC5mZC10YWJzX19saW5rW2FyaWEtc2VsZWN0ZWQ9XCJ0cnVlXCJdIHtcbiAgICAgIGNvbG9yOiAjMjEyNjJjO1xuICAgICAgYm9yZGVyLWJvdHRvbTogc29saWQgMnB4ICMwMDljZGY7IH1cbiAgICAuZmQtdGFic19fbGluay5pcy1kaXNhYmxlZCwgLmZkLXRhYnNfX2xpbmtbYXJpYS1kaXNhYmxlZD1cInRydWVcIl0ge1xuICAgICAgY29sb3I6ICM3ZjkwYTQ7XG4gICAgICBjdXJzb3I6IG5vdC1hbGxvd2VkOyB9XG4gICAgICAuZmQtdGFic19fbGluay5pcy1kaXNhYmxlZDpob3ZlciwgLmZkLXRhYnNfX2xpbmtbYXJpYS1kaXNhYmxlZD1cInRydWVcIl06aG92ZXIge1xuICAgICAgICBib3JkZXItYm90dG9tLWNvbG9yOiB0cmFuc3BhcmVudDsgfVxuICAuZmQtdGFic19fcGFuZWxbYXJpYS1leHBhbmRlZD1cImZhbHNlXCJdIHtcbiAgICBkaXNwbGF5OiBub25lOyB9XG4gIC5mZC10YWJzX19wYW5lbC5pcy1leHBhbmRlZCwgLmZkLXRhYnNfX3BhbmVsW2FyaWEtZXhwYW5kZWQ9XCJ0cnVlXCJdIHtcbiAgICBkaXNwbGF5OiBibG9jazsgfVxuXG4vKiFcbi5mZC10b2dnbGUrKC0tbm8tYm9yZGVyKVxuICAgIC5mZC10b2dnbGVfX2NvbnRlbnQrKClcbiAgICAuZmQtdG9nZ2xlX190aXRsZSsoKVxuKi9cbi5mZC10b2dnbGUge1xuICBmb250LXNpemU6IDFyZW07XG4gIGxpbmUtaGVpZ2h0OiAxLjU7XG4gIGNvbG9yOiAjMjEyNjJjO1xuICBwb3NpdGlvbjogcmVsYXRpdmU7XG4gIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgaGVpZ2h0OiA0MHB4O1xuICB3aWR0aDogNzZweDsgfVxuICAuZmQtdG9nZ2xlX19zd2l0Y2gge1xuICAgIGhlaWdodDogMzJweDtcbiAgICB3aWR0aDogMzJweDtcbiAgICBib3JkZXItcmFkaXVzOiA1MCU7XG4gICAgcG9zaXRpb246IGFic29sdXRlO1xuICAgIHRvcDogNHB4O1xuICAgIGxlZnQ6IDRweDtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiB3aGl0ZTtcbiAgICB0cmFuc2l0aW9uOiBsZWZ0IDAuMTI1cyBlYXNlLWluO1xuICAgIHBvaW50ZXItZXZlbnRzOiBub25lOyB9XG4gIC5mZC10b2dnbGUgaW5wdXQge1xuICAgIGJhY2tncm91bmQtY29sb3I6ICNjY2RhZWI7XG4gICAgYm9yZGVyLXJhZGl1czogMjBweDtcbiAgICB3aWR0aDogMTAwJTtcbiAgICBoZWlnaHQ6IDEwMCU7XG4gICAgYm9yZGVyLWNvbG9yOiB0cmFuc3BhcmVudDtcbiAgICB2ZXJ0aWNhbC1hbGlnbjogbWlkZGxlOyB9XG4gICAgLmZkLXRvZ2dsZSBpbnB1dDpjaGVja2VkOjphZnRlciB7XG4gICAgICBkaXNwbGF5OiBub25lOyB9XG4gICAgLmZkLXRvZ2dsZSBpbnB1dDpjaGVja2VkICsgLmZkLXRvZ2dsZV9fc3dpdGNoIHtcbiAgICAgIGxlZnQ6IGNhbGMoNTAlICsgMnB4KTsgfVxuICAgIC5mZC10b2dnbGUgaW5wdXRbZGlzYWJsZWRdLCAuZmQtdG9nZ2xlIGlucHV0LmlzLWRpc2FibGVkLCAuZmQtdG9nZ2xlIGlucHV0W2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdIHtcbiAgICAgIGJvcmRlci1jb2xvcjogI2NjZGFlYjsgfVxuICAgICAgLmZkLXRvZ2dsZSBpbnB1dFtkaXNhYmxlZF0gKyAuZmQtdG9nZ2xlX19zd2l0Y2gsIC5mZC10b2dnbGUgaW5wdXQuaXMtZGlzYWJsZWQgKyAuZmQtdG9nZ2xlX19zd2l0Y2gsIC5mZC10b2dnbGUgaW5wdXRbYXJpYS1kaXNhYmxlZD1cInRydWVcIl0gKyAuZmQtdG9nZ2xlX19zd2l0Y2gge1xuICAgICAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjZDdkN2Q3OyB9XG4gIC5mZC10b2dnbGUtLXNtYWxsIHtcbiAgICBoZWlnaHQ6IDMycHg7XG4gICAgd2lkdGg6IDYwcHg7IH1cbiAgICAuZmQtdG9nZ2xlLS1zbWFsbCBpbnB1dCB7XG4gICAgICBib3JkZXItcmFkaXVzOiAxNnB4OyB9XG4gICAgLmZkLXRvZ2dsZS0tc21hbGwgLmZkLXRvZ2dsZV9fc3dpdGNoIHtcbiAgICAgIGhlaWdodDogMjRweDtcbiAgICAgIHdpZHRoOiAyNHB4OyB9XG4gIC5mZC10b2dnbGUtLWxhcmdlIHtcbiAgICBoZWlnaHQ6IDUycHg7XG4gICAgd2lkdGg6IDEwMHB4OyB9XG4gICAgLmZkLXRvZ2dsZS0tbGFyZ2UgaW5wdXQge1xuICAgICAgYm9yZGVyLXJhZGl1czogMjZweDsgfVxuICAgIC5mZC10b2dnbGUtLWxhcmdlIC5mZC10b2dnbGVfX3N3aXRjaCB7XG4gICAgICBoZWlnaHQ6IDQ0cHg7XG4gICAgICB3aWR0aDogNDRweDsgfVxuXG4vKiFcbi5mZC1zcGlubmVyKyguaXMtaGlkZGVufFthcmlhLWhpZGRlbj10cnVlXSlcblxuSW5zcGlyZWQgYnkgbGluZSBzY2FsZSBzcGlubmVyIGZyb20gTG9hZCBBd2Vzb21lIHYxLjEuMCAoaHR0cDovL2dpdGh1Yi5kYW5pZWxjYXJkb3NvLm5ldC9sb2FkLWF3ZXNvbWUvKVxuKiBDb3B5cmlnaHQgMjAxNSBEYW5pZWwgQ2FyZG9zbyA8QERhbmllbENhcmRvc28+XG4qIExpY2Vuc2VkIHVuZGVyIE1JVFxuKi9cbi5mZC1zcGlubmVyIHtcbiAgcG9zaXRpb246IHJlbGF0aXZlO1xuICB3aWR0aDogMjlweDtcbiAgaGVpZ2h0OiA0MHB4O1xuICBkaXNwbGF5OiBmbGV4O1xuICBqdXN0aWZ5LWNvbnRlbnQ6IHNwYWNlLWJldHdlZW47XG4gIG1hcmdpbjogMCBhdXRvOyB9XG4gIC5mZC1zcGlubmVyLmlzLWhpZGRlbiwgLmZkLXNwaW5uZXJbYXJpYS1oaWRkZW49XCJ0cnVlXCJdIHtcbiAgICBkaXNwbGF5OiBub25lOyB9XG4gIC5pcy1idXN5LCBbYXJpYS1idXN5PVwidHJ1ZVwiXSB7XG4gICAgcG9zaXRpb246IHJlbGF0aXZlO1xuICAgIG1pbi1oZWlnaHQ6IDQwcHg7IH1cbiAgICAuaXMtYnVzeTo6YmVmb3JlLCBbYXJpYS1idXN5PVwidHJ1ZVwiXTo6YmVmb3JlIHtcbiAgICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICAgIGJhY2tncm91bmQtY29sb3I6IHJnYmEoMjU1LCAyNTUsIDI1NSwgMC45NSk7XG4gICAgICB0b3A6IDA7XG4gICAgICByaWdodDogMDtcbiAgICAgIGJvdHRvbTogMDtcbiAgICAgIGxlZnQ6IDA7XG4gICAgICB6LWluZGV4OiAxO1xuICAgICAgY29udGVudDogXCJcIjsgfVxuICAgIC5pcy1idXN5IC5mZC1zcGlubmVyLCBbYXJpYS1idXN5PVwidHJ1ZVwiXSAuZmQtc3Bpbm5lciB7XG4gICAgICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gICAgICB6LWluZGV4OiAyO1xuICAgICAgbGVmdDogY2FsYyg1MCUgLSAyOXB4LzIpO1xuICAgICAgdG9wOiBjYWxjKDUwJSAtIDQwcHgvMik7IH1cbiAgLmZkLXNwaW5uZXI6OmJlZm9yZSwgLmZkLXNwaW5uZXI6OmFmdGVyIHtcbiAgICBjb250ZW50OiBcIlwiO1xuICAgIHBvc2l0aW9uOiByZWxhdGl2ZTtcbiAgICB3aWR0aDogNXB4O1xuICAgIGhlaWdodDogMTAwJTtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjMDA5Y2RmOyB9XG4gIC5mZC1zcGlubmVyIGRpdjo6YmVmb3JlLCAuZmQtc3Bpbm5lciBkaXY6OmFmdGVyIHtcbiAgICBjb250ZW50OiBcIlwiO1xuICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICB3aWR0aDogNXB4O1xuICAgIGhlaWdodDogMTAwJTtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjMDA5Y2RmOyB9XG4gIC5mZC1zcGlubmVyIGRpdjo6YmVmb3JlIHtcbiAgICBsZWZ0OiA4cHg7IH1cbiAgLmZkLXNwaW5uZXIgZGl2OjphZnRlciB7XG4gICAgcmlnaHQ6IDhweDsgfVxuICAuZmQtc3Bpbm5lcjo6YmVmb3JlIHtcbiAgICBhbmltYXRpb246IGxpbmUtc2NhbGUgMXMgaW5maW5pdGUgZWFzZTtcbiAgICBhbmltYXRpb24tZGVsYXk6IC0xczsgfVxuICAuZmQtc3Bpbm5lciBkaXY6OmJlZm9yZSB7XG4gICAgYW5pbWF0aW9uOiBsaW5lLXNjYWxlIDFzIGluZmluaXRlIGVhc2U7XG4gICAgYW5pbWF0aW9uLWRlbGF5OiAtMC45czsgfVxuICAuZmQtc3Bpbm5lciBkaXY6OmFmdGVyIHtcbiAgICBhbmltYXRpb246IGxpbmUtc2NhbGUgMXMgaW5maW5pdGUgZWFzZTtcbiAgICBhbmltYXRpb24tZGVsYXk6IC0wLjhzOyB9XG4gIC5mZC1zcGlubmVyOjphZnRlciB7XG4gICAgYW5pbWF0aW9uOiBsaW5lLXNjYWxlIDFzIGluZmluaXRlIGVhc2U7XG4gICAgYW5pbWF0aW9uLWRlbGF5OiAtMC43czsgfVxuXG5Aa2V5ZnJhbWVzIGxpbmUtc2NhbGUge1xuICAwJSxcbiAgNDAlLFxuICAxMDAlIHtcbiAgICB0cmFuc2Zvcm06IHNjYWxlWSgwLjQpOyB9XG4gIDgwJSB7XG4gICAgdHJhbnNmb3JtOiBzY2FsZVkoMSk7IH0gfVxuXG4vKiFcbi5mZC1pbWFnZSsoKC0tcm91bmRlZHwtLWNpcmNsZSksICgtLXhzfC0tc3wtLW18LS1sfC0teGx8LS14eGwpLCAoLS1wcm9kdWN0fC0tcHJvZmlsZSkpXG4qL1xuLmZkLWltYWdlIHtcbiAgZGlzcGxheTogaW5saW5lLWJsb2NrO1xuICB2ZXJ0aWNhbC1hbGlnbjogbWlkZGxlO1xuICBiYWNrZ3JvdW5kLXJlcGVhdDogbm8tcmVwZWF0O1xuICBiYWNrZ3JvdW5kLXNpemU6IGNvdmVyO1xuICBiYWNrZ3JvdW5kLXBvc2l0aW9uOiA1MCU7IH1cbiAgLmZkLWltYWdlLS14cyB7XG4gICAgd2lkdGg6IDIwcHg7XG4gICAgaGVpZ2h0OiAyMHB4OyB9XG4gIC5mZC1pbWFnZS0tcyB7XG4gICAgd2lkdGg6IDM2cHg7XG4gICAgaGVpZ2h0OiAzNnB4OyB9XG4gIC5mZC1pbWFnZS0tbSB7XG4gICAgd2lkdGg6IDUycHg7XG4gICAgaGVpZ2h0OiA1MnB4OyB9XG4gIC5mZC1pbWFnZS0tbCB7XG4gICAgd2lkdGg6IDcycHg7XG4gICAgaGVpZ2h0OiA3MnB4OyB9XG4gIC5mZC1pbWFnZS0teGwge1xuICAgIHdpZHRoOiA5MnB4O1xuICAgIGhlaWdodDogOTJweDsgfVxuICAuZmQtaW1hZ2UtLXh4bCB7XG4gICAgd2lkdGg6IDEyMHB4O1xuICAgIGhlaWdodDogMTIwcHg7IH1cbiAgLmZkLWltYWdlLS1yb3VuZGVkIHtcbiAgICBib3JkZXItcmFkaXVzOiA4cHg7IH1cbiAgICAuZmQtaW1hZ2UtLXJvdW5kZWQuZmQtaW1hZ2UtLXhzLCAuZmQtaW1hZ2UtLXJvdW5kZWQuZmQtaW1hZ2UtLXMge1xuICAgICAgYm9yZGVyLXJhZGl1czogNHB4OyB9XG4gIC5mZC1pbWFnZS0tY2lyY2xlIHtcbiAgICBib3JkZXItcmFkaXVzOiA1MCU7IH1cbiAgLmZkLWltYWdlLS1wcm9maWxlLCAuZmQtaW1hZ2UtLXByb2R1Y3Qge1xuICAgIGJhY2tncm91bmQtY29sb3I6ICNkN2Q3ZDc7IH1cbiAgLmZkLWltYWdlLS1wcm9maWxlIHtcbiAgICBiYWNrZ3JvdW5kLWltYWdlOiB1cmwoXCJkYXRhOmltYWdlL3N2Zyt4bWw7YmFzZTY0LFBITjJaeUIzYVdSMGFEMGlOVElpSUdobGFXZG9kRDBpTlRJaUlIWnBaWGRDYjNnOUlqQWdNQ0ExTWlBMU1pSWdlRzFzYm5NOUltaDBkSEE2THk5M2QzY3Vkek11YjNKbkx6SXdNREF2YzNabklqNDhkR2wwYkdVK2RHNHRhVzFoWjJVdFltRmphMmR5YjNWdVpDMXBiV0ZuWlMwdGNISnZabWxzWlR3dmRHbDBiR1UrUEhCaGRHZ2daRDBpVFRJMklETTVkaTB4YURFeFl5MHlMamMxTkM0Mk5qY3ROaTQwTWlBeExURXhJREY2YlRBZ01HTXRNaTR4TkRnZ01DMDFMamd4TlMwdU16TXpMVEV4TFRGb01URjJNWHB0TVRFdE1VZ3hOV013TFRVdU5UVTRJRE11TkRZMExURXdMakl6TkNBNExqRTJOUzB4TVM0MU9UaEJOeTR3TURJZ055NHdNRElnTUNBd0lERWdNallnTVROaE55QTNJREFnTUNBeElESXVPRE0xSURFekxqUXdNa016TXk0MU16WWdNamN1TnpZMklETTNJRE15TGpRME1pQXpOeUF6T0hvaUlHWnBiR3d0Y25Wc1pUMGlibTl1ZW1WeWJ5SWdabWxzYkQwaUkwWkdSaUl2UGp3dmMzWm5QZz09XCIpOyB9XG4gIC5mZC1pbWFnZS0tcHJvZHVjdCB7XG4gICAgYmFja2dyb3VuZC1pbWFnZTogdXJsKFwiZGF0YTppbWFnZS9zdmcreG1sO2Jhc2U2NCxQSE4yWnlCM2FXUjBhRDBpTlRJaUlHaGxhV2RvZEQwaU5USWlJSFpwWlhkQ2IzZzlJakFnTUNBMU1pQTFNaUlnZUcxc2JuTTlJbWgwZEhBNkx5OTNkM2N1ZHpNdWIzSm5Mekl3TURBdmMzWm5JajQ4ZEdsMGJHVStkRzR0YVcxaFoyVXRZbUZqYTJkeWIzVnVaQzFwYldGblpTMHRjSEp2WkhWamREd3ZkR2wwYkdVK1BIQmhkR2dnWkQwaVRURXpMamczTmlBeE9DNHlNak5zTlM0NE56UXRNaTQxTlRVZ01URWdOUzQ1TXpRdE5TNHlPVEVnTWk0eE56Z3RNVEV1TlRnekxUVXVOVFUzZWsweE15QXpNeTR3TkROMkxURTBMakF6YkRFeExqa3hOeUExTGpjeGRqRTBMakE1TVd3dE1URXVOVGt0TlM0eU56VmhMalUwTGpVMElEQWdNQ0F4TFM0ek1qY3RMalE1TjNwdE15NHlOUzA1TGpJd09YWTFMalF4TjJFdU5UUXVOVFFnTUNBd0lEQWdMak14Tnk0ME9UTnNOUzQwTVRjZ01pNDNNRGhqTGpNMU9DNHhOak11TnpZMkxTNHhMamMyTmkwdU5Ea3pkaTAxTGpReE4yRXVOVFF5TGpVME1pQXdJREFnTUMwdU16RTNMUzQwT1RKc0xUVXVOREUzTFRJdU56QTVZUzQxTkRJdU5UUXlJREFnTUNBd0xTNDNOall1TkRremVtMDVMamMxTGpnNE9Xd3hNeTAxTGpjeGRqRTBMakF6WVM0MU5DNDFOQ0F3SURBZ01TMHVNekkyTGpRNU5rd3lOaUF6T0M0NE1UVldNalF1TnpJemVtMHhNaTR4TWpRdE5pNDFiQzAyTGpFMElESXVPREV6TFRFd0xqazNMVFV1T1RFM0lEUXVOemN0TWk0d056TmhMalV6Tmk0MU16WWdNQ0F3SURFZ0xqUXpNaUF3YkRFeExqa3dPQ0ExTGpFM04zb2lJR1pwYkd3dGNuVnNaVDBpYm05dWVtVnlieUlnWm1sc2JEMGlJMFpHUmlJdlBqd3ZjM1puUGc9PVwiKTsgfVxuXG5AZm9udC1mYWNlIHtcbiAgZm9udC1mYW1pbHk6IFwiRnVuZGFtZW50YWxJY29uc1wiO1xuICBzcmM6IHVybChcIkZ1bmRhbWVudGFsSWNvbnMud29mZjJcIikgZm9ybWF0KFwid29mZjJcIiksIHVybChcIkZ1bmRhbWVudGFsSWNvbnMud29mZlwiKSBmb3JtYXQoXCJ3b2ZmXCIpO1xuICBmb250LXdlaWdodDogbm9ybWFsO1xuICBmb250LXN0eWxlOiBub3JtYWw7IH1cblxuLmZkLWljb24ge1xuICBmb250LXNpemU6IDEuMTI1cmVtO1xuICBmb250LWZhbWlseTogXCJGdW5kYW1lbnRhbEljb25zXCI7XG4gIGxpbmUtaGVpZ2h0OiAxO1xuICBmb250LXN0eWxlOiBub3JtYWw7XG4gIGZvbnQtd2VpZ2h0OiBub3JtYWw7XG4gIHRleHQtYWxpZ246IGNlbnRlcjtcbiAgZGlzcGxheTogaW5saW5lLWJsb2NrO1xuICB0ZXh0LWRlY29yYXRpb246IGluaGVyaXQ7XG4gIHRleHQtdHJhbnNmb3JtOiBub25lO1xuICB0ZXh0LXJlbmRlcmluZzogb3B0aW1pemVMZWdpYmlsaXR5O1xuICAtd2Via2l0LWZvbnQtc21vb3RoaW5nOiBhbnRpYWxpYXNlZDtcbiAgLW1vei1vc3gtZm9udC1zbW9vdGhpbmc6IGdyYXlzY2FsZTsgfVxuICAuZmQtaWNvbi0tbWVkaXVtIHtcbiAgICBmb250LXNpemU6IDEuNjI1cmVtOyB9XG4gIC5mZC1pY29uLS1sYXJnZSB7XG4gICAgZm9udC1zaXplOiAycmVtOyB9XG4gIC5mZC1pY29uOjpiZWZvcmUge1xuICAgIGRpc3BsYXk6IGlubGluZTtcbiAgICB0ZXh0LWFsaWduOiBjZW50ZXI7IH1cbiAgLmZkLWljb24tLWFkZDo6YmVmb3JlIHtcbiAgICBjb250ZW50OiBcIu6ogVwiOyB9XG4gIC5mZC1pY29uLS1hcnJvdzo6YmVmb3JlIHtcbiAgICBjb250ZW50OiBcIu6oglwiOyB9XG4gIC5mZC1pY29uLS1iYWNrYXJyb3c6OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqINcIjsgfVxuICAuZmQtaWNvbi0tY2F1dGlvbjo6YmVmb3JlIHtcbiAgICBjb250ZW50OiBcIu6ohFwiOyB9XG4gIC5mZC1pY29uLS1jaGFuZ2U6OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqIVcIjsgfVxuICAuZmQtaWNvbi0tY2hlY2tlZDo6YmVmb3JlIHtcbiAgICBjb250ZW50OiBcIu6ohlwiOyB9XG4gIC5mZC1pY29uLS1jaGV2cm9uOjpiZWZvcmUsIC5mZC1wYWdpbmF0aW9uX19pdGVtIC5mZC1pY29uLS1jaGV2cm9uLWJhY2s6OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqIdcIjsgfVxuICAuZmQtaWNvbi0tY2xvbmU6OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqIhcIjsgfVxuICAuZmQtaWNvbi0tY2xvc2U6OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqIlcIjsgfVxuICAuZmQtaWNvbi0tY29sbGFwc2U6OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqIpcIjsgfVxuICAuZmQtaWNvbi0tZGVsZXRlOjpiZWZvcmUge1xuICAgIGNvbnRlbnQ6IFwi7qiLXCI7IH1cbiAgLmZkLWljb24tLWRvbmU6OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqIxcIjsgfVxuICAuZmQtaWNvbi0tZG91YmxlY2hldnJvbjo6YmVmb3JlIHtcbiAgICBjb250ZW50OiBcIu6ojVwiOyB9XG4gIC5mZC1pY29uLS1kcmFnZHJvcGxpc3Q6OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqI5cIjsgfVxuICAuZmQtaWNvbi0tZHJhZ2Ryb3BvYmplY3Q6OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqI9cIjsgfVxuICAuZmQtaWNvbi0tZWRpdDo6YmVmb3JlIHtcbiAgICBjb250ZW50OiBcIu6okFwiOyB9XG4gIC5mZC1pY29uLS1leHBhbmQ6OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqJFcIjsgfVxuICAuZmQtaWNvbi0tZmVlZGJhY2s6OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqJJcIjsgfVxuICAuZmQtaWNvbi0tZmlsdGVyOjpiZWZvcmUge1xuICAgIGNvbnRlbnQ6IFwi7qiTXCI7IH1cbiAgLmZkLWljb24tLWZpbHRlcnJlbW92ZTo6YmVmb3JlIHtcbiAgICBjb250ZW50OiBcIu6olFwiOyB9XG4gIC5mZC1pY29uLS1ncmlkOjpiZWZvcmUge1xuICAgIGNvbnRlbnQ6IFwi7qiVXCI7IH1cbiAgLmZkLWljb24tLWhlbHA6OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqJZcIjsgfVxuICAuZmQtaWNvbi0taW5mb29uOjpiZWZvcmUge1xuICAgIGNvbnRlbnQ6IFwi7qiXXCI7IH1cbiAgLmZkLWljb24tLWxpbms6OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqJhcIjsgfVxuICAuZmQtaWNvbi0tbGlzdDo6YmVmb3JlIHtcbiAgICBjb250ZW50OiBcIu6omVwiOyB9XG4gIC5mZC1pY29uLS1sb2NhbGl6YXRpb246OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqJpcIjsgfVxuICAuZmQtaWNvbi0tbG9jazo6YmVmb3JlIHtcbiAgICBjb250ZW50OiBcIu6om1wiOyB9XG4gIC5mZC1pY29uLS1tYXhpbWl6ZTo6YmVmb3JlIHtcbiAgICBjb250ZW50OiBcIu6onFwiOyB9XG4gIC5mZC1pY29uLS1taW5pbWl6ZTo6YmVmb3JlIHtcbiAgICBjb250ZW50OiBcIu6onVwiOyB9XG4gIC5mZC1pY29uLS1tb3JlOjpiZWZvcmUge1xuICAgIGNvbnRlbnQ6IFwi7qieXCI7IH1cbiAgLmZkLWljb24tLW5vaW1hZ2U6OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqJ9cIjsgfVxuICAuZmQtaWNvbi0tb3B0aW9uczo6YmVmb3JlIHtcbiAgICBjb250ZW50OiBcIu6ooFwiOyB9XG4gIC5mZC1pY29uLS1zZWFyY2g6OmJlZm9yZSB7XG4gICAgY29udGVudDogXCLuqKFcIjsgfVxuICAuZmQtaWNvbi0tc29ydDo6YmVmb3JlIHtcbiAgICBjb250ZW50OiBcIu6oolwiOyB9XG4gIC5mZC1pY29uLS1zeW5jOjpiZWZvcmUge1xuICAgIGNvbnRlbnQ6IFwi7qijXCI7IH1cbiAgLmZkLWljb24tLXRvcDo6YmVmb3JlIHtcbiAgICBjb250ZW50OiBcIu6opFwiOyB9XG4gIC5mZC1pY29uLS12aXNpYmlsaXR5b2ZmOjpiZWZvcmUge1xuICAgIGNvbnRlbnQ6IFwi7qilXCI7IH1cbiAgLmZkLWljb24tLXZpc2liaWxpdHlvbjo6YmVmb3JlIHtcbiAgICBjb250ZW50OiBcIu6oplwiOyB9XG4gIC5mZC1pY29uLS13YXJuaW5nOjpiZWZvcmUge1xuICAgIGNvbnRlbnQ6IFwi7qinXCI7IH1cblxuLmZkLXRleHQtdHJhbnNmb3JtLW5vbmUge1xuICB0ZXh0LXRyYW5zZm9ybTogbm9uZSAhaW1wb3J0YW50OyB9XG5cbi5mZC1oYXMtZm9udC13ZWlnaHQtYm9sZCB7XG4gIGZvbnQtd2VpZ2h0OiBib2xkICFpbXBvcnRhbnQ7IH1cblxuLmZkLWhhcy1mb250LXN0eWxlLWl0YWxpYyB7XG4gIGZvbnQtc3R5bGU6IGl0YWxpYyAhaW1wb3J0YW50OyB9XG5cbi5mZC1oYXMtdGV4dC1hbGlnbi1jZW50ZXIge1xuICB0ZXh0LWFsaWduOiBjZW50ZXIgIWltcG9ydGFudDsgfVxuXG4uZmQtaGFzLXRleHQtYWxpZ24tcmlnaHQge1xuICB0ZXh0LWFsaWduOiByaWdodCAhaW1wb3J0YW50OyB9XG5cbi5mZC1oYXMtZmxvYXQtbGVmdCB7XG4gIGZsb2F0OiBsZWZ0ICFpbXBvcnRhbnQ7IH1cblxuLmZkLWhhcy1mbG9hdC1yaWdodCB7XG4gIGZsb2F0OiByaWdodCAhaW1wb3J0YW50OyB9XG5cbi5mZC1oYXMtYm9yZGVyLXJhZGl1cy01MHBlcmNlbnQge1xuICBib3JkZXItcmFkaXVzOiA1MCUgIWltcG9ydGFudDsgfVxuXG4uZmQtaGFzLXR5cGUtbWludXMtMyB7XG4gIGZvbnQtc2l6ZTogMC43NXJlbTtcbiAgbGluZS1oZWlnaHQ6IDEuMzMzMzQ7XG4gIGZvbnQtd2VpZ2h0OiA3MDA7XG4gIHRleHQtdHJhbnNmb3JtOiB1cHBlcmNhc2U7IH1cblxuLmZkLWhhcy10eXBlLW1pbnVzLTIge1xuICBmb250LXNpemU6IDAuODEyNXJlbTtcbiAgbGluZS1oZWlnaHQ6IDEuNTM4NDc7XG4gIGZvbnQtd2VpZ2h0OiA0MDA7IH1cblxuLmZkLWhhcy10eXBlLW1pbnVzLTEge1xuICBmb250LXNpemU6IDAuODc1cmVtO1xuICBsaW5lLWhlaWdodDogMS40Mjg1ODtcbiAgZm9udC13ZWlnaHQ6IDQwMDsgfVxuXG4uZmQtaGFzLXR5cGUtYmFzZSxcbi5mZC1oYXMtdHlwZS0wIHtcbiAgZm9udC1zaXplOiAxcmVtO1xuICBsaW5lLWhlaWdodDogMS41O1xuICBmb250LXdlaWdodDogNDAwOyB9XG5cbi5mZC1oYXMtdHlwZS0xIHtcbiAgZm9udC1zaXplOiAxLjEyNXJlbTtcbiAgbGluZS1oZWlnaHQ6IDEuMzMzMzQ7XG4gIGZvbnQtd2VpZ2h0OiA2MDA7IH1cblxuLmZkLWhhcy10eXBlLTIge1xuICBmb250LXNpemU6IDEuMjVyZW07XG4gIGxpbmUtaGVpZ2h0OiAxLjQ7XG4gIGZvbnQtd2VpZ2h0OiA2MDA7IH1cblxuLmZkLWhhcy10eXBlLTMge1xuICBmb250LXNpemU6IDEuNjI1cmVtO1xuICBsaW5lLWhlaWdodDogMS4yMzA3NztcbiAgZm9udC1mYW1pbHk6IFJvYm90bywgc2Fucy1zZXJpZjtcbiAgZm9udC13ZWlnaHQ6IDYwMDsgfVxuXG4uZmQtaGFzLXR5cGUtNCB7XG4gIGZvbnQtc2l6ZTogMi4xODc1cmVtO1xuICBsaW5lLWhlaWdodDogMS4yNTcxNTtcbiAgZm9udC1mYW1pbHk6IFJvYm90bywgc2Fucy1zZXJpZjtcbiAgZm9udC13ZWlnaHQ6IDcwMDsgfVxuXG4uZmQtaGFzLXR5cGUtNSB7XG4gIGZvbnQtc2l6ZTogMi44MTI1cmVtO1xuICBsaW5lLWhlaWdodDogMS4xNTU1NjtcbiAgZm9udC1mYW1pbHk6IFJvYm90bywgc2Fucy1zZXJpZjtcbiAgZm9udC13ZWlnaHQ6IDUwMDsgfVxuXG4uZmQtaGFzLWZvbnQtZmFtaWx5LWJvZHkge1xuICBmb250LWZhbWlseTogJ09wZW4gU2FucycsIHNhbnMtc2VyaWY7IH1cblxuLmZkLWhhcy1mb250LWZhbWlseS1oZWFkZXIge1xuICBmb250LWZhbWlseTogUm9ib3RvLCBzYW5zLXNlcmlmOyB9XG5cbi5mZC1oYXMtZm9udC1mYW1pbHktY29kZSB7XG4gIGZvbnQtZmFtaWx5OiAnQ291cmllciBOZXcnLCBtb25vc3BhY2U7IH1cblxuLmZkLWhhcy1mb250LXdlaWdodC1saWdodCB7XG4gIGZvbnQtd2VpZ2h0OiAzMDA7IH1cblxuLmZkLWhhcy1mb250LXdlaWdodC1yZWcge1xuICBmb250LXdlaWdodDogNDAwOyB9XG5cbi5mZC1oYXMtZm9udC13ZWlnaHQtbWVkIHtcbiAgZm9udC13ZWlnaHQ6IDUwMDsgfVxuXG4uZmQtaGFzLWZvbnQtd2VpZ2h0LXNlbWkge1xuICBmb250LXdlaWdodDogNjAwOyB9XG5cbi5mZC1oYXMtZm9udC13ZWlnaHQtYm9sZCB7XG4gIGZvbnQtd2VpZ2h0OiA3MDA7IH1cblxuLmZkLWhhcy1jb2xvci1wcmltYXJ5LFxuLmZkLWhhcy1jb2xvci1wcmltYXJ5LTEge1xuICBjb2xvcjogIzAwNmZiYiAhaW1wb3J0YW50OyB9XG5cbi5mZC1oYXMtY29sb3ItcHJpbWFyeS0yIHtcbiAgY29sb3I6ICMyNzM5NGYgIWltcG9ydGFudDsgfVxuXG4uZmQtaGFzLWNvbG9yLWFjdGlvbixcbi5mZC1oYXMtY29sb3ItYWN0aW9uLTEge1xuICBjb2xvcjogIzAwOWNkZiAhaW1wb3J0YW50OyB9XG5cbi5mZC1oYXMtY29sb3ItYWN0aW9uLTIge1xuICBjb2xvcjogIzhEOURCQyAhaW1wb3J0YW50OyB9XG5cbi5mZC1oYXMtY29sb3ItdGV4dCxcbi5mZC1oYXMtY29sb3ItdGV4dC0xIHtcbiAgY29sb3I6ICMyMTI2MmMgIWltcG9ydGFudDsgfVxuXG4uZmQtaGFzLWNvbG9yLXRleHQtMiB7XG4gIGNvbG9yOiAjN2Y5MGE0ICFpbXBvcnRhbnQ7IH1cblxuLmZkLWhhcy1jb2xvci10ZXh0LTMge1xuICBjb2xvcjogIzYzNzU4YiAhaW1wb3J0YW50OyB9XG5cbi5mZC1oYXMtY29sb3ItdGV4dC1pbnZlcnNlLFxuLmZkLWhhcy1jb2xvci10ZXh0LWludmVyc2UtMSB7XG4gIGNvbG9yOiAjZmZmZmZmICFpbXBvcnRhbnQ7IH1cblxuLmZkLWhhcy1jb2xvci10ZXh0LWludmVyc2UtMiB7XG4gIGNvbG9yOiAjZjZmOGY5ICFpbXBvcnRhbnQ7IH1cblxuLmZkLWhhcy1jb2xvci10ZXh0LWludmVyc2UtMyB7XG4gIGNvbG9yOiAjZWVmMWYzICFpbXBvcnRhbnQ7IH1cblxuLmZkLWhhcy1jb2xvci1iYWNrZ3JvdW5kLFxuLmZkLWhhcy1jb2xvci1iYWNrZ3JvdW5kLTEge1xuICBjb2xvcjogI2ZmZmZmZiAhaW1wb3J0YW50OyB9XG5cbi5mZC1oYXMtY29sb3ItYmFja2dyb3VuZC0yIHtcbiAgY29sb3I6ICNmMGY1ZmYgIWltcG9ydGFudDsgfVxuXG4uZmQtaGFzLWNvbG9yLWJhY2tncm91bmQtMyB7XG4gIGNvbG9yOiAjMDAwMDAwICFpbXBvcnRhbnQ7IH1cblxuLmZkLWhhcy1jb2xvci1uZXV0cmFsLFxuLmZkLWhhcy1jb2xvci1uZXV0cmFsLTEge1xuICBjb2xvcjogI2Y5ZmJmYyAhaW1wb3J0YW50OyB9XG5cbi5mZC1oYXMtY29sb3ItbmV1dHJhbC0yIHtcbiAgY29sb3I6ICNkN2Q3ZDcgIWltcG9ydGFudDsgfVxuXG4uZmQtaGFzLWNvbG9yLW5ldXRyYWwtMyB7XG4gIGNvbG9yOiAjY2NkYWViICFpbXBvcnRhbnQ7IH1cblxuLmZkLWhhcy1jb2xvci1uZXV0cmFsLTQge1xuICBjb2xvcjogIzhhOGZhMSAhaW1wb3J0YW50OyB9XG5cbi5mZC1oYXMtY29sb3Itc3RhdHVzLFxuLmZkLWhhcy1jb2xvci1zdGF0dXMtMSB7XG4gIGNvbG9yOiAjNjFiZjMzICFpbXBvcnRhbnQ7IH1cblxuLmZkLWhhcy1jb2xvci1zdGF0dXMtMiB7XG4gIGNvbG9yOiAjZTk3MzI2ICFpbXBvcnRhbnQ7IH1cblxuLmZkLWhhcy1jb2xvci1zdGF0dXMtMyB7XG4gIGNvbG9yOiAjZGYxOTE5ICFpbXBvcnRhbnQ7IH1cblxuLmZkLWhhcy1iYWNrZ3JvdW5kLWltYWdlIHtcbiAgYmFja2dyb3VuZC1yZXBlYXQ6IG5vLXJlcGVhdDtcbiAgYmFja2dyb3VuZC1wb3NpdGlvbjogY2VudGVyO1xuICBiYWNrZ3JvdW5kLXNpemU6IGNvbnRhaW47IH1cblxuLmZkLWhhcy1iYWNrZ3JvdW5kLWZpeGVkIHtcbiAgYmFja2dyb3VuZC1yZXBlYXQ6IG5vLXJlcGVhdDtcbiAgYmFja2dyb3VuZC1wb3NpdGlvbjogY2VudGVyO1xuICBiYWNrZ3JvdW5kLWF0dGFjaG1lbnQ6IGZpeGVkOyB9XG5cbi5mZC1oYXMtYmFja2dyb3VuZC1zaXplLWNvbnRhaW4ge1xuICBiYWNrZ3JvdW5kLXNpemU6IGNvbnRhaW4gIWltcG9ydGFudDsgfVxuXG4uZmQtaGFzLWJhY2tncm91bmQtc2l6ZS1jb3ZlciB7XG4gIGJhY2tncm91bmQtc2l6ZTogY292ZXIgIWltcG9ydGFudDsgfVxuXG4uZmQtaGFzLWJhY2tncm91bmQtY29sb3ItcHJpbWFyeSxcbi5mZC1oYXMtYmFja2dyb3VuZC1jb2xvci1wcmltYXJ5LTEge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiAjMDA2ZmJiICFpbXBvcnRhbnQ7IH1cblxuLmZkLWhhcy1iYWNrZ3JvdW5kLWNvbG9yLXByaW1hcnktMiB7XG4gIGJhY2tncm91bmQtY29sb3I6ICMyNzM5NGYgIWltcG9ydGFudDsgfVxuXG4uZmQtaGFzLWJhY2tncm91bmQtY29sb3ItYWN0aW9uLFxuLmZkLWhhcy1iYWNrZ3JvdW5kLWNvbG9yLWFjdGlvbi0xIHtcbiAgYmFja2dyb3VuZC1jb2xvcjogIzAwOWNkZiAhaW1wb3J0YW50OyB9XG5cbi5mZC1oYXMtYmFja2dyb3VuZC1jb2xvci1hY3Rpb24tMiB7XG4gIGJhY2tncm91bmQtY29sb3I6ICM4RDlEQkMgIWltcG9ydGFudDsgfVxuXG4uZmQtaGFzLWJhY2tncm91bmQtY29sb3ItdGV4dCxcbi5mZC1oYXMtYmFja2dyb3VuZC1jb2xvci10ZXh0LTEge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiAjMjEyNjJjICFpbXBvcnRhbnQ7IH1cblxuLmZkLWhhcy1iYWNrZ3JvdW5kLWNvbG9yLXRleHQtMiB7XG4gIGJhY2tncm91bmQtY29sb3I6ICM3ZjkwYTQgIWltcG9ydGFudDsgfVxuXG4uZmQtaGFzLWJhY2tncm91bmQtY29sb3ItdGV4dC0zIHtcbiAgYmFja2dyb3VuZC1jb2xvcjogIzYzNzU4YiAhaW1wb3J0YW50OyB9XG5cbi5mZC1oYXMtYmFja2dyb3VuZC1jb2xvci10ZXh0LWludmVyc2UsXG4uZmQtaGFzLWJhY2tncm91bmQtY29sb3ItdGV4dC1pbnZlcnNlLTEge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiAjZmZmZmZmICFpbXBvcnRhbnQ7IH1cblxuLmZkLWhhcy1iYWNrZ3JvdW5kLWNvbG9yLXRleHQtaW52ZXJzZS0yIHtcbiAgYmFja2dyb3VuZC1jb2xvcjogI2Y2ZjhmOSAhaW1wb3J0YW50OyB9XG5cbi5mZC1oYXMtYmFja2dyb3VuZC1jb2xvci10ZXh0LWludmVyc2UtMyB7XG4gIGJhY2tncm91bmQtY29sb3I6ICNlZWYxZjMgIWltcG9ydGFudDsgfVxuXG4uZmQtaGFzLWJhY2tncm91bmQtY29sb3ItYmFja2dyb3VuZCxcbi5mZC1oYXMtYmFja2dyb3VuZC1jb2xvci1iYWNrZ3JvdW5kLTEge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiAjZmZmZmZmICFpbXBvcnRhbnQ7IH1cblxuLmZkLWhhcy1iYWNrZ3JvdW5kLWNvbG9yLWJhY2tncm91bmQtMiB7XG4gIGJhY2tncm91bmQtY29sb3I6ICNmMGY1ZmYgIWltcG9ydGFudDsgfVxuXG4uZmQtaGFzLWJhY2tncm91bmQtY29sb3ItYmFja2dyb3VuZC0zIHtcbiAgYmFja2dyb3VuZC1jb2xvcjogIzAwMDAwMCAhaW1wb3J0YW50OyB9XG5cbi5mZC1oYXMtYmFja2dyb3VuZC1jb2xvci1uZXV0cmFsLFxuLmZkLWhhcy1iYWNrZ3JvdW5kLWNvbG9yLW5ldXRyYWwtMSB7XG4gIGJhY2tncm91bmQtY29sb3I6ICNmOWZiZmMgIWltcG9ydGFudDsgfVxuXG4uZmQtaGFzLWJhY2tncm91bmQtY29sb3ItbmV1dHJhbC0yIHtcbiAgYmFja2dyb3VuZC1jb2xvcjogI2Q3ZDdkNyAhaW1wb3J0YW50OyB9XG5cbi5mZC1oYXMtYmFja2dyb3VuZC1jb2xvci1uZXV0cmFsLTMge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiAjY2NkYWViICFpbXBvcnRhbnQ7IH1cblxuLmZkLWhhcy1iYWNrZ3JvdW5kLWNvbG9yLW5ldXRyYWwtNCB7XG4gIGJhY2tncm91bmQtY29sb3I6ICM4YThmYTEgIWltcG9ydGFudDsgfVxuXG4uZmQtaGFzLWJhY2tncm91bmQtY29sb3Itc3RhdHVzLFxuLmZkLWhhcy1iYWNrZ3JvdW5kLWNvbG9yLXN0YXR1cy0xIHtcbiAgYmFja2dyb3VuZC1jb2xvcjogIzYxYmYzMyAhaW1wb3J0YW50OyB9XG5cbi5mZC1oYXMtYmFja2dyb3VuZC1jb2xvci1zdGF0dXMtMiB7XG4gIGJhY2tncm91bmQtY29sb3I6ICNlOTczMjYgIWltcG9ydGFudDsgfVxuXG4uZmQtaGFzLWJhY2tncm91bmQtY29sb3Itc3RhdHVzLTMge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiAjZGYxOTE5ICFpbXBvcnRhbnQ7IH1cblxuLmZkLWhhcy1tYXJnaW4tbm9uZSB7XG4gIG1hcmdpbjogMDsgfVxuXG4uZmQtaGFzLXBhZGRpbmctbm9uZSB7XG4gIHBhZGRpbmc6IDA7IH1cblxuLmZkLWhhcy1tYXJnaW4tdG9wLW5vbmUge1xuICBtYXJnaW4tdG9wOiAwOyB9XG5cbi5mZC1oYXMtcGFkZGluZy10b3Atbm9uZSB7XG4gIHBhZGRpbmctdG9wOiAwOyB9XG5cbi5mZC1oYXMtbWFyZ2luLXJpZ2h0LW5vbmUge1xuICBtYXJnaW4tcmlnaHQ6IDA7IH1cblxuLmZkLWhhcy1wYWRkaW5nLXJpZ2h0LW5vbmUge1xuICBwYWRkaW5nLXJpZ2h0OiAwOyB9XG5cbi5mZC1oYXMtbWFyZ2luLWJvdHRvbS1ub25lIHtcbiAgbWFyZ2luLWJvdHRvbTogMDsgfVxuXG4uZmQtaGFzLXBhZGRpbmctYm90dG9tLW5vbmUge1xuICBwYWRkaW5nLWJvdHRvbTogMDsgfVxuXG4uZmQtaGFzLW1hcmdpbi1sZWZ0LW5vbmUge1xuICBtYXJnaW4tbGVmdDogMDsgfVxuXG4uZmQtaGFzLXBhZGRpbmctbGVmdC1ub25lIHtcbiAgcGFkZGluZy1sZWZ0OiAwOyB9XG5cbi5mZC1oYXMtbWFyZ2luLWJhc2Uge1xuICBtYXJnaW46IDRweDsgfVxuXG4uZmQtaGFzLXBhZGRpbmctYmFzZSB7XG4gIHBhZGRpbmc6IDRweDsgfVxuXG4uZmQtaGFzLW1hcmdpbi10b3AtYmFzZSB7XG4gIG1hcmdpbi10b3A6IDRweDsgfVxuXG4uZmQtaGFzLXBhZGRpbmctdG9wLWJhc2Uge1xuICBwYWRkaW5nLXRvcDogNHB4OyB9XG5cbi5mZC1oYXMtbWFyZ2luLXJpZ2h0LWJhc2Uge1xuICBtYXJnaW4tcmlnaHQ6IDRweDsgfVxuXG4uZmQtaGFzLXBhZGRpbmctcmlnaHQtYmFzZSB7XG4gIHBhZGRpbmctcmlnaHQ6IDRweDsgfVxuXG4uZmQtaGFzLW1hcmdpbi1ib3R0b20tYmFzZSB7XG4gIG1hcmdpbi1ib3R0b206IDRweDsgfVxuXG4uZmQtaGFzLXBhZGRpbmctYm90dG9tLWJhc2Uge1xuICBwYWRkaW5nLWJvdHRvbTogNHB4OyB9XG5cbi5mZC1oYXMtbWFyZ2luLWxlZnQtYmFzZSB7XG4gIG1hcmdpbi1sZWZ0OiA0cHg7IH1cblxuLmZkLWhhcy1wYWRkaW5nLWxlZnQtYmFzZSB7XG4gIHBhZGRpbmctbGVmdDogNHB4OyB9XG5cbi5mZC1oYXMtbWFyZ2luLXhzIHtcbiAgbWFyZ2luOiA4cHg7IH1cblxuLmZkLWhhcy1wYWRkaW5nLXhzIHtcbiAgcGFkZGluZzogOHB4OyB9XG5cbi5mZC1oYXMtbWFyZ2luLXRvcC14cyB7XG4gIG1hcmdpbi10b3A6IDhweDsgfVxuXG4uZmQtaGFzLXBhZGRpbmctdG9wLXhzIHtcbiAgcGFkZGluZy10b3A6IDhweDsgfVxuXG4uZmQtaGFzLW1hcmdpbi1yaWdodC14cyB7XG4gIG1hcmdpbi1yaWdodDogOHB4OyB9XG5cbi5mZC1oYXMtcGFkZGluZy1yaWdodC14cyB7XG4gIHBhZGRpbmctcmlnaHQ6IDhweDsgfVxuXG4uZmQtaGFzLW1hcmdpbi1ib3R0b20teHMge1xuICBtYXJnaW4tYm90dG9tOiA4cHg7IH1cblxuLmZkLWhhcy1wYWRkaW5nLWJvdHRvbS14cyB7XG4gIHBhZGRpbmctYm90dG9tOiA4cHg7IH1cblxuLmZkLWhhcy1tYXJnaW4tbGVmdC14cyB7XG4gIG1hcmdpbi1sZWZ0OiA4cHg7IH1cblxuLmZkLWhhcy1wYWRkaW5nLWxlZnQteHMge1xuICBwYWRkaW5nLWxlZnQ6IDhweDsgfVxuXG4uZmQtaGFzLW1hcmdpbi1zIHtcbiAgbWFyZ2luOiAxMnB4OyB9XG5cbi5mZC1oYXMtcGFkZGluZy1zIHtcbiAgcGFkZGluZzogMTJweDsgfVxuXG4uZmQtaGFzLW1hcmdpbi10b3AtcyB7XG4gIG1hcmdpbi10b3A6IDEycHg7IH1cblxuLmZkLWhhcy1wYWRkaW5nLXRvcC1zIHtcbiAgcGFkZGluZy10b3A6IDEycHg7IH1cblxuLmZkLWhhcy1tYXJnaW4tcmlnaHQtcyB7XG4gIG1hcmdpbi1yaWdodDogMTJweDsgfVxuXG4uZmQtaGFzLXBhZGRpbmctcmlnaHQtcyB7XG4gIHBhZGRpbmctcmlnaHQ6IDEycHg7IH1cblxuLmZkLWhhcy1tYXJnaW4tYm90dG9tLXMge1xuICBtYXJnaW4tYm90dG9tOiAxMnB4OyB9XG5cbi5mZC1oYXMtcGFkZGluZy1ib3R0b20tcyB7XG4gIHBhZGRpbmctYm90dG9tOiAxMnB4OyB9XG5cbi5mZC1oYXMtbWFyZ2luLWxlZnQtcyB7XG4gIG1hcmdpbi1sZWZ0OiAxMnB4OyB9XG5cbi5mZC1oYXMtcGFkZGluZy1sZWZ0LXMge1xuICBwYWRkaW5nLWxlZnQ6IDEycHg7IH1cblxuLmZkLWhhcy1tYXJnaW4tcmVnIHtcbiAgbWFyZ2luOiAyMHB4OyB9XG5cbi5mZC1oYXMtcGFkZGluZy1yZWcge1xuICBwYWRkaW5nOiAyMHB4OyB9XG5cbi5mZC1oYXMtbWFyZ2luLXRvcC1yZWcge1xuICBtYXJnaW4tdG9wOiAyMHB4OyB9XG5cbi5mZC1oYXMtcGFkZGluZy10b3AtcmVnIHtcbiAgcGFkZGluZy10b3A6IDIwcHg7IH1cblxuLmZkLWhhcy1tYXJnaW4tcmlnaHQtcmVnIHtcbiAgbWFyZ2luLXJpZ2h0OiAyMHB4OyB9XG5cbi5mZC1oYXMtcGFkZGluZy1yaWdodC1yZWcge1xuICBwYWRkaW5nLXJpZ2h0OiAyMHB4OyB9XG5cbi5mZC1oYXMtbWFyZ2luLWJvdHRvbS1yZWcge1xuICBtYXJnaW4tYm90dG9tOiAyMHB4OyB9XG5cbi5mZC1oYXMtcGFkZGluZy1ib3R0b20tcmVnIHtcbiAgcGFkZGluZy1ib3R0b206IDIwcHg7IH1cblxuLmZkLWhhcy1tYXJnaW4tbGVmdC1yZWcge1xuICBtYXJnaW4tbGVmdDogMjBweDsgfVxuXG4uZmQtaGFzLXBhZGRpbmctbGVmdC1yZWcge1xuICBwYWRkaW5nLWxlZnQ6IDIwcHg7IH1cblxuLmZkLWhhcy1tYXJnaW4tbSB7XG4gIG1hcmdpbjogNDBweDsgfVxuXG4uZmQtaGFzLXBhZGRpbmctbSB7XG4gIHBhZGRpbmc6IDQwcHg7IH1cblxuLmZkLWhhcy1tYXJnaW4tdG9wLW0ge1xuICBtYXJnaW4tdG9wOiA0MHB4OyB9XG5cbi5mZC1oYXMtcGFkZGluZy10b3AtbSB7XG4gIHBhZGRpbmctdG9wOiA0MHB4OyB9XG5cbi5mZC1oYXMtbWFyZ2luLXJpZ2h0LW0ge1xuICBtYXJnaW4tcmlnaHQ6IDQwcHg7IH1cblxuLmZkLWhhcy1wYWRkaW5nLXJpZ2h0LW0ge1xuICBwYWRkaW5nLXJpZ2h0OiA0MHB4OyB9XG5cbi5mZC1oYXMtbWFyZ2luLWJvdHRvbS1tIHtcbiAgbWFyZ2luLWJvdHRvbTogNDBweDsgfVxuXG4uZmQtaGFzLXBhZGRpbmctYm90dG9tLW0ge1xuICBwYWRkaW5nLWJvdHRvbTogNDBweDsgfVxuXG4uZmQtaGFzLW1hcmdpbi1sZWZ0LW0ge1xuICBtYXJnaW4tbGVmdDogNDBweDsgfVxuXG4uZmQtaGFzLXBhZGRpbmctbGVmdC1tIHtcbiAgcGFkZGluZy1sZWZ0OiA0MHB4OyB9XG5cbi5mZC1oYXMtbWFyZ2luLWwge1xuICBtYXJnaW46IDEwMHB4OyB9XG5cbi5mZC1oYXMtcGFkZGluZy1sIHtcbiAgcGFkZGluZzogMTAwcHg7IH1cblxuLmZkLWhhcy1tYXJnaW4tdG9wLWwge1xuICBtYXJnaW4tdG9wOiAxMDBweDsgfVxuXG4uZmQtaGFzLXBhZGRpbmctdG9wLWwge1xuICBwYWRkaW5nLXRvcDogMTAwcHg7IH1cblxuLmZkLWhhcy1tYXJnaW4tcmlnaHQtbCB7XG4gIG1hcmdpbi1yaWdodDogMTAwcHg7IH1cblxuLmZkLWhhcy1wYWRkaW5nLXJpZ2h0LWwge1xuICBwYWRkaW5nLXJpZ2h0OiAxMDBweDsgfVxuXG4uZmQtaGFzLW1hcmdpbi1ib3R0b20tbCB7XG4gIG1hcmdpbi1ib3R0b206IDEwMHB4OyB9XG5cbi5mZC1oYXMtcGFkZGluZy1ib3R0b20tbCB7XG4gIHBhZGRpbmctYm90dG9tOiAxMDBweDsgfVxuXG4uZmQtaGFzLW1hcmdpbi1sZWZ0LWwge1xuICBtYXJnaW4tbGVmdDogMTAwcHg7IH1cblxuLmZkLWhhcy1wYWRkaW5nLWxlZnQtbCB7XG4gIHBhZGRpbmctbGVmdDogMTAwcHg7IH1cblxuLmZkLWhhcy1tYXJnaW4teGwge1xuICBtYXJnaW46IDE0OHB4OyB9XG5cbi5mZC1oYXMtcGFkZGluZy14bCB7XG4gIHBhZGRpbmc6IDE0OHB4OyB9XG5cbi5mZC1oYXMtbWFyZ2luLXRvcC14bCB7XG4gIG1hcmdpbi10b3A6IDE0OHB4OyB9XG5cbi5mZC1oYXMtcGFkZGluZy10b3AteGwge1xuICBwYWRkaW5nLXRvcDogMTQ4cHg7IH1cblxuLmZkLWhhcy1tYXJnaW4tcmlnaHQteGwge1xuICBtYXJnaW4tcmlnaHQ6IDE0OHB4OyB9XG5cbi5mZC1oYXMtcGFkZGluZy1yaWdodC14bCB7XG4gIHBhZGRpbmctcmlnaHQ6IDE0OHB4OyB9XG5cbi5mZC1oYXMtbWFyZ2luLWJvdHRvbS14bCB7XG4gIG1hcmdpbi1ib3R0b206IDE0OHB4OyB9XG5cbi5mZC1oYXMtcGFkZGluZy1ib3R0b20teGwge1xuICBwYWRkaW5nLWJvdHRvbTogMTQ4cHg7IH1cblxuLmZkLWhhcy1tYXJnaW4tbGVmdC14bCB7XG4gIG1hcmdpbi1sZWZ0OiAxNDhweDsgfVxuXG4uZmQtaGFzLXBhZGRpbmctbGVmdC14bCB7XG4gIHBhZGRpbmctbGVmdDogMTQ4cHg7IH1cblxuLmZkLWhhcy1jbGVhcmZpeDo6YWZ0ZXIge1xuICBjb250ZW50OiBcIlwiO1xuICBkaXNwbGF5OiB0YWJsZTtcbiAgY2xlYXI6IGJvdGg7IH1cblxuLmZkLWhhcy1kaXNwbGF5LWZsZXgge1xuICBkaXNwbGF5OiBmbGV4OyB9XG5cbi5mZC1oYXMtZGlzcGxheS1ibG9jayB7XG4gIGRpc3BsYXk6IGJsb2NrOyB9XG5cbi5mZC1oYXMtYWxpZ24taXRlbXMtY2VudGVyIHtcbiAgYWxpZ24taXRlbXM6IGNlbnRlcjsgfVxuXG4uZmQtaGFzLWZsZXgtZ3Jvdy0xIHtcbiAgZmxleC1ncm93OiAxOyB9XG4iLCJAaW1wb3J0IHVybChcIi8vZm9udHMuZ29vZ2xlYXBpcy5jb20vY3NzP2ZhbWlseT1Sb2JvdG86NDAwLDUwMCw3MDBcIik7XG5AaW1wb3J0IHVybChcIi8vZm9udHMuZ29vZ2xlYXBpcy5jb20vY3NzP2ZhbWlseT1PcGVuK1NhbnM6NDAwLDQwMGl0YWxpYyw2MDAsNzAwXCIpO1xuXG4kZmQtZm9udHM6IChcbiAgICBib2R5OiAje1wiJ09wZW4gU2FucydcIiwgc2Fucy1zZXJpZn0sXG4gICAgaGVhZGVyOiAje1wiUm9ib3RvXCIsIHNhbnMtc2VyaWZ9LFxuICAgIGNvZGU6ICN7XCInQ291cmllciBOZXcnXCIsIG1vbm9zcGFjZX0sXG4pO1xuIiwiQGltcG9ydCBcInNldHRpbmdzXCI7XG5cbi8vIFJlcXVpcmVkIHZhcmlhYmxlczpcbi8vIFx0JGZkLWJhY2tncm91bmQtY29sb3Jcbi8vIFx0JGZkLWNvbG9yXG4kZWxlbWVudHNfX2hlYWRlcnM6IGgxLCBoMiwgaDMsIGg0LCBoNSwgaDY7XG4kZWxlbWVudHNfX2Jsb2NrczogcCwgdWwsIG9sLCBibG9ja3F1b3RlLCB0YWJsZSwgZmlndXJlO1xuJGVsZW1lbnRzX19pbnRlcmFjdGl2ZTogYSwgYXVkaW9cXFtjb250cm9sc1xcXSwgYnV0dG9uLCBkZXRhaWxzLCBlbWJlZCwgaWZyYW1lLCBpbWdcXFt1c2VtYXBcXF0sIGlucHV0LCBrZXlnZW4sIGxhYmVsLCBvYmplY3RcXFt1c2VtYXBcXF0sIHNlbGVjdCwgdGV4dGFyZWEsIHZpZGVvXFxbY29udHJvbHNcXF07XG5cbi8qIVxuKiBAc2VjdGlvbiBSb290IEVsZW1lbnRcbiogRGVmYXVsdCBzdHlsZXMgZm9yIHJvb3QgZWxlbWVudHNcbiovXG5odG1sIHtcbiAgICBib3gtc2l6aW5nOiBib3JkZXItYm94O1xuICAgIG1pbi1oZWlnaHQ6IDEwMCU7XG59XG5odG1sLFxuYm9keSB7XG4gICAgZm9udC1zaXplOiAkZmQtZm9udC1zaXplO1xuICAgIGZvbnQtZmFtaWx5OiAkZmQtZm9udC1mYW1pbHk7XG4gICAgbGluZS1oZWlnaHQ6ICRmZC1saW5lLWhlaWdodDtcbn1cbioge1xuICAgIGJveC1zaXppbmc6IGluaGVyaXQ7XG4gICAgJjo6YmVmb3JlLFxuICAgICY6OmFmdGVyIHtcbiAgICAgICAgYm94LXNpemluZzogaW5oZXJpdDtcbiAgICB9XG59XG5ib2R5IHtcbiAgICBtYXJnaW46IDA7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogJGZkLWJhY2tncm91bmQtY29sb3I7XG4gICAgLXdlYmtpdC1mb250LXNtb290aGluZzogYW50aWFsaWFzZWQ7XG4gICAgY29sb3I6ICRmZC1jb2xvcjtcbn1cblxuLyoqXG4qIEBzZWN0aW9uIEhlYWRlciBFbGVtZW50c1xuKiBEZWZhdWx0IHN0eWxlcyBmb3IgaGVhZGVyIGVsZW1lbnRzXG4qL1xuI3skZWxlbWVudHNfX2hlYWRlcnN9IHtcbiAgICB0ZXh0LXJlbmRlcmluZzogb3B0aW1pemVMZWdpYmlsaXR5O1xuICAgIG1hcmdpbi1ib3R0b206ICRmZC1tYXJnaW4tYm90dG9tO1xuICAgIG1hcmdpbi10b3A6IDA7XG59XG5cbi8qIVxuKiBAc2VjdGlvbiBCbG9jayBFbGVtZW50c1xuKiBEZWZhdWx0IHN0eWxlcyBmb3IgYmxvY2sgZWxlbWVudHNcbiovXG4jeyRlbGVtZW50c19fYmxvY2tzfSB7XG4gICAgbWFyZ2luLXRvcDogMDtcbiAgICBtYXJnaW4tYm90dG9tOiAkZmQtbWFyZ2luLWJvdHRvbTtcbiAgICAmOmxhc3QtY2hpbGQge1xuICAgICAgICBtYXJnaW4tYm90dG9tOiAwO1xuICAgIH1cbn1cblxuLyohXG4qIEBzZWN0aW9uIExpc3QgRWxlbWVudHNcbiogRGVmYXVsdCBzdHlsZXMgZm9yIGxpc3RzXG4qL1xudWwsIG9sIHtcbiAgICBwYWRkaW5nLWxlZnQ6IDA7XG4gICAgLy9saXN0LXN0eWxlOiBub25lO1xufVxuXG5cbi8qIVxuKiBAc2VjdGlvbiBQaHJhc2VzIEVsZW1lbnRzXG4qIERlZmF1bHQgc3R5bGVzIGZvciBwaHJhc2UgZWxlbWVudHNcbiovXG5pbWcge1xuICAgIGxpbmUtaGVpZ2h0OiAwO1xuICAgIHZlcnRpY2FsLWFsaWduOiBtaWRkbGU7XG59XG5cbmEge1xuICAgIGNvbG9yOiAkZmQtY29sb3ItLWxpbms7XG4gICAgdGV4dC1kZWNvcmF0aW9uOiBub25lO1xuICAgICY6aG92ZXIge1xuICAgICAgICBjb2xvcjogJGZkLWNvbG9yLS1saW5rLWhvdmVyO1xuICAgIH1cbiAgICAmOmFjdGl2ZSxcbiAgICAmOmZvY3VzIHtcbiAgICAgICAgY29sb3I6ICRmZC1jb2xvci0tbGluay1ob3ZlcjtcbiAgICAgICAgb3V0bGluZTogbm9uZTtcbiAgICB9XG4gICAgJlthcmlhLWRpc2FibGVkPVwidHJ1ZVwiXSxcbiAgICAmLmlzLWRpc2FibGVkIHtcbiAgICAgICAgY29sb3I6ICRmZC1jb2xvci0tbGluay1kaXNhYmxlZDtcbiAgICAgICAgY3Vyc29yOiBub3QtYWxsb3dlZDtcbiAgICB9XG59XG5cbi8qIVxuKiBAc2VjdGlvbiBCdXR0b24gRWxlbWVudHNcbiogRGVmYXVsdCBzdHlsZXMgZm9yIGJ1dHRvbiBlbGVtZW50c1xuKi9cbmJ1dHRvbjo6LW1vei1mb2N1cy1pbm5lcixcbmlucHV0W3R5cGU9XCJzdWJtaXRcIl06Oi1tb3otZm9jdXMtaW5uZXIge1xuICAgIGJvcmRlcjogMDtcbiAgICBwYWRkaW5nOiAwO1xufVxuIiwiQGltcG9ydCBcImZ1bmN0aW9uc1wiO1xuXG4vL2xpYnJhcnkgbmFtZXNwYWNlXG4kZmQtbmFtZXNwYWNlOiBmZCAhZGVmYXVsdDtcblxuLy9icmVha3BvaW50c1xuJGZkLWJyZWFrcG9pbnRzOiAoXG4gICAgeHM6IDMyMHB4LFxuICAgIHM6IDgwMHB4LFxuICAgIG06IDEwMjRweCxcbiAgICBsOiAxNDQwcHgsXG4gICAgeGw6IDE1ODBweCxcbikgIWRlZmF1bHQ7XG5cbi8vc3BhY2luZ1xuJGZkLXNwYWNpbmctLWJhc2U6IDRweDtcbiRmZC1zcGFjaW5nOiAoXG4gICAgYmFzZTogJGZkLXNwYWNpbmctLWJhc2UsICAgIC8vNFxuICAgIHhzOiAkZmQtc3BhY2luZy0tYmFzZSAqIDIsICAvLzhcbiAgICBzOiAkZmQtc3BhY2luZy0tYmFzZSAqIDMsICAgLy8xMlxuICAgIHJlZzogJGZkLXNwYWNpbmctLWJhc2UgKiA1LCAvLzIwXG4gICAgbTogJGZkLXNwYWNpbmctLWJhc2UgKiAxMCwgIC8vNDBcbiAgICBsOiAkZmQtc3BhY2luZy0tYmFzZSAqIDI1LCAgLy8xMDBcbiAgICB4bDogJGZkLXNwYWNpbmctLWJhc2UgKiAzNywgLy8xNDhcbikgIWRlZmF1bHQ7XG5cbi8vdHlwZVxuJGZkLXR5cGUtLWJhc2U6IDE2cHg7XG4kZmQtdHlwZTogKFxuICAgIC0zOiAwLjc1cmVtIDEuMzMzMzQgYm9keSBib2xkIHVwcGVyY2FzZSwgICAgLy8xMi8xNlxuICAgIC0yOiAwLjgxMjVyZW0gMS41Mzg0NyBib2R5IHJlZyBub25lLFx0ICAgIC8vMTMvMjBcbiAgICAtMTogMC44NzVyZW0gMS40Mjg1OCBib2R5IHJlZyBub25lLFx0ICAgICAgICAvLzE0LzIwXG4gICAgMDogMXJlbSAxLjUgYm9keSByZWcgbm9uZSwgICAgIFx0ICAgICAgICAgICAgLy8xNi8yNFxuICAgIDE6IDEuMTI1cmVtIDEuMzMzMzQgYm9keSBzZW1pIG5vbmUsICAgXHQgICAgLy8xOC8yNFxuICAgIDI6IDEuMjVyZW0gMS40IGJvZHkgc2VtaSBub25lLCAgIFx0ICAgICAgICAvLzIwLzI4XG4gICAgMzogMS42MjVyZW0gMS4yMzA3NyBoZWFkZXIgc2VtaSBub25lLFx0ICAgIC8vMjYvMzJcbiAgICA0OiAyLjE4NzVyZW0gMS4yNTcxNSBoZWFkZXIgYm9sZCBub25lLFx0ICAgIC8vMzUvNDRcbiAgICA1OiAyLjgxMjVyZW0gMS4xNTU1NiBoZWFkZXIgbWVkIG5vbmUsICAgICAgIC8vNDUvNTJcbikgIWRlZmF1bHQ7XG5cbi8vZm9udHNcbiRmZC1mb250czogKFxuICAgIGJvZHk6ICN7c2Fucy1zZXJpZn0sXG4gICAgaGVhZGVyOiAje3NhbnMtc2VyaWZ9LFxuICAgIGNvZGU6ICN7bW9ub3NwYWNlfSxcbikgIWRlZmF1bHQ7XG5cbiRmZC13ZWlnaHRzOiAoXG4gICAgbGlnaHQ6IDMwMCxcbiAgICByZWc6IDQwMCxcbiAgICBtZWQ6IDUwMCxcbiAgICBzZW1pOiA2MDAsXG4gICAgYm9sZDogNzAwXG4pICFkZWZhdWx0O1xuXG4vL2NvbG9yc1xuJGZkLWNvbG9yczogKFxuICAgIHByaW1hcnk6IChcbiAgICAgICAgMTogIzAwNmZiYixcbiAgICAgICAgMjogIzI3Mzk0ZixcbiAgICApLFxuICAgIGFjdGlvbjogKFxuICAgICAgICAxOiAjMDA5Y2RmLFxuICAgICAgICAyOiAjOEQ5REJDXG4gICAgKSxcbiAgICB0ZXh0OiAoXG4gICAgICAgIDE6ICMyMTI2MmMsXG4gICAgICAgIDI6ICM3ZjkwYTQsXG4gICAgICAgIDM6ICM2Mzc1OGIsXG4gICAgKSxcbiAgICB0ZXh0LWludmVyc2U6IChcbiAgICAgICAgMTogI2ZmZmZmZixcbiAgICAgICAgMjogI2Y2ZjhmOSxcbiAgICAgICAgMzogI2VlZjFmMyxcbiAgICApLFxuICAgIGJhY2tncm91bmQ6IChcbiAgICAgICAgMTogI2ZmZmZmZixcbiAgICAgICAgMjogI2YwZjVmZixcbiAgICAgICAgMzogIzAwMDAwMFxuICAgICksXG4gICAgbmV1dHJhbDogKFxuICAgICAgICAxOiAjZjlmYmZjLFxuICAgICAgICAyOiAjZDdkN2Q3LFxuICAgICAgICAzOiAjY2NkYWViLFxuICAgICAgICA0OiAjOGE4ZmExLFxuICAgICksXG4gICAgc3RhdHVzOiAoXG4gICAgICAgIDE6ICM2MWJmMzMsXG4gICAgICAgIDI6ICNlOTczMjYsXG4gICAgICAgIDM6ICNkZjE5MTksXG4gICAgKVxuKSAhZGVmYXVsdDtcblxuXG4vL2ZlYXR1cmVzXG4kZmQtc3BhY2UtbW9kaWZ5OiBub3JtYWwgIWRlZmF1bHQ7IC8vbm9ybWFsLCBjb21wYWN0XG5cbi8vdWlcbiRmZC1wYWRkaW5nLS11aTogZmQtc3BhY2UocmVnKSAhZGVmYXVsdDtcbi8vJGZkLW1heC13aWR0aC0tdWk6IG1hcC1nZXQoJGZkLWJyZWFrcG9pbnRzLHhsKSAhZGVmYXVsdDtcbiRmZC1tYXgtd2lkdGgtLXVpOiAxMjkwcHggIWRlZmF1bHQ7XG5cbi8vZ2xvYmFsIHdpZHRoc1xuJGZkLXdpZHRoLS1ndXR0ZXI6IGZkLXNwYWNlKDgpICFkZWZhdWx0O1xuXG4vL3R5cGVcbiRmZC1mb250LWZhbWlseTogbWFwLWdldCgkZmQtZm9udHMsYm9keSkgIWRlZmF1bHQ7XG4kZmQtZm9udC1mYW1pbHktLWhlYWRlcjogbWFwLWdldCgkZmQtZm9udHMsaGVhZGVyKSAhZGVmYXVsdDtcbiRmZC1mb250LWZhbWlseS0tY29kZTogbWFwLWdldCgkZmQtZm9udHMsY29kZSkgIWRlZmF1bHQ7XG4kZmQtZm9udC1zaXplOiBudGgobWFwLWdldCgkZmQtdHlwZSwwKSwgMSkgIWRlZmF1bHQ7XG4kZmQtbGluZS1oZWlnaHQ6IG50aChtYXAtZ2V0KCRmZC10eXBlLDApLCAyKSAhZGVmYXVsdDtcblxuLy9iYXNlbGluZVxuJGZkLWNvbG9yOiBmZC1jb2xvcih0ZXh0KSAhZGVmYXVsdDtcbiRmZC1iYWNrZ3JvdW5kLWNvbG9yOiBmZC1jb2xvcihiYWNrZ3JvdW5kKSAhZGVmYXVsdDtcblxuLy9wb3NpdGlvbmluZ1xuJGZkLW1hcmdpbi1ib3R0b206IGZkLXNwYWNlKCkgIWRlZmF1bHQ7XG5cbi8vaW50ZXJhY3RpdmVcbiRmZC1jb2xvci0tbGluazogZmQtY29sb3IoYWN0aW9uKSAhZGVmYXVsdDtcbiRmZC1jb2xvci0tbGluay1ob3ZlcjogZGFya2VuKCRmZC1jb2xvci0tbGluaywgNSkgIWRlZmF1bHQ7XG4kZmQtY29sb3ItLWxpbmstYWN0aXZlOiBkYXJrZW4oJGZkLWNvbG9yLS1saW5rLCAxMCkgIWRlZmF1bHQ7XG4kZmQtY29sb3ItLWxpbmstZGlzYWJsZWQ6IGZkLWNvbG9yKHRleHQsIDIpICFkZWZhdWx0O1xuXG4vL3N0YXRlc1xuJGZkLWNvbG9yLS1lcnJvcjogZmQtY29sb3Ioc3RhdHVzLCAzKSAhZGVmYXVsdDtcbiRmZC1jb2xvci0td2FybmluZzogZmQtY29sb3Ioc3RhdHVzLCAyKSAhZGVmYXVsdDtcbiRmZC1jb2xvci0tc3VjY2VzczogZmQtY29sb3Ioc3RhdHVzLCAxKSAhZGVmYXVsdDtcblxuLy9hbmltYXRpb24gc3BlZWRcbiRmZC1hbmltYXRpb24tLXNwZWVkOiAwLjEyNXMgIWRlZmF1bHQ7XG5cbi8vRk9STVNcbi8vZGltZW5zaW9uc1xuJGZkLWZvcm1zLWhlaWdodC0taW5wdXQtdGV4dDogZmQtc3BhY2UoMTMpICFkZWZhdWx0O1xuJGZkLWZvcm1zLWhlaWdodC0taW5wdXQtY2hlY2s6IGZkLXNwYWNlKDcpICFkZWZhdWx0O1xuJGZkLWZvcm1zLXBhZGRpbmc6IGZkLXNwYWNlKDQpICFkZWZhdWx0O1xuLy9jb2xvcnNcbiRmZC1mb3Jtcy1jb2xvcjogJGZkLWNvbG9yICFkZWZhdWx0O1xuJGZkLWZvcm1zLWNvbG9yLS1wbGFjZWhvbGRlcjogZmQtY29sb3IodGV4dCwgMykgIWRlZmF1bHQ7XG4kZmQtZm9ybXMtY29sb3ItLWZvY3VzOiAkZmQtZm9ybXMtY29sb3IgIWRlZmF1bHQ7XG4kZmQtZm9ybXMtY29sb3ItLWRpc2FibGVkOiBmZC1jb2xvcih0ZXh0LCAzKSAhZGVmYXVsdDtcbiRmZC1mb3Jtcy1iYWNrZ3JvdW5kLWNvbG9yOiBmZC1jb2xvcihiYWNrZ3JvdW5kLCAxKSAhZGVmYXVsdDtcbiRmZC1mb3Jtcy1iYWNrZ3JvdW5kLWNvbG9yLS1jaGVjazogZmQtY29sb3IoYWN0aW9uLCAxKTtcbiRmZC1mb3Jtcy1iYWNrZ3JvdW5kLWNvbG9yLS1jaGVjay1kaXNhYmxlZDogZmQtY29sb3IodGV4dCwgMik7XG4kZmQtZm9ybXMtYmFja2dyb3VuZC1jb2xvci0tZGlzYWJsZWQ6IGZkLWNvbG9yKG5ldXRyYWwsIDEpICFkZWZhdWx0O1xuJGZkLWZvcm1zLWJvcmRlci1jb2xvcjogZmQtY29sb3IobmV1dHJhbCwgMykgIWRlZmF1bHQ7XG4kZmQtZm9ybXMtYm9yZGVyLWNvbG9yLS1jaGVjazogZmQtY29sb3IoYWN0aW9uKSAhZGVmYXVsdDtcbiRmZC1mb3Jtcy1ib3JkZXItY29sb3ItLWZvY3VzOiBmZC1jb2xvcihhY3Rpb24pICFkZWZhdWx0O1xuJGZkLWZvcm1zLWJvcmRlci1jb2xvci0tZGlzYWJsZWQ6IGxpZ2h0ZW4oZmQtY29sb3IobmV1dHJhbCwgMiksIDUlKSAhZGVmYXVsdDtcbi8vZWxlbWVudHNcbiRmZC1mb3Jtcy1zZWxlY3Qtd2lkdGgtLWJhY2tncm91bmQtaW1hZ2U6IDEycHggIWRlZmF1bHQ7XG4kZmQtZm9ybXMtc2VsZWN0LWJhY2tncm91bmQtaW1hZ2U6IFwiZGF0YTppbWFnZS9zdmcreG1sO2Jhc2U2NCxQSE4yWnlCNGJXeHVjejBpYUhSMGNEb3ZMM2QzZHk1M015NXZjbWN2TWpBd01DOXpkbWNpSUhkcFpIUm9QU0l4TWlJZ2FHVnBaMmgwUFNJNUlqNDhjR0YwYUNCbWFXeHNMWEoxYkdVOUltVjJaVzV2WkdRaUlHWnBiR3c5SWlNeU1USTJNa01pSUdROUlrMHhNUzQ1TXpVZ01TNDBOelZNTmk0eE9EZ2dOeTQ1TWpkaExqSTJOQzR5TmpRZ01DQXdJREV0TGpNM09DQXdUQzR3TmpVZ01TNDBOelZoTGpJek5pNHlNellnTUNBd0lERWdMakF5TmkwdU16UXpUREV1TXpneExqQTFPR0V1TWpVekxqSTFNeUF3SURBZ01TQXVNVFl6TFM0d05UbE1NUzQxTmpNZ01HRXVNalV5TGpJMU1pQXdJREFnTVNBdU1UY3hMakE0Tld3MExqSTJOU0EwTGpnNElEUXVNalkzTFRRdU9EaGhMakkxTWk0eU5USWdNQ0F3SURFZ0xqTTFNaTB1TURJM2JERXVNamt4SURFdU1EYzBZeTR3TlM0d05ESXVNRGd4TGpFd01pNHdPRFl1TVRZMllTNHlNell1TWpNMklEQWdNQ0F4TFM0d05pNHhOemQ2SWk4K1BDOXpkbWMrXCIgIWRlZmF1bHQ7XG4kZmQtZm9ybXMtc2VsZWN0LWJhY2tncm91bmQtaW1hZ2UtLWFjdGl2ZTogXCJkYXRhOmltYWdlL3N2Zyt4bWw7YmFzZTY0LFBITjJaeUI0Yld4dWN6MGlhSFIwY0RvdkwzZDNkeTUzTXk1dmNtY3ZNakF3TUM5emRtY2lJSGRwWkhSb1BTSXhNaUlnYUdWcFoyaDBQU0k1SWo0OGNHRjBhQ0JtYVd4c0xYSjFiR1U5SW1WMlpXNXZaR1FpSUdacGJHdzlJaU13TURoR1JESWlJR1E5SWsweE1TNDVNelVnTVM0ME56Vk1OaTR4T0RnZ055NDVNamRoTGpJMk5DNHlOalFnTUNBd0lERXRMak0zT0NBd1RDNHdOalVnTVM0ME56VmhMakl6Tmk0eU16WWdNQ0F3SURFZ0xqQXlOaTB1TXpRelRERXVNemd4TGpBMU9HRXVNalV6TGpJMU15QXdJREFnTVNBdU1UWXpMUzR3TlRsTU1TNDFOak1nTUdFdU1qVXlMakkxTWlBd0lEQWdNU0F1TVRjeExqQTROV3cwTGpJMk5TQTBMamc0SURRdU1qWTNMVFF1T0RoaExqSTFNaTR5TlRJZ01DQXdJREVnTGpNMU1pMHVNREkzYkRFdU1qa3hJREV1TURjMFl5NHdOUzR3TkRJdU1EZ3hMakV3TWk0d09EWXVNVFkyWVM0eU16WXVNak0ySURBZ01DQXhMUzR3Tmk0eE56ZDZJaTgrUEM5emRtYytcIiAhZGVmYXVsdDtcbiRmZC1mb3Jtcy1zZWxlY3QtYmFja2dyb3VuZC1pbWFnZS0tZXhwYW5kZWQ6IFwiZGF0YTppbWFnZS9zdmcreG1sO2Jhc2U2NCxQSE4yWnlCNGJXeHVjejBpYUhSMGNEb3ZMM2QzZHk1M015NXZjbWN2TWpBd01DOXpkbWNpSUhkcFpIUm9QU0l4TWlJZ2FHVnBaMmgwUFNJNElqNDhjR0YwYUNCbWFXeHNMWEoxYkdVOUltVjJaVzV2WkdRaUlHWnBiR3c5SWlNd01EaEdSRElpSUdROUlrMHhNUzQ1TXpVZ05pNDFNMHcyTGpFNE9DNHhNRFJoTGpJMk5DNHlOalFnTUNBd0lEQXRMak0zT0NBd1RDNHdOalVnTmk0MU0yRXVNalF1TWpRZ01DQXdJREF0TGpBMk1TNHhOemN1TWpNM0xqSXpOeUF3SURBZ01DQXVNRGczTGpFMk5Xd3hMakk1SURFdU1EY3hZUzR5TlRndU1qVTRJREFnTUNBd0lDNHhOak11TURVNFRERXVOVFl6SURoaExqSTFNaTR5TlRJZ01DQXdJREFnTGpFM01TMHVNRGcxYkRRdU1qWTFMVFF1T0RZeElEUXVNalkzSURRdU9EWXhZeTR3TkRNdU1EUTVMakV3TkM0d09DNHhOeTR3T0RWaExqSTJNUzR5TmpFZ01DQXdJREFnTGpFNE1pMHVNRFUzYkRFdU1qa3hMVEV1TURjeFlTNHlNell1TWpNMklEQWdNQ0F3SUM0d01qWXRMak0wTW5vaUx6NDhMM04yWno0PVwiICFkZWZhdWx0O1xuJGZkLWZvcm1zLXNlbGVjdC1iYWNrZ3JvdW5kLWltYWdlLS1kaXNhYmxlZDogXCJkYXRhOmltYWdlL3N2Zyt4bWw7YmFzZTY0LFBITjJaeUI0Yld4dWN6MGlhSFIwY0RvdkwzZDNkeTUzTXk1dmNtY3ZNakF3TUM5emRtY2lJSGRwWkhSb1BTSXhNaUlnYUdWcFoyaDBQU0k1SWo0OGNHRjBhQ0JtYVd4c0xYSjFiR1U5SW1WMlpXNXZaR1FpSUdacGJHdzlJaU0yTXpjMU9FSWlJR1E5SWsweE1TNDVNelVnTVM0ME56Vk1OaTR4T0RnZ055NDVNamRoTGpJMk5DNHlOalFnTUNBd0lERXRMak0zT0NBd1RDNHdOalVnTVM0ME56VmhMakl6TlM0eU16VWdNQ0F3SURFZ0xqQXlOaTB1TXpRelRERXVNemd4TGpBMU9HRXVNalV6TGpJMU15QXdJREFnTVNBdU1UWXpMUzR3TlRsTU1TNDFOak1nTUdFdU1qVXlMakkxTWlBd0lEQWdNU0F1TVRjeExqQTROV3cwTGpJMk5TQTBMamc0SURRdU1qWTNMVFF1T0RoaExqSTFNaTR5TlRJZ01DQXdJREVnTGpNMU1pMHVNREkzYkRFdU1qa3hJREV1TURjMFl5NHdOUzR3TkRJdU1EZ3hMakV3TWk0d09EWXVNVFkyWVM0eU16UXVNak0wSURBZ01DQXhMUzR3Tmk0eE56ZDZJaTgrUEM5emRtYytcIiAhZGVmYXVsdDtcbiIsIkBpbXBvcnQgXCJzZXR0aW5nc1wiO1xuQGltcG9ydCBcIm1peGluc1wiO1xuXG4vL2Vsc1xuJGZkLWVsZW1lbnRzLWlucHV0cy0tdGV4dDogXCJpbnB1dFt0eXBlPXRleHRdXCIsIFwiaW5wdXRbdHlwZT1wYXNzd29yZF1cIiwgXCJpbnB1dFt0eXBlPWVtYWlsXVwiLCBcImlucHV0W3R5cGU9dXJsXVwiLCBcImlucHV0W3R5cGU9c2VhcmNoXVwiLCBcImlucHV0W3R5cGU9dGVsXVwiLCBcImlucHV0W3R5cGU9bnVtYmVyXVwiLCBcImlucHV0W3R5cGU9ZGF0ZV1cIjtcbiRmZC1lbGVtZW50cy1pbnB1dHMtLWNoZWNrOiBcImlucHV0W3R5cGU9cmFkaW9dXCIsIFwiaW5wdXRbdHlwZT1jaGVja2JveF1cIjtcbi8vYW5pbVxuJGZkLWZvcm1zLXRyYW5zaXRpb24tcGFyYW1zOiAkZmQtYW5pbWF0aW9uLS1zcGVlZCBlYXNlLWluICFkZWZhdWx0O1xuXG4lZm9ybS1maWVsZC1iYXNlIHtcbiAgICBAaW5jbHVkZSBmZC1mb3JtLWJhc2U7XG4gICAgdHJhbnNpdGlvbjogYm9yZGVyLWNvbG9yICRmZC1mb3Jtcy10cmFuc2l0aW9uLXBhcmFtcywgYmFja2dyb3VuZC1jb2xvciAkZmQtZm9ybXMtdHJhbnNpdGlvbi1wYXJhbXMsIGJhY2tncm91bmQtaW1hZ2UgJGZkLWZvcm1zLXRyYW5zaXRpb24tcGFyYW1zO1xuICAgICY6OmFmdGVyIHtcbiAgICAgICAgdHJhbnNpdGlvbjogYm9yZGVyLWNvbG9yICRmZC1mb3Jtcy10cmFuc2l0aW9uLXBhcmFtcztcbiAgICB9XG4gICAgJjo6cGxhY2Vob2xkZXIge1xuICAgICAgICBjb2xvcjogJGZkLWZvcm1zLWNvbG9yLS1wbGFjZWhvbGRlcjtcbiAgICB9XG59XG5maWVsZHNldCB7XG4gICAgYm9yZGVyOiAwO1xuICAgIHBhZGRpbmc6IDA7XG4gICAgbWFyZ2luOiAwO1xufVxuI3skZmQtZWxlbWVudHMtaW5wdXRzLS10ZXh0fSxcbnRleHRhcmVhIHtcbiAgICBAaW5jbHVkZSBmZC1mb3JtLXRleHQ7XG4gICAgd2lkdGg6IDEwMCU7XG59XG50ZXh0YXJlYSB7XG4gICAgaGVpZ2h0OiAkZmQtZm9ybXMtaGVpZ2h0LS1pbnB1dC10ZXh0ICogMjtcbiAgICBwYWRkaW5nLXRvcDogJGZkLWZvcm1zLXBhZGRpbmc7XG59XG5zZWxlY3Qge1xuICAgIEBpbmNsdWRlIGZkLWZvcm0tc2VsZWN0O1xuICAgIHdpZHRoOiAxMDAlO1xuICAgICZbbXVsdGlwbGVdIHtcbiAgICAgICAgaGVpZ2h0OiAkZmQtZm9ybXMtaGVpZ2h0LS1pbnB1dC10ZXh0ICogMztcbiAgICAgICAgYmFja2dyb3VuZC1pbWFnZTogbm9uZTtcbiAgICAgICAgcGFkZGluZy10b3A6ICRmZC1mb3Jtcy1wYWRkaW5nO1xuICAgIH1cbn1cbiN7JGZkLWVsZW1lbnRzLWlucHV0cy0tY2hlY2t9IHtcbiAgICBAZXh0ZW5kICVmb3JtLWZpZWxkLWJhc2U7XG4gICAgaGVpZ2h0OiAkZmQtZm9ybXMtaGVpZ2h0LS1pbnB1dC1jaGVjaztcbiAgICB3aWR0aDogJGZkLWZvcm1zLWhlaWdodC0taW5wdXQtY2hlY2s7XG4gICAgbWFyZ2luOiAwO1xuICAgIHZlcnRpY2FsLWFsaWduOiBtaWRkbGU7XG4gICAgcG9zaXRpb246IHJlbGF0aXZlO1xuICAgICY6Y2hlY2tlZCB7XG4gICAgICAgIGJvcmRlci1jb2xvcjogJGZkLWZvcm1zLWJvcmRlci1jb2xvci0tY2hlY2s7XG4gICAgICAgIGJhY2tncm91bmQtY29sb3I6ICRmZC1mb3Jtcy1ib3JkZXItY29sb3ItLWNoZWNrO1xuICAgIH1cbiAgICAmW2Rpc2FibGVkXSxcbiAgICAmW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLFxuICAgICYuaXMtZGlzYWJsZWQge1xuICAgICAgICBib3JkZXItY29sb3I6ICRmZC1mb3Jtcy1ib3JkZXItY29sb3ItLWRpc2FibGVkO1xuICAgICAgICBiYWNrZ3JvdW5kLWNvbG9yOiAkZmQtZm9ybXMtYmFja2dyb3VuZC1jb2xvci0tZGlzYWJsZWQ7XG4gICAgfVxufVxuaW5wdXRbdHlwZT1cImNoZWNrYm94XCJdIHtcbiAgICAmOmNoZWNrZWQge1xuICAgICAgICAmOjphZnRlciB7XG4gICAgICAgICAgICBjb250ZW50OiBcIlwiO1xuICAgICAgICAgICAgd2lkdGg6IDE2cHg7XG4gICAgICAgICAgICBoZWlnaHQ6IDZweDtcbiAgICAgICAgICAgIGJvcmRlci1jb2xvcjogJGZkLWZvcm1zLWJhY2tncm91bmQtY29sb3I7XG4gICAgICAgICAgICBib3JkZXItc3R5bGU6IHNvbGlkO1xuICAgICAgICAgICAgYm9yZGVyLXdpZHRoOiAwIDAgMXB4IDFweDtcbiAgICAgICAgICAgIHRyYW5zZm9ybTogcm90YXRlKC00NWRlZyk7XG4gICAgICAgICAgICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gICAgICAgICAgICB6LWluZGV4OiAyO1xuICAgICAgICAgICAgdG9wOiBjYWxjKDUwJSAtIDVweCk7XG4gICAgICAgICAgICBsZWZ0OiBjYWxjKDUwJSAtIDE2cHgvMik7XG4gICAgICAgIH1cbiAgICAgICAgJltkaXNhYmxlZF0sXG4gICAgICAgICZbYXJpYS1kaXNhYmxlZD1cInRydWVcIl0sXG4gICAgICAgICYuaXMtZGlzYWJsZWQge1xuICAgICAgICAgICAgJjo6YWZ0ZXIge1xuICAgICAgICAgICAgICAgIGJvcmRlci1jb2xvcjogJGZkLWZvcm1zLWJhY2tncm91bmQtY29sb3ItLWNoZWNrLWRpc2FibGVkO1xuICAgICAgICAgICAgfVxuICAgICAgICB9XG4gICAgfVxufVxuaW5wdXRbdHlwZT1cInJhZGlvXCJdIHtcbiAgICBib3JkZXItcmFkaXVzOiA1MCU7XG4gICAgJjo6YWZ0ZXIge1xuICAgICAgICAkY2hlY2stc2l6ZV86IGZkLXNwYWNlKDQpO1xuICAgICAgICBjb250ZW50OiBcIlwiO1xuICAgICAgICBib3JkZXItcmFkaXVzOiA1MCU7XG4gICAgICAgIHdpZHRoOiAkY2hlY2stc2l6ZV87XG4gICAgICAgIGhlaWdodDogJGNoZWNrLXNpemVfO1xuICAgICAgICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gICAgICAgIGJvdHRvbTogMDtcbiAgICAgICAgcmlnaHQ6IDA7XG4gICAgICAgIHRvcDogY2FsYyg1MCUgLSAoI3skY2hlY2stc2l6ZV99LzIpKTtcbiAgICAgICAgbGVmdDogY2FsYyg1MCUgLSAoI3skY2hlY2stc2l6ZV99LzIpKTtcbiAgICAgICAgdHJhbnNpdGlvbjogYmFja2dyb3VuZC1jb2xvciAkZmQtZm9ybXMtdHJhbnNpdGlvbi1wYXJhbXM7XG4gICAgICAgIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50O1xuICAgIH1cbiAgICAmOmNoZWNrZWQge1xuICAgICAgICBiYWNrZ3JvdW5kLWNvbG9yOiAkZmQtZm9ybXMtYmFja2dyb3VuZC1jb2xvcjtcbiAgICAgICAgJjo6YWZ0ZXIge1xuICAgICAgICAgICAgYmFja2dyb3VuZC1jb2xvcjogJGZkLWZvcm1zLWJhY2tncm91bmQtY29sb3ItLWNoZWNrO1xuICAgICAgICB9XG4gICAgICAgICZbZGlzYWJsZWRdLFxuICAgICAgICAmW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLFxuICAgICAgICAmLmlzLWRpc2FibGVkIHtcbiAgICAgICAgICAgICY6OmFmdGVyIHtcbiAgICAgICAgICAgICAgICBiYWNrZ3JvdW5kLWNvbG9yOiAkZmQtZm9ybXMtYmFja2dyb3VuZC1jb2xvci0tY2hlY2stZGlzYWJsZWQ7XG4gICAgICAgICAgICB9XG4gICAgICAgIH1cbiAgICB9XG59XG4iLCJAaW1wb3J0IFwic2V0dGluZ3NcIjtcblxuJG5zOiBucygpO1xuLy91dGlsc1xuQG1peGluIHJlc2V0IHtcbiAgICBmb250LXNpemU6ICRmZC1mb250LXNpemU7XG4gICAgbGluZS1oZWlnaHQ6ICRmZC1saW5lLWhlaWdodDtcbiAgICBjb2xvcjogJGZkLWNvbG9yO1xufVxuXG5cblxuLy9lbHNcbkBtaXhpbiBmZC1mb3JtLWJhc2Uge1xuICAgIEBpbmNsdWRlIHJlc2V0O1xuICAgIEBpbmNsdWRlIGZkLXR5cGUoMCwgYm9keSk7XG4gICAgYXBwZWFyYW5jZTogbm9uZTtcbiAgICAtd2Via2l0LWFwcGVhcmFuY2U6IHRleHRmaWVsZDtcbiAgICAtbW96LWFwcGVhcmFuY2U6IHRleHRmaWVsZDtcbiAgICBmb250LXNpemU6IGluaGVyaXQ7XG4gICAgYm94LXNpemluZzogYm9yZGVyLWJveDtcbiAgICBvdXRsaW5lOiBub25lO1xuICAgIGJvcmRlci1zdHlsZTogc29saWQ7XG4gICAgYm9yZGVyLXdpZHRoOiAxcHg7XG4gICAgYm9yZGVyLWNvbG9yOiAkZmQtZm9ybXMtYm9yZGVyLWNvbG9yO1xuICAgIGJvcmRlci1yYWRpdXM6IDA7XG4gICAgY29sb3I6ICRmZC1mb3Jtcy1jb2xvcjtcbiAgICAvL2JhY2tncm91bmQtY29sb3I6ICRmZC1mb3Jtcy1iYWNrZ3JvdW5kLWNvbG9yO1xuICAgIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50O1xuICAgIHRyYW5zaXRpb246IGJvcmRlci1jb2xvciAkZmQtYW5pbWF0aW9uLS1zcGVlZDtcbiAgICAvL3N0YXRlc1xuICAgICY6Zm9jdXMsXG4gICAgJjpob3ZlciB7XG4gICAgICAgIGJvcmRlci1jb2xvcjogJGZkLWZvcm1zLWJvcmRlci1jb2xvci0tZm9jdXM7XG4gICAgICAgIC8vYmFja2dyb3VuZC1jb2xvcjogJGZkLWZvcm1zLWJhY2tncm91bmQtY29sb3I7XG4gICAgfVxuICAgICYuaXMtaW52YWxpZCB7XG4gICAgICAgIGJvcmRlci1jb2xvcjogJGZkLWNvbG9yLS1lcnJvcjtcbiAgICB9XG4gICAgJi5pcy12YWxpZCB7XG4gICAgICAgIGJvcmRlci1jb2xvcjogJGZkLWNvbG9yLS1zdWNjZXNzO1xuICAgIH1cbiAgICAmLmlzLXdhcm5pbmcge1xuICAgICAgICBib3JkZXItY29sb3I6ICRmZC1jb2xvci0td2FybmluZztcbiAgICB9XG4gICAgJjpkaXNhYmxlZCxcbiAgICAmW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLFxuICAgICYuaXMtZGlzYWJsZWQge1xuICAgICAgICBjdXJzb3I6IG5vdC1hbGxvd2VkO1xuICAgICAgICBjb2xvcjogJGZkLWZvcm1zLWNvbG9yLS1kaXNhYmxlZDtcbiAgICAgICAgYm9yZGVyLWNvbG9yOiAkZmQtZm9ybXMtYm9yZGVyLWNvbG9yLS1kaXNhYmxlZDtcbiAgICAgICAgYmFja2dyb3VuZC1jb2xvcjogJGZkLWZvcm1zLWJhY2tncm91bmQtY29sb3ItLWRpc2FibGVkO1xuICAgIH1cbiAgICAmW3JlYWRvbmx5XSxcbiAgICAmLmlzLXJlYWRvbmx5IHtcbiAgICAgICAgY29sb3I6ICRmZC1mb3Jtcy1jb2xvcjtcbiAgICAgICAgLy9iYWNrZ3JvdW5kLWNvbG9yOiAkZmQtZm9ybXMtYmFja2dyb3VuZC1jb2xvcjtcbiAgICAgICAgYm9yZGVyLWNvbG9yOiAkZmQtZm9ybXMtYm9yZGVyLWNvbG9yLS1kaXNhYmxlZDtcbiAgICAgICAgYm9yZGVyLXdpZHRoOiAwIDAgMXB4O1xuICAgIH1cbiAgICBAY29udGVudDtcbn1cbkBtaXhpbiBmZC1mb3JtLXRleHQge1xuICAgIEBpbmNsdWRlIGZkLWZvcm0tYmFzZTtcbiAgICBoZWlnaHQ6ICRmZC1mb3Jtcy1oZWlnaHQtLWlucHV0LXRleHQ7XG4gICAgcGFkZGluZy1sZWZ0OiAkZmQtZm9ybXMtcGFkZGluZztcbiAgICBwYWRkaW5nLXJpZ2h0OiAkZmQtZm9ybXMtcGFkZGluZztcbiAgICBAY29udGVudDtcbn1cbkBtaXhpbiBmZC1mb3JtLXNlbGVjdCB7XG4gICAgQGluY2x1ZGUgZmQtZm9ybS10ZXh0O1xuICAgIGFwcGVhcmFuY2U6IG5vbmU7XG4gICAgLW1vei1hcHBlYXJhbmNlOiBub25lO1xuICAgIGJhY2tncm91bmQtaW1hZ2U6IHVybCgjeyRmZC1mb3Jtcy1zZWxlY3QtYmFja2dyb3VuZC1pbWFnZX0pO1xuICAgIGJhY2tncm91bmQtcmVwZWF0OiBuby1yZXBlYXQ7XG4gICAgYmFja2dyb3VuZC1wb3NpdGlvbjogY2FsYygxMDAlIC0gI3skZmQtZm9ybXMtc2VsZWN0LXdpZHRoLS1iYWNrZ3JvdW5kLWltYWdlfSkgY2VudGVyO1xuICAgIHBhZGRpbmctcmlnaHQ6ICgkZmQtZm9ybXMtcGFkZGluZyAqIDIpICsgJGZkLWZvcm1zLXNlbGVjdC13aWR0aC0tYmFja2dyb3VuZC1pbWFnZTtcbiAgICAmOmZvY3VzLFxuICAgICY6aG92ZXIge1xuICAgICAgICBiYWNrZ3JvdW5kLWltYWdlOiB1cmwoI3skZmQtZm9ybXMtc2VsZWN0LWJhY2tncm91bmQtaW1hZ2UtLWFjdGl2ZX0pO1xuICAgIH1cbiAgICAmW2FyaWEtZXhwYW5kZWQ9XCJ0cnVlXCJdLFxuICAgICYuaXMtZXhwYW5kZWQge1xuICAgICAgICBiYWNrZ3JvdW5kLWltYWdlOiB1cmwoI3skZmQtZm9ybXMtc2VsZWN0LWJhY2tncm91bmQtaW1hZ2UtLWV4cGFuZGVkfSk7XG4gICAgfVxuICAgICZbZGlzYWJsZWRdLFxuICAgICZbYXJpYS1kaXNhYmxlZD1cInRydWVcIl0sXG4gICAgJi5pcy1kaXNhYmxlZCB7XG4gICAgICAgIGJhY2tncm91bmQtaW1hZ2U6IHVybCgjeyRmZC1mb3Jtcy1zZWxlY3QtYmFja2dyb3VuZC1pbWFnZS0tZGlzYWJsZWR9KTtcbiAgICB9XG4gICAgQGNvbnRlbnQ7XG59XG5cblxuXG5AbWl4aW4gZmQtY2xlYXJmaXgge1xuICAgICY6OmFmdGVyIHtcbiAgICAgICAgY29udGVudDogXCJcIjtcbiAgICAgICAgZGlzcGxheTogdGFibGU7XG4gICAgICAgIGNsZWFyOiBib3RoO1xuICAgIH1cbn1cblxuQG1peGluIGZkLWxhc3QtY2hpbGQge1xuICAgICY6bGFzdC1jaGlsZCB7XG4gICAgICAgIG1hcmdpbi1ib3R0b206IDA7XG4gICAgICAgIG1hcmdpbi1yaWdodDogMDtcbiAgICAgICAgQGNvbnRlbnQ7XG4gICAgfVxufVxuQG1peGluIGZkLWZpcnN0LWNoaWxkIHtcbiAgICAmOmZpcnN0LWNoaWxkIHtcbiAgICAgICAgbWFyZ2luLWxlZnQ6IDA7XG4gICAgICAgIEBjb250ZW50O1xuICAgIH1cbn1cblxuQG1peGluIGZkLXNjcmVlbigkc2l6ZSwgJGRpbWVuc2lvbjogd2lkdGgpIHtcbiAgQGlmIG1hcC1oYXMta2V5KCRmZC1icmVha3BvaW50cywgJHNpemUpIHtcbiAgICBAbWVkaWEgKG1pbi0jeyRkaW1lbnNpb259OiBtYXAtZ2V0KCRmZC1icmVha3BvaW50cywgJHNpemUpKSB7XG4gICAgICAgIEBjb250ZW50O1xuICAgIH1cbiAgfSBAZWxzZSB7XG4gICAgQHdhcm4gXCJVbmtub3duIGAjeyRzaXplfWAgaW4gJGZkLWJyZWFrcG9pbnRzIG1hcFwiO1xuICB9XG59XG5cbkBtaXhpbiBmZC1wcmludCgpIHtcblx0QG1lZGlhIHByaW50IHtcblx0XHRAY29udGVudDtcblx0fVxufVxuXG4vLyRzaXplOiAtMywtMiwtMSwwLDEsMiwzLDQsNVxuLy8kZm9udDogYm9keSwgaGVhZGVyLCBjb2RlXG4vLyR3ZWlnaHQ6IHJlZywgbWVkLCBzZW1pXG4vLyR0cmFuc2Zvcm06IG5vbmUsIHVwcGVyY2FzZSwgbG93ZXJjYXNlXG5AbWl4aW4gZmQtdHlwZSgkc2l6ZTogXCIwXCIsICRmb250OiBkZWZhdWx0LCAkd2VpZ2h0OiBkZWZhdWx0LCAkdHJhbnNmb3JtOiBkZWZhdWx0KSB7XG5cbiAgICAvL2dldCB0eXBlIG1hcCDigJTCoHNldCBkZWZhdWx0IHRvIDBcbiAgICAkbGlzdDogbWFwLWdldCgkZmQtdHlwZSwgXCIwXCIpO1xuICAgIEBpZiBtYXAtaGFzLWtleSgkZmQtdHlwZSwgJHNpemUpIHtcbiAgICAgICAgJGxpc3Q6IG1hcC1nZXQoJGZkLXR5cGUsICRzaXplKTtcbiAgICB9IEBlbHNlIHtcbiAgICAgICAgQHdhcm4gXCJVbmtub3duIGAjeyRzaXplfWAgaW4gJHR5cGUgbWFwXCI7XG4gICAgfVxuICAgIGZvbnQtc2l6ZTogbnRoKCRsaXN0LCAxKTtcbiAgICBsaW5lLWhlaWdodDogbnRoKCRsaXN0LCAyKTtcbiAgICAvL0hBTkRMRSBUWVBFIEZBQ0VcbiAgICBAaWYgJGZvbnQgIT0gZGVmYXVsdCB7XG4gICAgICAgIC8vZXhwbGljaXRseVxuICAgICAgICBAaWYgbWFwLWhhcy1rZXkoJGZkLWZvbnRzLCAkZm9udCkge1xuICAgICAgICAgICAgZm9udC1mYW1pbHk6IG1hcC1nZXQoJGZkLWZvbnRzLCAkZm9udCk7XG4gICAgICAgIH0gQGVsc2Uge1xuICAgICAgICAgICAgQHdhcm4gXCJVbmtub3duIGAjeyRmZC1mb250fWAgaW4gJGZvbnRzIG1hcFwiO1xuICAgICAgICB9XG4gICAgfSBAZWxzZSB7XG4gICAgICAgIC8vaW1wbGljaXR5XG4gICAgICAgICRfZm9udDogbnRoKCRsaXN0LCAzKTtcbiAgICAgICAgQGlmICRfZm9udCAhPSBib2R5IHtcbiAgICAgICAgICAgIGZvbnQtZmFtaWx5OiBtYXAtZ2V0KCRmZC1mb250cywgJF9mb250KTtcbiAgICAgICAgfVxuICAgIH1cbiAgICAvL0hBTkRMRSBXRUlHSFRcbiAgICBAaWYgJHdlaWdodCAhPSBkZWZhdWx0IHtcbiAgICAgICAgQGluY2x1ZGUgZmQtd2VpZ2h0KCR3ZWlnaHQpO1xuICAgIH0gQGVsc2Uge1xuICAgICAgICAvL2ltcGxpY2l0eVxuICAgICAgICAkX3dlaWdodDogbnRoKCRsaXN0LCA0KTtcbiAgICAgICAgQGluY2x1ZGUgZmQtd2VpZ2h0KCRfd2VpZ2h0KTtcbiAgICB9XG4gICAgLy9IQU5ETEUgVFJBTlNGT1JNXG4gICAgQGlmICR0cmFuc2Zvcm0gIT0gZGVmYXVsdCB7XG4gICAgICAgIHRleHQtdHJhbnNmb3JtOiAkdHJhbnNmb3JtO1xuICAgIH0gQGVsc2Uge1xuICAgICAgICAvL2ltcGxpY2l0eVxuICAgICAgICAkX3RyYW5zZm9ybTogbnRoKCRsaXN0LCA1KTtcbiAgICAgICAgQGlmICRfdHJhbnNmb3JtICE9IG5vbmUge1xuICAgICAgICAgICAgdGV4dC10cmFuc2Zvcm06ICRfdHJhbnNmb3JtO1xuICAgICAgICB9XG4gICAgfVxufVxuXG5cbkBtaXhpbiBmZC13ZWlnaHQoJHdlaWdodDogcmVnKSB7XG4gICAgQGlmICR3ZWlnaHQgPT0gbGlnaHQge1xuICAgICAgICBmb250LXdlaWdodDogMzAwO1xuICAgIH0gQGVsc2UgaWYgJHdlaWdodCA9PSByZWcge1xuICAgICAgICBmb250LXdlaWdodDogNDAwO1xuICAgIH0gQGVsc2UgaWYgJHdlaWdodCA9PSBtZWQge1xuICAgICAgICBmb250LXdlaWdodDogNTAwO1xuICAgIH0gQGVsc2UgaWYgJHdlaWdodCA9PSBzZW1pIHtcbiAgICAgICAgZm9udC13ZWlnaHQ6IDYwMDtcbiAgICB9IEBlbHNlIGlmICR3ZWlnaHQgPT0gYm9sZCB7XG4gICAgICAgIGZvbnQtd2VpZ2h0OiA3MDA7XG4gICAgfVxufVxuXG5cbi8vVGFrZW4gZnJvbSBodHRwczovL2dpdGh1Yi5jb20vdGhvdWdodGJvdC9ib3VyYm9uL2Jsb2IvbWFzdGVyL2NvcmUvYm91cmJvbi9saWJyYXJ5L190cmlhbmdsZS5zY3NzXG5AbWl4aW4gdHJpYW5nbGUoJHNpemUsICRjb2xvciwgJGRpcmVjdGlvbikge1xuICAkd2lkdGg6IG50aCgkc2l6ZSwgMSk7XG4gICRoZWlnaHQ6IG50aCgkc2l6ZSwgbGVuZ3RoKCRzaXplKSk7XG4gICRmb3JlZ3JvdW5kLWNvbG9yOiBudGgoJGNvbG9yLCAxKTtcbiAgJGJhY2tncm91bmQtY29sb3I6IGlmKGxlbmd0aCgkY29sb3IpID09IDIsIG50aCgkY29sb3IsIDIpLCB0cmFuc3BhcmVudCk7XG4gIGhlaWdodDogMDtcbiAgd2lkdGg6IDA7XG5cbiAgQGlmICgkZGlyZWN0aW9uID09IHVwKSBvciAoJGRpcmVjdGlvbiA9PSBkb3duKSBvciAoJGRpcmVjdGlvbiA9PSByaWdodCkgb3IgKCRkaXJlY3Rpb24gPT0gbGVmdCkge1xuICAgICR3aWR0aDogJHdpZHRoIC8gMjtcbiAgICAkaGVpZ2h0OiBpZihsZW5ndGgoJHNpemUpID4gMSwgJGhlaWdodCwgJGhlaWdodC8yKTtcblxuICAgIEBpZiAkZGlyZWN0aW9uID09IHVwIHtcbiAgICAgIGJvcmRlci1ib3R0b206ICRoZWlnaHQgc29saWQgJGZvcmVncm91bmQtY29sb3I7XG4gICAgICBib3JkZXItbGVmdDogJHdpZHRoIHNvbGlkICRiYWNrZ3JvdW5kLWNvbG9yO1xuICAgICAgYm9yZGVyLXJpZ2h0OiAkd2lkdGggc29saWQgJGJhY2tncm91bmQtY29sb3I7XG4gICAgfSBAZWxzZSBpZiAkZGlyZWN0aW9uID09IHJpZ2h0IHtcbiAgICAgIGJvcmRlci1ib3R0b206ICR3aWR0aCBzb2xpZCAkYmFja2dyb3VuZC1jb2xvcjtcbiAgICAgIGJvcmRlci1sZWZ0OiAkaGVpZ2h0IHNvbGlkICRmb3JlZ3JvdW5kLWNvbG9yO1xuICAgICAgYm9yZGVyLXRvcDogJHdpZHRoIHNvbGlkICRiYWNrZ3JvdW5kLWNvbG9yO1xuICAgIH0gQGVsc2UgaWYgJGRpcmVjdGlvbiA9PSBkb3duIHtcbiAgICAgIGJvcmRlci1sZWZ0OiAkd2lkdGggc29saWQgJGJhY2tncm91bmQtY29sb3I7XG4gICAgICBib3JkZXItcmlnaHQ6ICR3aWR0aCBzb2xpZCAkYmFja2dyb3VuZC1jb2xvcjtcbiAgICAgIGJvcmRlci10b3A6ICRoZWlnaHQgc29saWQgJGZvcmVncm91bmQtY29sb3I7XG4gICAgfSBAZWxzZSBpZiAkZGlyZWN0aW9uID09IGxlZnQge1xuICAgICAgYm9yZGVyLWJvdHRvbTogJHdpZHRoIHNvbGlkICRiYWNrZ3JvdW5kLWNvbG9yO1xuICAgICAgYm9yZGVyLXJpZ2h0OiAkaGVpZ2h0IHNvbGlkICRmb3JlZ3JvdW5kLWNvbG9yO1xuICAgICAgYm9yZGVyLXRvcDogJHdpZHRoIHNvbGlkICRiYWNrZ3JvdW5kLWNvbG9yO1xuICAgIH1cbiAgfSBAZWxzZSBpZiAoJGRpcmVjdGlvbiA9PSB1cC1yaWdodCkgb3IgKCRkaXJlY3Rpb24gPT0gdXAtbGVmdCkge1xuICAgIGJvcmRlci10b3A6ICRoZWlnaHQgc29saWQgJGZvcmVncm91bmQtY29sb3I7XG5cbiAgICBAaWYgJGRpcmVjdGlvbiA9PSB1cC1yaWdodCB7XG4gICAgICBib3JkZXItbGVmdDogICR3aWR0aCBzb2xpZCAkYmFja2dyb3VuZC1jb2xvcjtcbiAgICB9IEBlbHNlIGlmICRkaXJlY3Rpb24gPT0gdXAtbGVmdCB7XG4gICAgICBib3JkZXItcmlnaHQ6ICR3aWR0aCBzb2xpZCAkYmFja2dyb3VuZC1jb2xvcjtcbiAgICB9XG4gIH0gQGVsc2UgaWYgKCRkaXJlY3Rpb24gPT0gZG93bi1yaWdodCkgb3IgKCRkaXJlY3Rpb24gPT0gZG93bi1sZWZ0KSB7XG4gICAgYm9yZGVyLWJvdHRvbTogJGhlaWdodCBzb2xpZCAkZm9yZWdyb3VuZC1jb2xvcjtcblxuICAgIEBpZiAkZGlyZWN0aW9uID09IGRvd24tcmlnaHQge1xuICAgICAgYm9yZGVyLWxlZnQ6ICAkd2lkdGggc29saWQgJGJhY2tncm91bmQtY29sb3I7XG4gICAgfSBAZWxzZSBpZiAkZGlyZWN0aW9uID09IGRvd24tbGVmdCB7XG4gICAgICBib3JkZXItcmlnaHQ6ICR3aWR0aCBzb2xpZCAkYmFja2dyb3VuZC1jb2xvcjtcbiAgICB9XG4gIH0gQGVsc2UgaWYgKCRkaXJlY3Rpb24gPT0gaW5zZXQtdXApIHtcbiAgICBib3JkZXItY29sb3I6ICRiYWNrZ3JvdW5kLWNvbG9yICRiYWNrZ3JvdW5kLWNvbG9yICRmb3JlZ3JvdW5kLWNvbG9yO1xuICAgIGJvcmRlci1zdHlsZTogc29saWQ7XG4gICAgYm9yZGVyLXdpZHRoOiAkaGVpZ2h0ICR3aWR0aDtcbiAgfSBAZWxzZSBpZiAoJGRpcmVjdGlvbiA9PSBpbnNldC1kb3duKSB7XG4gICAgYm9yZGVyLWNvbG9yOiAkZm9yZWdyb3VuZC1jb2xvciAkYmFja2dyb3VuZC1jb2xvciAkYmFja2dyb3VuZC1jb2xvcjtcbiAgICBib3JkZXItc3R5bGU6IHNvbGlkO1xuICAgIGJvcmRlci13aWR0aDogJGhlaWdodCAkd2lkdGg7XG4gIH0gQGVsc2UgaWYgKCRkaXJlY3Rpb24gPT0gaW5zZXQtcmlnaHQpIHtcbiAgICBib3JkZXItY29sb3I6ICRiYWNrZ3JvdW5kLWNvbG9yICRiYWNrZ3JvdW5kLWNvbG9yICRiYWNrZ3JvdW5kLWNvbG9yICRmb3JlZ3JvdW5kLWNvbG9yO1xuICAgIGJvcmRlci1zdHlsZTogc29saWQ7XG4gICAgYm9yZGVyLXdpZHRoOiAkd2lkdGggJGhlaWdodDtcbiAgfSBAZWxzZSBpZiAoJGRpcmVjdGlvbiA9PSBpbnNldC1sZWZ0KSB7XG4gICAgYm9yZGVyLWNvbG9yOiAkYmFja2dyb3VuZC1jb2xvciAkZm9yZWdyb3VuZC1jb2xvciAkYmFja2dyb3VuZC1jb2xvciAkYmFja2dyb3VuZC1jb2xvcjtcbiAgICBib3JkZXItc3R5bGU6IHNvbGlkO1xuICAgIGJvcmRlci13aWR0aDogJHdpZHRoICRoZWlnaHQ7XG4gIH1cbn1cblxuQG1peGluIHJvdGF0ZSgkZGVnOiA5MCl7XG4gICAgJHNEZWc6ICN7JGRlZ31kZWc7XG5cbiAgICAtd2Via2l0LXRyYW5zZm9ybTogcm90YXRlKCRzRGVnKTtcbiAgICAtbW96LXRyYW5zZm9ybTogcm90YXRlKCRzRGVnKTtcbiAgICAtbXMtdHJhbnNmb3JtOiByb3RhdGUoJHNEZWcpO1xuICAgIC1vLXRyYW5zZm9ybTogcm90YXRlKCRzRGVnKTtcbiAgICB0cmFuc2Zvcm06IHJvdGF0ZSgkc0RlZyk7XG59XG4iLCJAZnVuY3Rpb24gY29sb3IoJGtleTogcmVnKSB7XG4gICAgQGlmIG1hcC1oYXMta2V5KCRjb2xvcnMsICRrZXkpIHtcbiAgICAgICAgQHJldHVybiBtYXAtZ2V0KCRjb2xvcnMsICRrZXkpO1xuICAgIH0gQGVsc2Uge1xuICAgICAgICBAd2FybiBcIlVua25vd24gYCN7JGtleX1gIGluICRjb2xvcnMgbWFwXCI7XG4gICAgICAgIEByZXR1cm4gYmxhY2s7XG4gICAgfVxufVxuQGZ1bmN0aW9uIG5zKCRzdHI6IFwiXCIpIHtcblx0JG5zOiAjeyRmZC1uYW1lc3BhY2V9LTtcbiAgICBAcmV0dXJuICRucyArICRzdHI7XG59XG5cbi8vaWZcbkBmdW5jdGlvbiBmZC1pZigkYm9vbCwgJHBvc3MpIHtcbiAgICBAaWYgJGJvb2wge1xuICAgICAgICBAcmV0dXJuIG50aCgkcG9zcywgMSk7XG4gICAgfVxuICAgIEByZXR1cm4gbnRoKCRwb3NzLCAyKTtcbn1cblxuLy9zcGFjZSBoZWxwZXJcbkBmdW5jdGlvbiBmZC1tb2RpZnktc3BhY2VfKCRzaXplKSB7XG4gICAgJF9zaXplOiAkc2l6ZTtcbiAgICBAaWYgJGZkLXNwYWNlLW1vZGlmeSA9PSBjb21wYWN0IHtcbiAgICAgICAgJF9zaXplOiAkX3NpemUgLyAyO1xuICAgIH1cbiAgICBAcmV0dXJuICRfc2l6ZTtcbn1cblxuLy9hY2NlcHRzIHNpemUga2V5IG9yIGluY3JlbWVudCwgbW9kaWZ5IGVuYWJsZXMgb24gZmQtc3BhY2UtbW9kaWZpZXJcbkBmdW5jdGlvbiBmZC1zcGFjZSgkc2l6ZTogcmVnLCAkbW9kaWZpYWJsZTogZmFsc2UpIHtcbiAgICAkX21hcDogJGZkLXNwYWNpbmc7XG4gICAgLy9zZXQgYmFzZVxuICAgICRfc2l6ZTogbWFwLWdldCgkX21hcCwgYmFzZSk7XG4gICAgQGlmIHR5cGUtb2YoJHNpemUpID09IG51bWJlciB7XG4gICAgICAgIC8vbXVsdGlwbHlcbiAgICAgICAgJF9zaXplOiAkX3NpemUgKiAkc2l6ZTtcbiAgICB9IEBlbHNlIHtcbiAgICAgICAgQGlmIG1hcC1oYXMta2V5KCRfbWFwLCAkc2l6ZSkge1xuICAgICAgICAgICAgJF9zaXplOiBtYXAtZ2V0KCRfbWFwLCAkc2l6ZSk7XG4gICAgICAgIH0gQGVsc2Uge1xuICAgICAgICAgICAgQHdhcm4gXCJJbnZhbGlkICRzaXplIG9mIGAjeyRzaXplfWAuIFZhbGlkICRzaXplIHZhbHVlcyBhcmUgI3ttYXAta2V5cygkX21hcCl9LiBSZXR1cm5pbmcgZGVmYXVsdCBgI3skX3NpemV9YC5cIjtcbiAgICAgICAgfVxuICAgIH1cbiAgICBAaWYgJG1vZGlmaWFibGUge1xuICAgICAgICAkX3NpemU6IGZkLW1vZGlmeS1zcGFjZV8oJF9zaXplKTtcbiAgICB9XG4gICAgQHJldHVybiAkX3NpemU7XG59XG5cblxuQGZ1bmN0aW9uIGZkLWNvbG9yKCR0eXBlOiB0ZXh0LCAkc2hhZGU6IDEpIHtcbiAgICAkX21hcDogJGZkLWNvbG9ycztcbiAgICAvL2NoZWNrIHR5cGVcbiAgICBAaWYgbWFwLWhhcy1rZXkoJF9tYXAsICR0eXBlKSB7XG4gICAgICAgICRfZ3JvdXA6IG1hcC1nZXQoJF9tYXAsICR0eXBlKTtcbiAgICAgICAgLy9jaGVjayBzaGFkZVxuICAgICAgICBAaWYgbWFwLWhhcy1rZXkoJF9ncm91cCwgJHNoYWRlKSB7XG4gICAgICAgICAgICAkX2NvbG9yOiBtYXAtZ2V0KCRfZ3JvdXAsICRzaGFkZSk7XG4gICAgICAgICAgICBAcmV0dXJuICRfY29sb3I7XG4gICAgICAgIH0gQGVsc2Uge1xuICAgICAgICAgICAgQHdhcm4gXCJJbnZhbGlkICRzaGFkZSBvZiBgI3skc2hhZGV9YCBpbiB0aGUgbWFwICR0eXBlIG9mIGAjeyR0eXBlfWAuIFZhbGlkICRzaGFkZSB2YWx1ZXMgYXJlICN7bWFwLWtleXMoJF9ncm91cCl9LiBSZXR1cm5pbmcgYGJsYWNrYC5cIjtcbiAgICAgICAgICAgIEByZXR1cm4gYmxhY2s7XG4gICAgICAgIH1cbiAgICB9IEBlbHNlIHtcbiAgICAgICAgQHdhcm4gXCJJbnZhbGlkIG1hcCAkdHlwZSBvZiBgI3skdHlwZX1gLiBWYWxpZCAkdHlwZSB2YWx1ZXMgYXJlICN7bWFwLWtleXMoJF9tYXApfS4gUmV0dXJuaW5nIGBibGFja2AuXCI7XG4gICAgICAgIEByZXR1cm4gYmxhY2s7XG4gICAgfVxufVxuIiwiQGltcG9ydCBcIi4uL2NvcmUvc2V0dGluZ3NcIjtcbkBpbXBvcnQgXCIuLi9jb3JlL2Z1bmN0aW9uc1wiO1xuQGltcG9ydCBcIi4uL2NvcmUvbWl4aW5zXCI7XG5cbi8qIVxuLmZkLXNlY3Rpb24rKC0tZnVsbC1ibGVlZCwgLS1uby1ib3JkZXIpXG4gICAgLmZkLXNlY3Rpb25fX2hlYWRlclxuICAgICAgICAuZmQtc2VjdGlvbl9fdGl0bGVcbiAgICAgICAgLmZkLXNlY3Rpb25fX2FjdGlvbnNcbiAgICAuZmQtc2VjdGlvbl9fZm9vdGVyXG4qL1xuXG4kYmxvY2s6IG5zKHNlY3Rpb24pO1xuLiN7JGJsb2NrfSB7XG5cbiAgICAkZmQtc2VjdGlvbi1ib3JkZXItY29sb3I6IGZkLWNvbG9yKG5ldXRyYWwsIDMpICFkZWZhdWx0O1xuICAgICRmZC1zZWN0aW9uLXBhZGRpbmc6ICRmZC1wYWRkaW5nLS11aSAhZGVmYXVsdDtcbiAgICAkZmQtc2VjdGlvbi1wYWRkaW5nLS10b3A6IGZkLXNwYWNlKG0pICFkZWZhdWx0O1xuICAgICRmZC1zZWN0aW9uLXBhZGRpbmctLWJvdHRvbTogZmQtc3BhY2UocmVnKSAhZGVmYXVsdDtcblxuICAgIEBpbmNsdWRlIGZkLWNsZWFyZml4O1xuICAgIHBhZGRpbmc6ICRmZC1zZWN0aW9uLXBhZGRpbmctLXRvcCAkZmQtc2VjdGlvbi1wYWRkaW5nICRmZC1zZWN0aW9uLXBhZGRpbmctLWJvdHRvbTtcbiAgICBib3JkZXItYm90dG9tOiBzb2xpZCAycHggJGZkLXNlY3Rpb24tYm9yZGVyLWNvbG9yO1xuICAgICY6bGFzdC1jaGlsZCxcbiAgICAmLS1uby1ib3JkZXIge1xuICAgICAgICBib3JkZXItYm90dG9tOiAwO1xuICAgIH1cbiAgICAmLS1mdWxsLWJsZWVkIHtcbiAgICAgICAgcGFkZGluZy1yaWdodDogMDtcbiAgICAgICAgcGFkZGluZy1sZWZ0OiAwO1xuICAgICAgICAuI3skYmxvY2t9X19oZWFkZXIsIC4jeyRibG9ja31fX2Zvb3RlciB7XG4gICAgICAgICAgICBtYXJnaW4tbGVmdDogJGZkLXNlY3Rpb24tcGFkZGluZztcbiAgICAgICAgICAgIG1hcmdpbi1yaWdodDogJGZkLXNlY3Rpb24tcGFkZGluZztcbiAgICAgICAgfVxuICAgIH1cbiAgICAmX19oZWFkZXIge1xuICAgICAgICBtaW4taGVpZ2h0OiBmZC1zcGFjZSgxMCk7XG4gICAgICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgICAgIGFsaWduLWl0ZW1zOiBjZW50ZXI7XG4gICAgICAgIG1hcmdpbi1ib3R0b206IGZkLXNwYWNlKDQpO1xuICAgIH1cbiAgICAmX190aXRsZSB7XG4gICAgICAgIEBpbmNsdWRlIGZkLXR5cGUoMyk7XG4gICAgICAgIGZsZXg6IDE7XG4gICAgICAgIG1hcmdpbi1ib3R0b206IDA7XG4gICAgfVxuICAgICZfX2FjdGlvbnMge1xuICAgICAgICBtYXJnaW4tbGVmdDogYXV0bztcbiAgICB9XG4gICAgJl9fZm9vdGVyIHtcbiAgICAgICAgZGlzcGxheTogZmxleDtcbiAgICAgICAganVzdGlmeS1jb250ZW50OiBjZW50ZXI7XG4gICAgfVxufVxuIiwiQGltcG9ydCBcIi4uL2NvcmUvc2V0dGluZ3NcIjtcbkBpbXBvcnQgXCIuLi9jb3JlL2Z1bmN0aW9uc1wiO1xuQGltcG9ydCBcIi4uL2NvcmUvbWl4aW5zXCI7XG5cbiRibG9jazogbnMoY29udGFpbmVyKTtcbi4jeyRibG9ja30ge1xuICAgIEBpbmNsdWRlIGZkLWNsZWFyZml4O1xuICAgIC8vcGFkZGluZzogMCAkZmQtcGFkZGluZy0tdWk7XG4gICAgbWFyZ2luLWJvdHRvbTogJGZkLW1hcmdpbi1ib3R0b207XG4gICAgbWF4LXdpZHRoOiAkZmQtbWF4LXdpZHRoLS11aTtcbiAgICAmOmxhc3QtY2hpbGQge1xuICAgICAgICBtYXJnaW4tYm90dG9tOiAwO1xuICAgIH1cbiAgICAmLS1mbHVpZCB7XG4gICAgICAgIG1heC13aWR0aDogMTAwJTtcbiAgICB9XG4gICAgLy8gJi0tYmxlZWQge1xuICAgIC8vICAgICBwYWRkaW5nOiAwO1xuICAgIC8vIH1cbiAgICAmLS1mbGV4IHtcbiAgICAgICAgZGlzcGxheTogZmxleDtcbiAgICB9XG4gICAgJi0tY2VudGVyZWQge1xuICAgICAgICBtYXJnaW4tbGVmdDogYXV0bztcbiAgICAgICAgbWFyZ2luLXJpZ2h0OiBhdXRvO1xuICAgIH1cbn1cbiIsIkBpbXBvcnQgXCIuLi9jb3JlL21peGluc1wiO1xuXG5AbWl4aW4gbmF2bGlzdCgkZGlyZWN0aW9uOiBob3Jpem9udGFsKSB7XG4gICAgbGlzdC1zdHlsZTogbm9uZTtcbiAgICBwYWRkaW5nOiAwO1xuXHRbYXJpYS1zZWxlY3RlZD10cnVlXSB7XG5cdFx0Y3Vyc29yOiBkZWZhdWx0O1xuXHR9XG5cdGEge1xuXHRcdGNvbG9yOiBpbmhlcml0O1xuXHR9XG5cdFthcmlhLWhpZGRlbj10cnVlXSB7XG5cdFx0ZGlzcGxheTogbm9uZTtcblx0fVxuXHRAaWYgJGRpcmVjdGlvbiA9IGhvcml6b250YWwge1xuXHQgICAgQGluY2x1ZGUgZmQtY2xlYXJmaXg7XG5cdFx0bWFyZ2luOiAwO1xuXHRcdGxpIHtcblx0XHRcdGZsb2F0OiBsZWZ0O1xuXHRcdH1cblx0fVxufVxuXG4vKlxuV0hZIFRISVM6XG5PdGhlciBzZW1hbnRpYyBncmlkcyBkb24ndCBlYWlseSBhbGxvdyBmb3IgZml4ZWQgZ3V0dGVyIHdpZHRoc1xubm9yIGRvIHRoZXkgdGFrZSBhZHZhbnRhZ2Ugb2YgdGhlIENTUyBjYWxjIGZ1bmN0aW9uXG5hbmQgdGhleSBjYW4gZ2V0IGtpbmQgb2YgY29uZnVzaW5nLlxuVGhpcyBpcyBtZWFudCBmb3Igc2ltcGxlIGxheW91dCBwcm9ibGVtcyDigJTCoFxuaS5lLiwgeW91IGhhdmUgYSBib3ggYW5kIHlvdSBuZWVkIHRocmVlIGNvbHMgaW5zaWRlIG9mIGVxdWFsIHdpZHRoc1xud2l0aCBndXR0ZXJzIGJldHdlZW4uXG5cblRoZSBGTE9XIHRlcm1pbm9sb2d5IGlzIG1lYW50IHRvIGJlIG5ldHVyYWwgb3V0c2lkZSBvZiByb3dzIGFuZCBjb2x1bW5zXG5hbmQgY29tZXMgZnJvbSB0aGUgSFRNTDUgc3BlYyByZWZlcnJpbmcgdG8gZWxlbWVudHMgdGhhdCBjYW4gY29udGFpbiBvdGhlciBlbGVtZW50c1xuaHR0cDovL3czYy5naXRodWIuaW8vaHRtbC9kb20uaHRtbCNraW5kcy1vZi1jb250ZW50LWZsb3ctY29udGVudFxuXG5VU0FHRTpcbuKAlMKgT3V0ZXIgY29udGFpbmVycyBzaG91bGQgY29udGFpbiB0aGUgYEBpbmNsdWRlIGZsb3ctYm94YCBiYXNlIHN0eWxlc1xu4oCUwqBDb2x1bW5zIGdldCBgQGluY2x1ZGUgZmxvd2Agd2l0aCBgJHNwYW5gIGFuZCBgJGNvbHNgIHBhcmFtc1xuXG5FWEFNUExFIE1BUktVUDpcbjxzZWN0aW9uPlxuICA8ZGl2IGNsYXNzPVwiYm94XCI+eDwvZGl2PlxuICA8ZGl2IGNsYXNzPVwiYm94XCI+eDwvZGl2PlxuICA8ZGl2IGNsYXNzPVwiYm94XCI+eDwvZGl2PlxuICA8ZGl2IGNsYXNzPVwiYm94XCI+eDwvZGl2PlxuPC9zZWN0aW9uPlxuXG5FWEFNUExFIENTUzpcbnNlY3Rpb24ge1xuICBAaW5jbHVkZSBmbG93LWJveCgpXG4gIC5ib3gge1xuICAgIEBpbmNsdWRlIGZsb3coMik7XG4gICAgJjpmaXJzdC1jaGlsZCB7XG4gICAgICBAaW5jbHVkZSBmbG93LXNoaWZ0KDIpO1xuICAgIH1cbiAgfVxufVxuXG5PVVRQVVQ6XG5UaGlzIHdpbGwgcmVuZGVyIDQgYm94ZXMgc3Bhbm5pbmcgMiBjb2xzIGVhY2ggaW5kZW50ZWQgMiBjb2xzXG4oYmFzZWQgb24gZGVmYXVsdHMpXG5cbnwtLXwgfC0tfCB8LS18IHwtLXwgfC0tfCB8LS18IHwtLXwgfC0tfCB8LS18IHwtLXwgfC0tfCB8LS18XG4gICAgICAgICAgfCAgYm94ICB8IHwgIGJveCAgfCB8ICBib3ggIHwgfCAgYm94ICB8XG5cbiovXG5cbiRmbG93X3dpZHRoX29mX2d1dHRlcjogJGZkLXdpZHRoLS1ndXR0ZXI7XG5cbi8vQXBwbHkgdG8gb3V0ZXIgY29udGFpbmVyXG5AbWl4aW4gZmQtZmxvdy1ib3gge1xuICBAaW5jbHVkZSBmZC1jbGVhcmZpeDtcbn1cblxuLy9BcHBseSB0byBcImNvbHVtbmVkXCIgY29udGFpbmVyc1xuQG1peGluIGZkLWZsb3coJHNwYW46IDEyLCAkY29sczogMTIpIHtcbiAgZmxvYXQ6IGxlZnQ7XG5cbiAgLy9zZXQgbWFyZ2luIGZvciBndXR0ZXJcbiAgbWFyZ2luLXJpZ2h0OiAkZmxvd193aWR0aF9vZl9ndXR0ZXI7XG4gICY6bGFzdC1jaGlsZCB7XG4gICAgbWFyZ2luLXJpZ2h0OiAwO1xuICB9XG4gIC8vY2FsYyB3aWR0aCB3aXRob3V0IGd1dHRlcnNcbiAgJG51bV9vZl9ndXR0ZXJzOiAkY29scyAtIDE7XG4gICRndXR0ZXJfd2lkdGhfdG90YWw6ICRudW1fb2ZfZ3V0dGVycyAqICRmbG93X3dpZHRoX29mX2d1dHRlcjtcblxuICAvL2NhbGMgc3Bhbm5lZCBndXR0ZXIgd2lkdGhcbiAgJGd1dHRlcl93aWR0aF9zcGFubmVkOiAkZmxvd193aWR0aF9vZl9ndXR0ZXIgKiAoJHNwYW4gLSAxKTtcblxuICAvL3RoZSBtYXRoXG4gIC8vIzEgc3VidHJhY3QgdG90YWwgZ3V0dGVyIHdpZHRoIGZyb20gY29udGFpbmVyIHdpZHRoIChlLmcuLCAxMiBjb2xzIGhhdmUgMTEgZ3V0dGVycyAqIDIwcHgpXG4gIC8vIzIgZGl2aWRlIHJlbWFpbmluZyBzcGFjZSBieSBudW1iZXIgb2YgY29scyB0byBnZXQgd2lkdGggZm9yIGVhY2ggY29sXG4gIC8vIzMgbXVsdGlwbHkgY29sIHdpZHRoIGJ5IG51bWJlciBvZiBjb2xzIHRvIHNwYW5cbiAgLy8jNCBhZGQgYmFjayBpbiBndXR0ZXIgc3BhY2UgZm9yIGNvbHMgc3Bhbm5pbmcgbXVsdGlwbGUgY29scyAoZS5nLiwgMyBjb2wgc3BhbnMgb3ZlciAyIGd1dHRlcnMpXG4gIHdpZHRoOiBjYWxjKFxuICAgIChcbiAgICAgIChcbiAgICAgICAgKDEwMCUgLSAjeyRndXR0ZXJfd2lkdGhfdG90YWx9KVxuICAgICAgICAgIC8gI3skY29sc31cbiAgICAgICkgKiAjeyRzcGFufVxuICAgICkgKyAjeyRndXR0ZXJfd2lkdGhfc3Bhbm5lZH1cbiAgKTtcbn1cblxuLy9JbmRlbnRzIGNvbnRlbnRcbkBtaXhpbiBmZC1mbG93LXNoaWZ0KCRzcGFuLCAkY29sczogMTIpIHtcblxuICAvL2NhbGMgd2lkdGggd2l0aG91dCBndXR0ZXJzXG4gICRudW1fb2ZfZ3V0dGVyczogJGNvbHMgLSAxO1xuICAkZ3V0dGVyX3dpZHRoX3RvdGFsOiAkbnVtX29mX2d1dHRlcnMgKiAkZmxvd193aWR0aF9vZl9ndXR0ZXI7XG5cbiAgLy9jYWxjIHNwYW5uZWQgZ3V0dGVyIHdpZHRoXG4gICRndXR0ZXJfd2lkdGhfc3Bhbm5lZDogJGZsb3dfd2lkdGhfb2ZfZ3V0dGVyICogKCRzcGFuKTtcblxuICBtYXJnaW4tbGVmdDogY2FsYyhcbiAgICAoXG4gICAgICAoXG4gICAgICAgICgxMDAlIC0gI3skZ3V0dGVyX3dpZHRoX3RvdGFsfSlcbiAgICAgICAgICAvICN7JGNvbHN9XG4gICAgICApICogI3skc3Bhbn1cbiAgICApICsgI3skZ3V0dGVyX3dpZHRoX3NwYW5uZWR9XG4gICk7XG59XG4iLCJAaW1wb3J0IFwiLi4vY29yZS9zZXR0aW5nc1wiO1xuQGltcG9ydCBcIi4uL2NvcmUvZnVuY3Rpb25zXCI7XG5AaW1wb3J0IFwiLi4vY29yZS9taXhpbnNcIjtcbkBpbXBvcnQgXCJtaXhpbnNcIjtcblxuJGJsb2NrOiBucyhjb2wpO1xuXG4vKiFcbiAgICAuZmQtY29sKygtLTEuLi4xMiwgLS1zaGlmdC0xLi4uMTEpXG4qL1xuLiN7JGJsb2NrfSB7XG4gICAgZmxleDogMTtcbiAgICBAaW5jbHVkZSBmZC1zY3JlZW4ocykge1xuICAgICAgICBAZm9yICRpIGZyb20gMSB0aHJvdWdoIDEyIHtcbiAgICAgICAgICAgICYtLSN7JGl9IHtcbiAgICAgICAgICAgICAgICBAaW5jbHVkZSBmZC1mbG93KCRpLCAxMik7XG4gICAgICAgICAgICB9XG4gICAgICAgIH1cbiAgICAgICAgQGZvciAkaSBmcm9tIDEgdGhyb3VnaCAxMSB7XG4gICAgICAgICAgICAmLS1zaGlmdC0jeyRpfSB7XG4gICAgICAgICAgICAgICAgQGluY2x1ZGUgZmQtZmxvdy1zaGlmdCgkaSk7XG4gICAgICAgICAgICB9XG4gICAgICAgIH1cbiAgICB9XG4gICAgQGF0LXJvb3Qge1xuICAgICAgICBbY2xhc3NePVwiI3skYmxvY2t9XCJdIHtcbiAgICAgICAgICAgIG1hcmdpbi1ib3R0b206ICRmZC1tYXJnaW4tYm90dG9tO1xuICAgICAgICAgICAgJjpsYXN0LWNoaWxkIHtcbiAgICAgICAgICAgICAgICBtYXJnaW4tYm90dG9tOiAwO1xuICAgICAgICAgICAgfVxuICAgICAgICAgICAgQGluY2x1ZGUgZmQtc2NyZWVuKHMpIHtcbiAgICAgICAgICAgICAgICBtYXJnaW4tYm90dG9tOiAwO1xuICAgICAgICAgICAgfVxuICAgICAgICB9XG4gICAgfVxufVxuIiwiQGltcG9ydCBcIi4uL2NvcmUvc2V0dGluZ3NcIjtcbkBpbXBvcnQgXCIuLi9jb3JlL21peGluc1wiO1xuQGltcG9ydCBcIi4uL2NvcmUvZnVuY3Rpb25zXCI7XG5cbiRibG9jazogbnModWkpO1xuXG4vKiFcbi5mZC11aSsoLS1maXhlZClcbiAgICAuZmQtdWlfX2hlYWRlcisoLS1maXhlZClcbiAgICAuZmQtdWlfX2FwcFxuICAgIC5mZC11aV9fZm9vdGVyKygtLWZpeGVkKVxuICAgIC5mZC11aV9fb3ZlcmxheVxuKi9cblxuLiN7JGJsb2NrfSB7XG4gICAgLy90aGVzZSB2YXJzIGNhbiBiZSBzZXQgZ2xvYmFsbHkgdG8gbG9jayBhbGwgcGFnZXNcbiAgICAvL2Fsc28sIC0tZml4ZWQgbW9kaWZpZXJzIGNhbiBiZSB1c2VkIGluIHRoZSBIVE1MIHRvIHNldCBwZXIgdGVtcGxhdGUgY29uZmlndXJhdGlvbnNcbiAgICAkZmQtdWktZml4ZWQ6IGZhbHNlICFkZWZhdWx0O1xuICAgICRmZC11aS1oZWFkZXItZml4ZWQ6IGZhbHNlICFkZWZhdWx0O1xuICAgICRmZC11aS1mb290ZXItZml4ZWQ6IGZhbHNlICFkZWZhdWx0O1xuXG4gICAgJGZkLXVpLWhlYWRlci1oZWlnaHQ6IDUwcHggIWRlZmF1bHQ7XG4gICAgJGZkLXVpLWhlYWRlci1iYWNrZ3JvdW5kLWNvbG9yOiBmZC1jb2xvcihwcmltYXJ5KSAhZGVmYXVsdDtcbiAgICAkZmQtdWktZm9vdGVyLWhlaWdodDogNDBweCAhZGVmYXVsdDtcbiAgICAkZmQtdWktZm9vdGVyLWJhY2tncm91bmQtY29sb3I6IGZkLWNvbG9yKHByaW1hcnksIDIpICFkZWZhdWx0O1xuXG4gICAgJF91aS1pcy1maXhlZDogJGZkLXVpLWZpeGVkIG9yICgkZmQtdWktaGVhZGVyLWZpeGVkIGFuZCAkZmQtdWktZm9vdGVyLWZpeGVkKTtcbiAgICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gICAgbWluLWhlaWdodDogMTAwdmg7XG4gICAgd2lkdGg6IDEwMHZ3O1xuICAgIG1heC13aWR0aDogMTAwdnc7XG4gICAgJi0tZml4ZWQge1xuICAgICAgICBkaXNwbGF5OiBmbGV4O1xuICAgICAgICBmbGV4LWRpcmVjdGlvbjogY29sdW1uO1xuICAgICAgICBtYXgtaGVpZ2h0OiAxMDB2aDtcbiAgICAgICAgLiN7JGJsb2NrfV9faGVhZGVyIHtcbiAgICAgICAgICAgIGZsZXg6IDAgMCAkZmQtdWktaGVhZGVyLWhlaWdodDtcbiAgICAgICAgICAgIHBvc2l0aW9uOiBzdGF0aWM7XG4gICAgICAgIH1cbiAgICAgICAgJiAuI3skYmxvY2t9X19mb290ZXIge1xuICAgICAgICAgICAgZmxleDogMCAwICRmZC11aS1mb290ZXItaGVpZ2h0O1xuICAgICAgICAgICAgcG9zaXRpb246IHN0YXRpYztcbiAgICAgICAgfVxuICAgICAgICAmIC4jeyRibG9ja31fX2FwcCB7XG4gICAgICAgICAgICBvdmVyZmxvdzogc2Nyb2xsO1xuICAgICAgICAgICAgbWFyZ2luLXRvcDogMDtcbiAgICAgICAgICAgIGZsZXg6IDE7XG4gICAgICAgICAgICBtaW4taGVpZ2h0OiBhdXRvO1xuICAgICAgICB9XG4gICAgfVxuICAgIEBpZiAkX3VpLWlzLWZpeGVkIHtcbiAgICAgICAgZGlzcGxheTogZmxleDtcbiAgICAgICAgZmxleC1kaXJlY3Rpb246IGNvbHVtbjtcbiAgICAgICAgbWF4LWhlaWdodDogMTAwdmg7XG4gICAgfVxuICAgICZfX2hlYWRlciB7XG4gICAgICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICAgICAgei1pbmRleDogMTtcbiAgICAgICAgYmFja2dyb3VuZDogJGZkLXVpLWhlYWRlci1iYWNrZ3JvdW5kLWNvbG9yO1xuICAgICAgICB3aWR0aDogMTAwJTtcbiAgICAgICAgbWluLWhlaWdodDogJGZkLXVpLWhlYWRlci1oZWlnaHQ7XG4gICAgICAgIGhlaWdodDogJGZkLXVpLWhlYWRlci1oZWlnaHQ7XG4gICAgICAgICYtLWZpeGVkIHtcbiAgICAgICAgICAgIHBvc2l0aW9uOiBmaXhlZDtcbiAgICAgICAgfVxuICAgICAgICBAaWYgJF91aS1pcy1maXhlZCB7XG4gICAgICAgICAgICBwb3NpdGlvbjogc3RhdGljO1xuICAgICAgICAgICAgZmxleDogMCAwICRmZC11aS1oZWFkZXItaGVpZ2h0O1xuICAgICAgICB9IEBlbHNlIHtcbiAgICAgICAgICAgIEBpZiAkZmQtdWktaGVhZGVyLWZpeGVkIHtcbiAgICAgICAgICAgICAgICBwb3NpdGlvbjogZml4ZWQ7XG4gICAgICAgICAgICB9XG4gICAgICAgIH1cbiAgICB9XG4gICAgJl9fZm9vdGVyIHtcbiAgICAgICAgYmFja2dyb3VuZDogJGZkLXVpLWZvb3Rlci1iYWNrZ3JvdW5kLWNvbG9yO1xuICAgICAgICB3aWR0aDogMTAwJTtcbiAgICAgICAgbWluLWhlaWdodDogJGZkLXVpLWZvb3Rlci1oZWlnaHQ7XG4gICAgICAgIGhlaWdodDogJGZkLXVpLWZvb3Rlci1oZWlnaHQ7XG4gICAgICAgICYtLWZpeGVkIHtcbiAgICAgICAgICAgIHBvc2l0aW9uOiBmaXhlZDtcbiAgICAgICAgICAgIGJvdHRvbTogMDtcbiAgICAgICAgfVxuICAgICAgICBAaWYgJF91aS1pcy1maXhlZCB7XG4gICAgICAgICAgICBwb3NpdGlvbjogc3RhdGljO1xuICAgICAgICAgICAgZmxleDogMCAwICRmZC11aS1mb290ZXItaGVpZ2h0O1xuICAgICAgICB9IEBlbHNlIHtcbiAgICAgICAgICAgIEBpZiAkZmQtdWktZm9vdGVyLWZpeGVkIHtcbiAgICAgICAgICAgICAgICBwb3NpdGlvbjogZml4ZWQ7XG4gICAgICAgICAgICAgICAgYm90dG9tOiAwO1xuICAgICAgICAgICAgfVxuICAgICAgICB9XG4gICAgfVxuICAgICZfX2FwcCB7XG4gICAgICAgIG1hcmdpbi10b3A6ICRmZC11aS1oZWFkZXItaGVpZ2h0O1xuICAgICAgICBtaW4taGVpZ2h0OiBjYWxjKDEwMHZoIC0gI3skZmQtdWktZm9vdGVyLWhlaWdodH0gLSAjeyRmZC11aS1oZWFkZXItaGVpZ2h0fSk7XG4gICAgICAgIHdpZHRoOiAxMDAlO1xuICAgICAgICBkaXNwbGF5OiBmbGV4O1xuICAgICAgICBwb3NpdGlvbjogcmVsYXRpdmU7XG4gICAgICAgIEBpZiAkX3VpLWlzLWZpeGVkIHtcbiAgICAgICAgICAgIG92ZXJmbG93OiBzY3JvbGw7XG4gICAgICAgICAgICBmbGV4OiAxO1xuICAgICAgICAgICAgbWFyZ2luLXRvcDogMDtcbiAgICAgICAgfSBAZWxzZSB7XG4gICAgICAgICAgICBAaWYgJGZkLXVpLWhlYWRlci1maXhlZCB7XG4gICAgICAgICAgICAgICAgbWluLWhlaWdodDogY2FsYygxMDB2aCAtICN7JGZkLXVpLWZvb3Rlci1oZWlnaHR9KTtcbiAgICAgICAgICAgIH1cbiAgICAgICAgICAgIEBpZiAkZmQtdWktZm9vdGVyLWZpeGVkIHtcbiAgICAgICAgICAgICAgICBwYWRkaW5nLWJvdHRvbTogJGZkLXVpLWZvb3Rlci1oZWlnaHQ7XG4gICAgICAgICAgICB9XG4gICAgICAgIH1cbiAgICB9XG4gICAgJl9fbWFpbiB7XG4gICAgICAgIEBpZiAkX3VpLWlzLWZpeGVkIHtcbiAgICAgICAgICAgIG92ZXJmbG93OiBzY3JvbGw7XG4gICAgICAgIH1cbiAgICB9XG4gICAgJl9fb3ZlcmxheSB7XG4gICAgICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICB9XG59XG4iLCJAaW1wb3J0IFwiLi4vY29yZS9zZXR0aW5nc1wiO1xuQGltcG9ydCBcIi4uL2NvcmUvbWl4aW5zXCI7XG5AaW1wb3J0IFwiLi4vY29yZS9mdW5jdGlvbnNcIjtcblxuJGJsb2NrOiBucyhhcHApO1xuXG4vKiFcbi5mZC1hcHBcbiAgICAuZmQtYXBwX19zaWRlYmFyXG4gICAgLmZkLWFwcF9fbWFpblxuKi9cblxuLiN7JGJsb2NrfSB7XG4gICAgJGZkLWFwcC1zaWRlYmFyLXdpZHRoOiAyNTBweCAhZGVmYXVsdDtcbiAgICAkZmQtYXBwLXNpZGViYXItaGVpZ2h0LS1taW5pbWl6ZWQ6IDQwcHggIWRlZmF1bHQ7XG4gICAgJGZkLWFwcC1zaWRlYmFyLXdpZHRoLS1taW5pbWl6ZWQ6IDgwcHggIWRlZmF1bHQ7XG4gICAgJGZkLWFwcC1zaWRlYmFyLWJhY2tncm91bmQtY29sb3I6IGZkLWNvbG9yKHByaW1hcnksIDIpICFkZWZhdWx0O1xuICAgIHdpZHRoOiAxMDAlO1xuICAgIEBpbmNsdWRlIGZkLXNjcmVlbihzKSB7XG4gICAgICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgfVxuICAgICZfX3NpZGViYXIge1xuICAgICAgICBiYWNrZ3JvdW5kLWNvbG9yOiAkZmQtYXBwLXNpZGViYXItYmFja2dyb3VuZC1jb2xvcjtcbiAgICAgICAgd2lkdGg6IDEwMHZ3O1xuICAgICAgICBtYXgtaGVpZ2h0OiAkZmQtYXBwLXNpZGViYXItaGVpZ2h0LS1taW5pbWl6ZWQ7XG4gICAgICAgICY6aG92ZXIge1xuICAgICAgICAgICAgcG9zaXRpb246IGFic29sdXRlO1xuICAgICAgICAgICAgbWluLWhlaWdodDogMTAwJTtcbiAgICAgICAgfVxuICAgICAgICBAaW5jbHVkZSBmZC1zY3JlZW4ocykge1xuICAgICAgICAgICAgd2lkdGg6ICRmZC1hcHAtc2lkZWJhci13aWR0aC0tbWluaW1pemVkO1xuICAgICAgICAgICAgbWF4LWhlaWdodDogMTAwJTtcbiAgICAgICAgICAgICY6aG92ZXIge1xuICAgICAgICAgICAgICAgIHdpZHRoOiAkZmQtYXBwLXNpZGViYXItd2lkdGg7XG4gICAgICAgICAgICAgICAgcG9zaXRpb246IHJlbGF0aXZlO1xuICAgICAgICAgICAgICAgIG1hcmdpbi1yaWdodDogLTIwMHB4O1xuICAgICAgICAgICAgfVxuICAgICAgICB9XG4gICAgICAgIEBpbmNsdWRlIGZkLXNjcmVlbihsKSB7XG4gICAgICAgICAgICB3aWR0aDogJGZkLWFwcC1zaWRlYmFyLXdpZHRoO1xuICAgICAgICAgICAgJjpob3ZlciB7XG4gICAgICAgICAgICAgICAgd2lkdGg6ICRmZC1hcHAtc2lkZWJhci13aWR0aDtcbiAgICAgICAgICAgICAgICBtYXJnaW4tcmlnaHQ6IDA7XG4gICAgICAgICAgICB9XG4gICAgICAgIH1cbiAgICAgICAgb3ZlcmZsb3c6IHNjcm9sbDtcbiAgICB9XG4gICAgJl9fbWFpbiB7XG4gICAgICAgIGZsZXg6IDE7XG4gICAgICAgIG92ZXJmbG93OiBzY3JvbGw7XG4gICAgfVxufVxuIiwiQGltcG9ydCBcIi4uL2NvcmUvc2V0dGluZ3NcIjtcbkBpbXBvcnQgXCIuLi9jb3JlL2Z1bmN0aW9uc1wiO1xuQGltcG9ydCBcIi4uL2NvcmUvbWl4aW5zXCI7XG5cbiRibG9jazogbnMocGFnZSk7XG4uI3skYmxvY2t9IHtcbiAgICAkZmQtcGFnZS1iYWNrZ3JvdW5kLWNvbG9yOiBmZC1jb2xvcihiYWNrZ3JvdW5kLCAyKSAhZGVmYXVsdDtcbiAgICAkZmQtcGFnZS1oZWFkZXItaGVpZ2h0OiA3NnB4ICFkZWZhdWx0O1xuICAgICRmZC1wYWdlLWludHJvLWJhY2tncm91bmQtY29sb3I6IGZkLWNvbG9yKGJhY2tncm91bmQsIDIpICFkZWZhdWx0O1xuICAgICRmZC1wYWdlLWludHJvLXBhZGRpbmc6IGZkLXNwYWNlKDQpICFkZWZhdWx0O1xuICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgZmxleC1kaXJlY3Rpb246IGNvbHVtbjtcbiAgICBtaW4taGVpZ2h0OiAxMDAlO1xuICAgIHdpZHRoOiAxMDAlO1xuICAgICZfX2hlYWRlciB7XG4gICAgICAgIGJvcmRlci1ib3R0b206IHNvbGlkIDFweCBmZC1jb2xvcihuZXV0cmFsLCAzKTtcbiAgICAgICAgYmFja2dyb3VuZC1jb2xvcjogJGZkLXBhZ2UtYmFja2dyb3VuZC1jb2xvcjtcbiAgICAgICAgaGVpZ2h0OiAkZmQtcGFnZS1oZWFkZXItaGVpZ2h0O1xuICAgIH1cbiAgICAmX19pbnRybyB7XG4gICAgICAgIEBpbmNsdWRlIGZkLXR5cGUoLTEpO1xuICAgICAgICBwYWRkaW5nOiAkZmQtcGFnZS1pbnRyby1wYWRkaW5nICRmZC1wYWRkaW5nLS11aTtcbiAgICAgICAgYmFja2dyb3VuZC1jb2xvcjogJGZkLXBhZ2UtaW50cm8tYmFja2dyb3VuZC1jb2xvcjtcbiAgICAgICAgdGV4dC1hbGlnbjogY2VudGVyO1xuICAgICAgICBib3JkZXItYm90dG9tOiBzb2xpZCAxcHggZmQtY29sb3IobmV1dHJhbCwgMyk7XG4gICAgICAgIG1hcmdpbi1ib3R0b206IC0xcHg7XG4gICAgfVxuICAgICZfX2NvbnRlbnQge1xuICAgICAgICBmbGV4LWdyb3c6IDE7XG4gICAgfVxufVxuIiwiQGltcG9ydCBcIi4uL2NvcmUvc2V0dGluZ3NcIjtcbkBpbXBvcnQgXCIuLi9jb3JlL2Z1bmN0aW9uc1wiO1xuQGltcG9ydCBcIi4uL2NvcmUvbWl4aW5zXCI7XG5cbi8qIVxuLmZkLXBhbmVsXG4gICAgLmZkLXBhbmVsX19oZWFkZXJcbiAgICAgICAgLmZkLXBhbmVsX190aXRsZVxuICAgICAgICAuZmQtcGFuZWxfX2FjdGlvbnNcbiAgICAuZmQtcGFuZWxfX2Zvb3RlclxuKi9cblxuJGJsb2NrOiBucyhwYW5lbCk7XG4uI3skYmxvY2t9IHtcbiAgICBAaW5jbHVkZSBmZC1jbGVhcmZpeDtcbiAgICAmX19oZWFkZXIge1xuICAgICAgICBtaW4taGVpZ2h0OiBmZC1zcGFjZSgxMCk7XG4gICAgICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgICAgIGFsaWduLWl0ZW1zOiBjZW50ZXI7XG4gICAgICAgIG1hcmdpbi1ib3R0b206IGZkLXNwYWNlKDQpO1xuICAgIH1cbiAgICAmX190aXRsZSB7XG4gICAgICAgIEBpbmNsdWRlIGZkLXR5cGUoMyk7XG4gICAgICAgIGZsZXg6IDE7XG4gICAgICAgIG1hcmdpbi1ib3R0b206IDA7XG4gICAgfVxuICAgICZfX2FjdGlvbnMge1xuICAgICAgICBtYXJnaW4tbGVmdDogYXV0bztcbiAgICB9XG4gICAgJl9fZm9vdGVyIHtcbiAgICAgICAgZGlzcGxheTogZmxleDtcbiAgICAgICAganVzdGlmeS1jb250ZW50OiBjZW50ZXI7XG4gICAgfVxufVxuIiwiQGltcG9ydCBcIi4uL2NvcmUvc2V0dGluZ3NcIjtcbkBpbXBvcnQgXCIuLi9jb3JlL21peGluc1wiO1xuQGltcG9ydCBcIi4uL2NvcmUvZnVuY3Rpb25zXCI7XG5cbiRibG9jazogbnMob3ZlcmxheSk7XG5cbi8qIVxuLmZkLW92ZXJsYXlcblxuKi9cblxuXG4uI3skYmxvY2t9IHtcbiAgICAkZmQtb3ZlcmxheS1iYWNrZ3JvdW5kLWNvbG9yOiByZ2JhKGJsYWNrLDAuOCkgIWRlZmF1bHQ7XG5cbiAgICAgICAgcG9zaXRpb246IGZpeGVkO1xuICAgICAgICBkaXNwbGF5OiBmbGV4O1xuICAgICAgICBhbGlnbi1pdGVtczogY2VudGVyO1xuICAgICAgICBqdXN0aWZ5LWNvbnRlbnQ6IGNlbnRlcjtcbiAgICAgICAgaGVpZ2h0OiAxMDB2aDtcbiAgICAgICAgd2lkdGg6IDEwMHZ3O1xuICAgICAgICB0b3A6IDA7XG4gICAgICAgIGJhY2tncm91bmQ6ICRmZC1vdmVybGF5LWJhY2tncm91bmQtY29sb3I7XG4gICAgICAgIHotaW5kZXg6IDEwMDA7XG4gICAgICAgIGNvbG9yOiBmZC1jb2xvcih0ZXh0LWludmVyc2UpO1xuICAgICAgICAmW2FyaWEtaGlkZGVuPVwidHJ1ZVwiXSB7XG4gICAgICAgICAgICBkaXNwbGF5OiBub25lO1xuICAgICAgICB9XG5cbn1cbiIsIkBpbXBvcnQgXCIuLi9jb3JlL3NldHRpbmdzXCI7XG5AaW1wb3J0IFwiLi4vY29yZS9taXhpbnNcIjtcbkBpbXBvcnQgXCIuLi9jb3JlL2Z1bmN0aW9uc1wiO1xuQGltcG9ydCBcIi4uL2NvbXBvbmVudHMvbWl4aW5zXCI7XG5cbi8qIVxuLmZkLWFsZXJ0KygtLXdhcm5pbmcuIC0tZXJyb3IpXG4gICAgLmZkLWFsZXJ0X19jbG9zZVxuKi9cbiRibG9jazogbnMoYWxlcnQpO1xuXG4uI3skYmxvY2t9IHtcbiAgICAvL1NFVFRJTkdTXG4gICAgJGZkLWFsZXJ0LWJhY2tncm91bmQtY29sb3I6IGZkLWNvbG9yKHRleHQsIDMpICFkZWZhdWx0O1xuICAgICRmZC1hbGVydC1iYWNrZ3JvdW5kLWNvbG9yLS13YXJuaW5nOiBmZC1jb2xvcihzdGF0dXMsIDIpICFkZWZhdWx0O1xuICAgICRmZC1hbGVydC1iYWNrZ3JvdW5kLWNvbG9yLS1lcnJvcjogZmQtY29sb3Ioc3RhdHVzLCAzKSAhZGVmYXVsdDtcbiAgICAkZmQtYWxlcnQtY29sb3ItLXdhcm5pbmc6IGZkLWNvbG9yKHRleHQsIDEpICFkZWZhdWx0O1xuICAgICRmZC1hbGVydC1jb2xvcjogZmQtY29sb3IodGV4dC1pbnZlcnNlLCAxKSAhZGVmYXVsdDtcbiAgICAkZmQtYWxlcnQtYm9yZGVyLWNvbG9yOiBmZC1jb2xvcihuZXV0cmFsLCAyKSAhZGVmYXVsdDtcbiAgICAkZmQtYWxlcnQtaGVpZ2h0OiBmZC1zcGFjZSgxMykgIWRlZmF1bHQ7XG4gICAgJGZkLWFsZXJ0LWFjdGlvbi0tY2xlcmFuY2U6IDUwcHg7XG5cbiAgICAvLyBCbG9ja1xuICAgIGNvbG9yOiAkZmQtYWxlcnQtY29sb3I7XG4gICAgYm9yZGVyOiBzb2xpZCAxcHggJGZkLWFsZXJ0LWJvcmRlci1jb2xvcjtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiAkZmQtYWxlcnQtYmFja2dyb3VuZC1jb2xvcjtcbiAgICBtaW4taGVpZ2h0OiAkZmQtYWxlcnQtaGVpZ2h0O1xuICAgIHBhZGRpbmc6IGZkLXNwYWNlKHMpO1xuXG4gICAgLy8gRWxlbWVudHNcbiAgICAmX19jbG9zZSB7XG4gICAgICAgIEBpbmNsdWRlIGZkLWJ1dHRvbi1yZXNldDsgIC8vcmVtb3ZlcyBkZWZhdWx0IGJ1dHRvbiBjaHJvbWVcbiAgICAgICAgY29sb3I6IGZkLWNvbG9yKHRleHQtaW52ZXJzZSwgMSk7XG4gICAgICAgIHdpZHRoOiBmZC1zcGFjZShtKTsgLy9iZXN0IHByYWN0aWNlIGhpdCBzcGFjZVxuICAgICAgICBoZWlnaHQ6IGZkLXNwYWNlKG0pO1xuICAgICAgICBmbG9hdDogcmlnaHQ7XG4gICAgICAgIG1hcmdpbjogLSAoZmQtc3BhY2UocykvMik7XG4gICAgfVxuXG4gICAgLy8gTW9kaWZpZXJzXG4gICAgJi0td2FybmluZyB7XG4gICAgICBiYWNrZ3JvdW5kLWNvbG9yOiAkZmQtYWxlcnQtYmFja2dyb3VuZC1jb2xvci0td2FybmluZztcbiAgICAgIGNvbG9yOiAkZmQtYWxlcnQtY29sb3ItLXdhcm5pbmc7XG5cbiAgICB9XG4gICAgJi0tZXJyb3Ige1xuICAgICAgYmFja2dyb3VuZC1jb2xvcjogJGZkLWFsZXJ0LWJhY2tncm91bmQtY29sb3ItLWVycm9yO1xuICAgIH1cblxuXG59XG4iLCIkbnM6IG5zKCk7XG5AbWl4aW4gZmQtYnV0dG9uLXJlc2V0IHtcbiAgICBtYXJnaW46IDA7XG4gICAgcGFkZGluZzogMDtcbiAgICBmb250LXNtb290aGluZzogYW50aWFsaWFzZWQ7XG4gICAgYXBwZWFyYW5jZTogbm9uZTtcbiAgICBvdXRsaW5lOiAwO1xuICAgIGJvcmRlcjogMDtcbiAgICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gICAgdGV4dC1kZWNvcmF0aW9uOiBub25lO1xuICAgIGN1cnNvcjogcG9pbnRlcjtcbiAgICB1c2VyLXNlbGVjdDogbm9uZTtcbiAgICB2ZXJ0aWNhbC1hbGlnbjogbWlkZGxlO1xuICAgIHdoaXRlLXNwYWNlOiBub3dyYXA7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogdHJhbnNwYXJlbnQ7XG59XG4iLCJAaW1wb3J0IFwiLi4vY29yZS9zZXR0aW5nc1wiO1xuQGltcG9ydCBcIi4uL2NvcmUvbWl4aW5zXCI7XG5AaW1wb3J0IFwiLi4vY29yZS9mdW5jdGlvbnNcIjtcbkBpbXBvcnQgXCJtaXhpbnNcIjtcblxuLyohXG4uZmQtYnV0dG9uKyggKC0tc21hbGwgfCAtLWxhcmdlKSwgLS1pY29uLCAtLXRleHQsIC0tbGluaywgLS1hY3Rpb24tYmFyKSsoICguaXMtZGlzYWJsZWQgfCBbYXJpYS1kaXNhYmxlZD10cnVlXSkgfCAoLmlzLXNlbGVjdGVkIHwgW2FyaWEtc2VsZWN0ZWQ9dHJ1ZV0gfCAoLmlzLXByZXNzZWQgfCBbYXJpYS1wcmVzc2VkPXRydWVdKSlcbiovXG5cbi8vc2V0IGNvbXBvbmVudCBuYW1lIHVzaW5nIG5hbWVzcGFjZSBmdW5jdGlvbiwgdGhlbiB1c2UgI3skYmxvY2t9IGJlbG93XG4kYmxvY2s6IG5zKGJ1dHRvbik7XG4uI3skYmxvY2t9IHtcbiAgICAvL1NFVFRJTkdTXG4gICAgJGZkLWJ1dHRvbi1jb2xvcjogZmQtY29sb3IodGV4dC1pbnZlcnNlLCAyKSAhZGVmYXVsdDtcbiAgICAkZmQtYnV0dG9uLWNvbG9yLS1ob3ZlcjogJGZkLWJ1dHRvbi1jb2xvciAhZGVmYXVsdDtcbiAgICAkZmQtYnV0dG9uLWNvbG9yLS10ZXh0OiAkZmQtY29sb3ItLWxpbmsgIWRlZmF1bHQ7XG4gICAgJGZkLWJ1dHRvbi1jb2xvci0tYWN0aXZlOiAkZmQtYnV0dG9uLWNvbG9yICFkZWZhdWx0O1xuICAgICRmZC1idXR0b24tY29sb3ItLWRpc2FibGVkOiBmZC1jb2xvcih0ZXh0LCAyKSAhZGVmYXVsdDtcbiAgICAkZmQtYnV0dG9uLWJhY2tncm91bmQtY29sb3I6IGZkLWNvbG9yKGFjdGlvbikgIWRlZmF1bHQ7XG4gICAgJGZkLWJ1dHRvbi1iYWNrZ3JvdW5kLWNvbG9yLS1ob3ZlcjogZGFya2VuKCRmZC1idXR0b24tYmFja2dyb3VuZC1jb2xvciwgNSkgIWRlZmF1bHQ7XG4gICAgJGZkLWJ1dHRvbi1iYWNrZ3JvdW5kLWNvbG9yLS1hY3RpdmU6IGRhcmtlbigkZmQtYnV0dG9uLWJhY2tncm91bmQtY29sb3IsMTApICFkZWZhdWx0O1xuICAgICRmZC1idXR0b24tYmFja2dyb3VuZC1jb2xvci0tZGlzYWJsZWQ6IGZkLWNvbG9yKG5ldXRyYWwpICFkZWZhdWx0O1xuICAgICRmZC1idXR0b24tc2hhZG93LS1mb2N1czogMCAwIDRweCAxcHggcmdiYShmZC1jb2xvcihuZXV0cmFsLCA0KSwgMSkgIWRlZmF1bHQ7XG5cbiAgICAvL3NpemVzXG4gICAgJGZkLWJ1dHRvbi1oZWlnaHQ6IGZkLXNwYWNlKDEzKSAhZGVmYXVsdDtcbiAgICAkZmQtYnV0dG9uLWhlaWdodC0tc21hbGw6IGZkLXNwYWNlKDEwKSAhZGVmYXVsdDtcbiAgICAkZmQtYnV0dG9uLWhlaWdodC0tbGFyZ2U6IGZkLXNwYWNlKDE5KSAhZGVmYXVsdDtcbiAgICAkZmQtYnV0dG9uLWhlaWdodC0tbGluazogZmQtc3BhY2UoNykgIWRlZmF1bHQ7XG4gICAgJGZkLWJ1dHRvbi1oZWlnaHQtLWxpbmstc21hbGw6IGZkLXNwYWNlKDYpICFkZWZhdWx0O1xuICAgICRmZC1idXR0b24taWNvbi1oZWlnaHQ6IDI2cHggIWRlZmF1bHQ7XG4gICAgJGZkLWJ1dHRvbi1pY29uLWhlaWdodC0tc21hbGw6IDE4cHggIWRlZmF1bHQ7XG4gICAgJGZkLWJ1dHRvbi1pY29uLWhlaWdodC0tbGFyZ2U6IDMycHggIWRlZmF1bHQ7XG4gICAgLy9hbmltXG4gICAgJGZkLWJ1dHRvbi10cmFuc2l0aW9uLXBhcmFtczogJGZkLWFuaW1hdGlvbi0tc3BlZWQgZWFzZS1pbiAhZGVmYXVsdDtcblxuICAgIC8vQkFTRVxuICAgIC8vc2V0IGFsbCByZXNldCBhbmQgYmFzZWxpbmUgYmxvY2sgc3R5bGVzXG4gICAgQGluY2x1ZGUgZmQtYnV0dG9uLXJlc2V0O1xuICAgIEBpbmNsdWRlIGZkLXR5cGUoMSwgaGVhZGVyLCBtZWQpO1xuICAgIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiAkZmQtYnV0dG9uLWJhY2tncm91bmQtY29sb3I7XG4gICAgdHJhbnNpdGlvbjogYmFja2dyb3VuZC1jb2xvciAkZmQtYnV0dG9uLXRyYW5zaXRpb24tcGFyYW1zO1xuICAgIGNvbG9yOiAkZmQtYnV0dG9uLWNvbG9yO1xuICAgIG1heC1oZWlnaHQ6ICRmZC1idXR0b24taGVpZ2h0O1xuICAgIGhlaWdodDogJGZkLWJ1dHRvbi1oZWlnaHQ7XG4gICAgbGluZS1oZWlnaHQ6ICRmZC1idXR0b24taGVpZ2h0O1xuICAgIHBhZGRpbmctbGVmdDogZmQtc3BhY2UoNSk7XG4gICAgcGFkZGluZy1yaWdodDogZmQtc3BhY2UoNSk7XG4gICAgdGV4dC1hbGlnbjogY2VudGVyO1xuICAgIHRleHQtdHJhbnNmb3JtOiB1cHBlcmNhc2U7XG4gICAgYm9yZGVyLXJhZGl1czogMDtcbiAgICAvL01PRElGSUVSU1xuICAgICYtLXNtYWxsIHtcbiAgICAgICAgQGluY2x1ZGUgZmQtdHlwZSgwKTtcbiAgICAgICAgQGluY2x1ZGUgZmQtd2VpZ2h0KHNlbWkpO1xuICAgICAgICBtYXgtaGVpZ2h0OiAkZmQtYnV0dG9uLWhlaWdodC0tc21hbGw7XG4gICAgICAgIGhlaWdodDogJGZkLWJ1dHRvbi1oZWlnaHQtLXNtYWxsO1xuICAgICAgICBsaW5lLWhlaWdodDogJGZkLWJ1dHRvbi1oZWlnaHQtLXNtYWxsO1xuICAgICAgICBwYWRkaW5nLWxlZnQ6IGZkLXNwYWNlKDQpO1xuICAgICAgICBwYWRkaW5nLXJpZ2h0OiBmZC1zcGFjZSg0KTtcbiAgICB9XG4gICAgJi0tbGFyZ2Uge1xuICAgICAgICBAaW5jbHVkZSBmZC10eXBlKDIpO1xuICAgICAgICBtYXgtaGVpZ2h0OiAkZmQtYnV0dG9uLWhlaWdodC0tbGFyZ2U7XG4gICAgICAgIGhlaWdodDogJGZkLWJ1dHRvbi1oZWlnaHQtLWxhcmdlO1xuICAgICAgICBsaW5lLWhlaWdodDogJGZkLWJ1dHRvbi1oZWlnaHQtLWxhcmdlO1xuICAgICAgICBwYWRkaW5nLWxlZnQ6IGZkLXNwYWNlKDcpO1xuICAgICAgICBwYWRkaW5nLXJpZ2h0OiBmZC1zcGFjZSg3KTtcbiAgICAgICAgJi4jeyRibG9ja30tLWljb24ge1xuICAgICAgICAgICAgLy9wYWRkaW5nLWxlZnQ6IGZkLXNwYWNlKDUpO1xuICAgICAgICAgICAgLy9wYWRkaW5nLXJpZ2h0OiBmZC1zcGFjZSg1KTtcbiAgICAgICAgfVxuICAgIH1cbiAgICAmOmhvdmVyIHtcbiAgICAgICAgYmFja2dyb3VuZC1jb2xvcjogJGZkLWJ1dHRvbi1iYWNrZ3JvdW5kLWNvbG9yLS1ob3ZlcjtcbiAgICAgICAgY29sb3I6ICRmZC1idXR0b24tY29sb3ItLWhvdmVyO1xuICAgICAgICB0ZXh0LWRlY29yYXRpb246IG5vbmU7XG4gICAgfVxuICAgICY6Zm9jdXMge1xuICAgICAgICBjb2xvcjogJGZkLWJ1dHRvbi1jb2xvci0taG92ZXI7XG4gICAgICAgIGJveC1zaGFkb3c6ICRmZC1idXR0b24tc2hhZG93LS1mb2N1cztcbiAgICAgICAgb3V0bGluZTogc29saWQgMnB4IGxpZ2h0ZW4oJGZkLWJ1dHRvbi1iYWNrZ3JvdW5kLWNvbG9yLCAxNSk7XG4gICAgfVxuICAgICY6YWN0aXZlLFxuICAgICYuaXMtYWN0aXZlLFxuICAgICZbYXJpYS1zZWxlY3RlZD1cInRydWVcIl0sXG4gICAgJi5pcy1zZWxlY3RlZCxcbiAgICAmW2FyaWEtcHJlc3NlZD1cInRydWVcIl0sXG4gICAgJi5pcy1wcmVzc2VkIHtcbiAgICAgICAgYmFja2dyb3VuZC1jb2xvcjogJGZkLWJ1dHRvbi1iYWNrZ3JvdW5kLWNvbG9yLS1hY3RpdmU7XG4gICAgICAgIGNvbG9yOiAkZmQtYnV0dG9uLWNvbG9yLS1hY3RpdmU7XG4gICAgfVxuICAgICZbYXJpYS1kaXNhYmxlZD1cInRydWVcIl0sXG4gICAgJi5pcy1kaXNhYmxlZCxcbiAgICAmOmRpc2FibGVkIHtcbiAgICAgICAgb3V0bGluZTogc29saWQgMXB4IGZkLWNvbG9yKG5ldXRyYWwsIDIpO1xuICAgICAgICBjb2xvcjogJGZkLWJ1dHRvbi1jb2xvci0tZGlzYWJsZWQ7XG4gICAgICAgIGJhY2tncm91bmQtY29sb3I6ICRmZC1idXR0b24tYmFja2dyb3VuZC1jb2xvci0tZGlzYWJsZWQ7XG4gICAgICAgIGN1cnNvcjogbm90LWFsbG93ZWQ7XG4gICAgfVxuICAgICYtLXRleHQsXG4gICAgJi0tbGluayB7XG4gICAgICAgIGNvbG9yOiAkZmQtYnV0dG9uLWNvbG9yLS10ZXh0O1xuICAgICAgICBiYWNrZ3JvdW5kLWNvbG9yOiB0cmFuc3BhcmVudDtcbiAgICAgICAgJjpob3ZlcixcbiAgICAgICAgJjpmb2N1cyB7XG4gICAgICAgICAgICBiYWNrZ3JvdW5kLWNvbG9yOiB0cmFuc3BhcmVudDtcbiAgICAgICAgICAgIGNvbG9yOiBkYXJrZW4oJGZkLWJ1dHRvbi1jb2xvci0tdGV4dCwgNSk7XG4gICAgICAgIH1cbiAgICAgICAgJjphY3RpdmUsXG4gICAgICAgICZbYXJpYS1zZWxlY3RlZD1cInRydWVcIl0sXG4gICAgICAgICYuaXMtc2VsZWN0ZWQsXG4gICAgICAgICZbYXJpYS1wcmVzc2VkPVwidHJ1ZVwiXSxcbiAgICAgICAgJi5pcy1wcmVzc2VkLFxuICAgICAgICAmW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLFxuICAgICAgICAmLmlzLWRpc2FibGVkLFxuICAgICAgICAmOmRpc2FibGVkIHtcbiAgICAgICAgICAgIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50O1xuICAgICAgICAgICAgb3V0bGluZTogbm9uZTtcbiAgICAgICAgICAgIGJveC1zaGFkb3c6IG5vbmU7XG4gICAgICAgIH1cbiAgICAgICAgJjphY3RpdmUsXG4gICAgICAgICZbYXJpYS1zZWxlY3RlZD1cInRydWVcIl0sXG4gICAgICAgICYuaXMtc2VsZWN0ZWQsXG4gICAgICAgICZbYXJpYS1wcmVzc2VkPVwidHJ1ZVwiXSxcbiAgICAgICAgJi5pcy1wcmVzc2VkIHtcbiAgICAgICAgICAgIGNvbG9yOiBkYXJrZW4oJGZkLWJ1dHRvbi1jb2xvci0tdGV4dCwgMTApO1xuICAgICAgICB9XG4gICAgICAgICZbYXJpYS1kaXNhYmxlZD1cInRydWVcIl0sXG4gICAgICAgICYuaXMtZGlzYWJsZWQsXG4gICAgICAgICY6ZGlzYWJsZWQge1xuICAgICAgICAgICAgY29sb3I6ICRmZC1idXR0b24tY29sb3ItLWRpc2FibGVkO1xuICAgICAgICB9XG4gICAgfVxuICAgICYtLWxpbmsge1xuICAgICAgICBoZWlnaHQ6ICRmZC1idXR0b24taGVpZ2h0LS1saW5rO1xuICAgICAgICBsaW5lLWhlaWdodDogJGZkLWJ1dHRvbi1oZWlnaHQtLWxpbms7XG4gICAgICAgIHBhZGRpbmctbGVmdDogZmQtc3BhY2UoNCk7XG4gICAgICAgIHBhZGRpbmctcmlnaHQ6IGZkLXNwYWNlKDQpO1xuICAgICAgICBwb3NpdGlvbjogcmVsYXRpdmU7XG4gICAgICAgIC8vYWRqdXN0bWVudCBmb3Igc21hbGwgYnV0dG9uXG4gICAgICAgICYuI3skYmxvY2t9LS1zbWFsbCB7XG4gICAgICAgICAgICBoZWlnaHQ6ICRmZC1idXR0b24taGVpZ2h0LS1saW5rLXNtYWxsO1xuICAgICAgICAgICAgbGluZS1oZWlnaHQ6ICRmZC1idXR0b24taGVpZ2h0LS1saW5rLXNtYWxsO1xuICAgICAgICB9XG4gICAgICAgICY6OmFmdGVyIHtcbiAgICAgICAgICAgIGNvbnRlbnQ6IFwiXCI7XG4gICAgICAgICAgICBib3JkZXItYm90dG9tOiBzb2xpZCAycHggdHJhbnNwYXJlbnQ7XG4gICAgICAgICAgICB3aWR0aDogY2FsYygxMDAlIC0gI3tmZC1zcGFjZSg0KX0qMik7XG4gICAgICAgICAgICBoZWlnaHQ6IDJweDtcbiAgICAgICAgICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICAgICAgICAgIGJvdHRvbTogMXB4O1xuICAgICAgICAgICAgbGVmdDogMDtcbiAgICAgICAgICAgIG1hcmdpbi1sZWZ0OiBmZC1zcGFjZSg0KTtcbiAgICAgICAgICAgIHRyYW5zaXRpb246IGJvcmRlci1ib3R0b20tY29sb3IgJGZkLWJ1dHRvbi10cmFuc2l0aW9uLXBhcmFtcztcbiAgICAgICAgfVxuICAgICAgICAmOmZvY3VzIHtcbiAgICAgICAgICAgIG91dGxpbmU6IG5vbmU7XG4gICAgICAgICAgICBib3gtc2hhZG93OiBub25lO1xuICAgICAgICB9XG4gICAgICAgICY6aG92ZXIsXG4gICAgICAgICY6Zm9jdXMsXG4gICAgICAgICY6YWN0aXZlLFxuICAgICAgICAmW2FyaWEtc2VsZWN0ZWQ9XCJ0cnVlXCJdLFxuICAgICAgICAmLmlzLXNlbGVjdGVkLFxuICAgICAgICAmW2FyaWEtcHJlc3NlZD1cInRydWVcIl0sXG4gICAgICAgICYuaXMtcHJlc3NlZCB7XG4gICAgICAgICAgICAmOjphZnRlciB7XG4gICAgICAgICAgICAgICAgYm9yZGVyLWJvdHRvbS1jb2xvcjogJGZkLWJ1dHRvbi1jb2xvci0tdGV4dDtcbiAgICAgICAgICAgIH1cbiAgICAgICAgfVxuICAgICAgICAmW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLFxuICAgICAgICAmLmlzLWRpc2FibGVkLFxuICAgICAgICAmOmRpc2FibGVkIHtcbiAgICAgICAgICAgICY6OmFmdGVyIHtcbiAgICAgICAgICAgICAgICBkaXNwbGF5OiBub25lO1xuICAgICAgICAgICAgfVxuICAgICAgICB9XG4gICAgfVxuICAgIC8vRUxFTUVOVFNcbiAgICAmID4gKiB7XG4gICAgICAgIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgICAgICAgdmVydGljYWwtYWxpZ246IHRvcDtcbiAgICAgICAgbWFyZ2luLXJpZ2h0OiBmZC1zcGFjZSgzKTtcbiAgICAgICAgQGF0LXJvb3Qge1xuICAgICAgICAgICAgLiN7JGJsb2NrfS0taWNvbiA+ICoge1xuICAgICAgICAgICAgICAgIG1hcmdpbi1sZWZ0OiBhdXRvO1xuICAgICAgICAgICAgICAgIG1hcmdpbi1yaWdodDogYXV0bztcbiAgICAgICAgICAgIH1cbiAgICAgICAgfVxuICAgICAgICBtYXJnaW4tdG9wOiAkZmQtYnV0dG9uLWhlaWdodCAvIDIgLSAkZmQtYnV0dG9uLWljb24taGVpZ2h0IC8gMjtcbiAgICAgICAgQGF0LXJvb3Qge1xuICAgICAgICAgICAgLiN7JGJsb2NrfS0tc21hbGwgPiAqIHtcbiAgICAgICAgICAgICAgICBtYXJnaW4tdG9wOiAkZmQtYnV0dG9uLWhlaWdodC0tc21hbGwgLyAyIC0gJGZkLWJ1dHRvbi1pY29uLWhlaWdodC0tc21hbGwgLyAyO1xuICAgICAgICAgICAgfVxuICAgICAgICB9XG4gICAgICAgIEBhdC1yb290IHtcbiAgICAgICAgICAgIC4jeyRibG9ja30tLWxhcmdlID4gKiB7XG4gICAgICAgICAgICAgICAgbWFyZ2luLXRvcDogJGZkLWJ1dHRvbi1oZWlnaHQtLWxhcmdlIC8gMiAtICRmZC1idXR0b24taWNvbi1oZWlnaHQtLWxhcmdlIC8gMjtcbiAgICAgICAgICAgIH1cbiAgICAgICAgfVxuICAgIH1cbiAgICAvL3NwZWNpYWwgZmxhdm9yXG4gICAgJi0tYWN0aW9uLWJhciB7XG4gICAgICAgIEBleHRlbmQgLiN7JGJsb2NrfS0tbGFyZ2U7XG4gICAgICAgIEBpbmNsdWRlIGZkLXR5cGUoLTMpO1xuICAgICAgICBtaW4td2lkdGg6IDEzNXB4O1xuICAgICAgICBsaW5lLWhlaWdodDogJGZkLWJ1dHRvbi1oZWlnaHQtLWxhcmdlIC0gJGZkLWJ1dHRvbi1pY29uLWhlaWdodC0tbGFyZ2UgLSBmZC1zcGFjZSgzKTtcbiAgICAgICAgdmVydGljYWwtYWxpZ246IG1pZGRsZTtcbiAgICAgICAgJiA+ICoge1xuICAgICAgICAgICAgZGlzcGxheTogYmxvY2sgIWltcG9ydGFudDtcbiAgICAgICAgICAgIG1hcmdpbi10b3A6IGZkLXNwYWNlKDMpO1xuICAgICAgICAgICAgbWFyZ2luLWxlZnQ6IGF1dG87XG4gICAgICAgICAgICBtYXJnaW4tcmlnaHQ6IGF1dG87XG4gICAgICAgIH1cbiAgICB9XG59XG4iLCJAaW1wb3J0IFwiLi4vY29yZS9zZXR0aW5nc1wiO1xuQGltcG9ydCBcIi4uL2NvcmUvbWl4aW5zXCI7XG5AaW1wb3J0IFwiLi4vY29yZS9mdW5jdGlvbnNcIjtcbkBpbXBvcnQgXCJtaXhpbnNcIjtcblxuLyohXG4uZmQtZHJvcGRvd24rKClcbiAgICAuZmQtZHJvcGRvd25fX2NvbnRyb2wrKFtkaXNhYmxlZF0pXG4gICAgLmZkLWRyb3Bkb3duX19tZW51KygpXG4qL1xuJGJsb2NrOiBucyhkcm9wZG93bik7XG5cbi4jeyRibG9ja30ge1xuICAgIC8vTE9DQUwgVkFSUyAoc2V0IGFsbCB0aGVtZWFibGUgcHJvcGVydGllcywgYWx3YXlzIGluY2x1ZGUgIWRlZmF1bHQpXG4gICAgJGZkLWRyb3Bkb3duLW1lbnUtY29sb3I6IHNvbGlkIDFweCAkZmQtZm9ybXMtY29sb3IgIWRlZmF1bHQ7XG4gICAgJGZkLWRyb3Bkb3duLW1lbnUtYm9yZGVyOiBzb2xpZCAxcHggJGZkLWZvcm1zLWJvcmRlci1jb2xvciAhZGVmYXVsdDtcbiAgICAkZmQtZHJvcGRvd24tbWVudS16LWluZGV4OiAyICFkZWZhdWx0O1xuICAgICRmZC1kcm9wZG93bi1tZW51LWJhY2tncm91bmQtY29sb3I6IGZkLWNvbG9yKGJhY2tncm91bmQpICFkZWZhdWx0O1xuICAgICRmZC1kcm9wZG93bi1tZW51LXNoYWRvdzogMCAwIDRweCAxcHggcmdiYShmZC1jb2xvcihuZXV0cmFsLCA0KSwgMC4yKSAhZGVmYXVsdDtcbiAgICAvL2l0ZW1zXG4gICAgJGZkLWRyb3Bkb3duLW1lbnUtaXRlbS1jb2xvcjogJGZkLWRyb3Bkb3duLW1lbnUtY29sb3IgIWRlZmF1bHQ7XG4gICAgJGZkLWRyb3Bkb3duLW1lbnUtaXRlbS1jb2xvci0taG92ZXI6IGZkLWNvbG9yKHRleHQtaW52ZXJzZSkgIWRlZmF1bHQ7XG4gICAgJGZkLWRyb3Bkb3duLW1lbnUtaXRlbS1iYWNrZ3JvdW5kLWNvbG9yOiAkZmQtZHJvcGRvd24tbWVudS1iYWNrZ3JvdW5kLWNvbG9yICFkZWZhdWx0O1xuICAgICRmZC1kcm9wZG93bi1tZW51LWl0ZW0tYmFja2dyb3VuZC1jb2xvci0taG92ZXI6IGRhcmtlbihmZC1jb2xvcihhY3Rpb24pLCA1JSkgIWRlZmF1bHQ7XG4gICAgJGZkLWRyb3Bkb3duLW1lbnUtaXRlbS1wYWRkaW5nOiBmZC1zcGFjZSgzKSBmZC1zcGFjZSg0KSAhZGVmYXVsdDtcbiAgICAvL2FuaW1cbiAgICAkZmQtZHJvcGRvd24tbWVudS1pdGVtLXRyYW5zaXRpb24tcGFyYW1zOiAkZmQtYW5pbWF0aW9uLS1zcGVlZCBlYXNlLWluICFkZWZhdWx0O1xuXG4gICAgLy9CTE9DSyBCQVNFICoqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKipcbiAgICAvL3NldCBhbGwgQkxPQ0sgcmVzZXQgYW5kIGJhc2VsaW5lIHN0eWxlc1xuICAgIEBpbmNsdWRlIHJlc2V0O1xuICAgIHBvc2l0aW9uOiByZWxhdGl2ZTtcbiAgICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG5cbiAgICAmX19jb250cm9sIHtcbiAgICAgICAgQGluY2x1ZGUgZmQtYnV0dG9uLXJlc2V0O1xuICAgICAgICBAaW5jbHVkZSBmZC1mb3JtLXNlbGVjdDtcbiAgICAgICAgcG9zaXRpb246IHJlbGF0aXZlO1xuICAgICAgICBsaW5lLWhlaWdodDogJGZkLWZvcm1zLWhlaWdodC0taW5wdXQtdGV4dDtcbiAgICAgICAgJlthcmlhLWV4cGFuZGVkPVwidHJ1ZVwiXSxcbiAgICAgICAgJi5pcy1leHBhbmRlZCB7XG4gICAgICAgICAgICBib3JkZXItY29sb3I6ICRmZC1mb3Jtcy1ib3JkZXItY29sb3ItLWZvY3VzO1xuICAgICAgICAgICAgei1pbmRleDogJGZkLWRyb3Bkb3duLW1lbnUtei1pbmRleCArIDE7XG4gICAgICAgICAgICBib3gtc2hhZG93OiAkZmQtZHJvcGRvd24tbWVudS1zaGFkb3c7XG4gICAgICAgIH1cbiAgICAgICAgJi0tbm8tYm9yZGVyIHtcbiAgICAgICAgICAgIGJvcmRlci1jb2xvcjogdHJhbnNwYXJlbnQ7XG4gICAgICAgICAgICAmW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLFxuICAgICAgICAgICAgJi5pcy1kaXNhYmxlZCxcbiAgICAgICAgICAgICY6ZGlzYWJsZWQge1xuICAgICAgICAgICAgICAgIGJvcmRlci1jb2xvcjogdHJhbnNwYXJlbnQ7XG4gICAgICAgICAgICB9XG4gICAgICAgIH1cbiAgICB9XG4gICAgJl9faWNvbiB7XG4gICAgICAgIG1hcmdpbi1yaWdodDogZmQtc3BhY2UoMyk7XG4gICAgICAgIHZlcnRpY2FsLWFsaWduOiBtaWRkbGU7XG4gICAgICAgIHRyYW5zZm9ybTogdHJhbnNsYXRlWSgtMnB4KTtcbiAgICB9XG4gICAgJl9fbWVudSxcbiAgICAmX19vcHRpb25zIHtcbiAgICAgICAgbWFyZ2luLWxlZnQ6IDA7XG4gICAgICAgIHBhZGRpbmctbGVmdDogMDtcbiAgICAgICAgbGlzdC1zdHlsZTogbm9uZTtcbiAgICAgICAgbWluLXdpZHRoOiAxMDAlO1xuICAgICAgICBib3JkZXI6ICRmZC1kcm9wZG93bi1tZW51LWJvcmRlcjtcbiAgICAgICAgYmFja2dyb3VuZDogJGZkLWRyb3Bkb3duLW1lbnUtYmFja2dyb3VuZC1jb2xvcjtcbiAgICAgICAgcG9zaXRpb246IGFic29sdXRlO1xuICAgICAgICB3aGl0ZS1zcGFjZTogbm93cmFwO1xuICAgICAgICB6LWluZGV4OiAkZmQtZHJvcGRvd24tbWVudS16LWluZGV4O1xuICAgICAgICB0cmFuc2Zvcm06IHRyYW5zbGF0ZVkoLTFweCk7XG4gICAgICAgIGJveC1zaGFkb3c6ICRmZC1kcm9wZG93bi1tZW51LXNoYWRvdztcbiAgICAgICAgb3BhY2l0eTogMTtcbiAgICAgICAgdmlzaWJpbGl0eTogdmlzaWJsZTtcbiAgICAgICAgdHJhbnNpdGlvbjogb3BhY2l0eSAkZmQtZHJvcGRvd24tbWVudS1pdGVtLXRyYW5zaXRpb24tcGFyYW1zO1xuICAgICAgICAmW2FyaWEtaGlkZGVuPVwidHJ1ZVwiXSxcbiAgICAgICAgJi5pcy1oaWRkZW4ge1xuICAgICAgICAgICAgb3BhY2l0eTogMDtcbiAgICAgICAgICAgIHZpc2liaWxpdHk6IGhpZGRlbjtcbiAgICAgICAgfVxuICAgIH1cbiAgICAmX19ncm91cCB7XG4gICAgICAgIG1hcmdpbi1sZWZ0OiAwO1xuICAgICAgICBwYWRkaW5nLWxlZnQ6IDA7XG4gICAgICAgIGxpc3Qtc3R5bGU6IG5vbmU7XG4gICAgfVxuICAgICZfX2l0ZW0sXG4gICAgJl9fb3B0aW9uIHtcbiAgICAgICAgQGluY2x1ZGUgcmVzZXQ7XG4gICAgICAgIEBpbmNsdWRlIGZkLXR5cGUoLTEsYm9keSk7XG4gICAgICAgIGRpc3BsYXk6IGJsb2NrO1xuICAgICAgICBwYWRkaW5nLWxlZnQ6IDA7XG4gICAgICAgIGxpc3Qtc3R5bGU6IG5vbmU7XG4gICAgICAgIHBhZGRpbmc6ICRmZC1kcm9wZG93bi1tZW51LWl0ZW0tcGFkZGluZztcbiAgICAgICAgJjpob3ZlciB7XG4gICAgICAgICAgICBjb2xvcjogJGZkLWRyb3Bkb3duLW1lbnUtaXRlbS1jb2xvci0taG92ZXI7XG4gICAgICAgICAgICBiYWNrZ3JvdW5kLWNvbG9yOiAkZmQtZHJvcGRvd24tbWVudS1pdGVtLWJhY2tncm91bmQtY29sb3ItLWhvdmVyO1xuICAgICAgICAgICAgdGV4dC1kZWNvcmF0aW9uOiBub25lO1xuICAgICAgICB9XG4gICAgfVxuICAgICZfX3NlcGFyYXRvciB7XG4gICAgICAgIEBpbmNsdWRlIHJlc2V0O1xuICAgICAgICBAaW5jbHVkZSBmZC10eXBlKC0zLCBib2R5LCByZWcsIG5vbmUpO1xuICAgICAgICBkaXNwbGF5OiBibG9jaztcbiAgICAgICAgY29sb3I6IGZkLWNvbG9yKHRleHQsIDIpO1xuICAgICAgICBwYWRkaW5nOiAkZmQtZHJvcGRvd24tbWVudS1pdGVtLXBhZGRpbmc7XG4gICAgICAgIHBhZGRpbmctdG9wOiBmZC1zcGFjZSg0KTtcbiAgICAgICAgYm9yZGVyLXRvcDogc29saWQgMXB4IGZkLWNvbG9yKG5ldXRyYWwsIDMpO1xuICAgIH1cblxufVxuIiwiQGltcG9ydCBcIi4uL2NvcmUvc2V0dGluZ3NcIjtcbkBpbXBvcnQgXCIuLi9jb3JlL21peGluc1wiO1xuQGltcG9ydCBcIi4uL2NvcmUvZnVuY3Rpb25zXCI7XG5AaW1wb3J0IFwiLi9kcm9wZG93blwiO1xuXG4vKiFcbi5mZC1jb250ZXh0dWFsLW1lbnVcbiovXG4kYmxvY2s6IG5zKGNvbnRleHR1YWwtbWVudSk7XG5cbi4jeyRibG9ja30ge1xuICAgIG1pbi13aWR0aDogMTY5cHg7XG4gICAgcmlnaHQ6IDA7XG59XG4iLCJAaW1wb3J0IFwiLi4vY29yZS9zZXR0aW5nc1wiO1xuQGltcG9ydCBcIi4uL2NvcmUvbWl4aW5zXCI7XG5AaW1wb3J0IFwiLi4vY29yZS9mdW5jdGlvbnNcIjtcbkBpbXBvcnQgXCIuL2J1dHRvblwiO1xuQGltcG9ydCBcIi4vY29udGV4dHVhbC1tZW51XCI7XG5cbi8qIVxuLmZkLWFjdGlvbi1iYXJcblx0LmZkLWFjdGlvbi1iYXJfX25hdmlnYXRpb25cblx0LmZkLWFjdGlvbi1iYXJfX3RpdGxlXG5cdC5mZC1hY3Rpb24tYmFyX19hY3Rpb25zKyguaXMtZGlzYWJsZWQgfCBhcmlhLWhpZGRlbik/XG4gICAgICAgIC5mZC1hY3Rpb24tYmFyX19hY3Rpb24taXRlbVxuKi9cbiRibG9jazogbnMoYWN0aW9uLWJhcik7XG5cbi4jeyRibG9ja30ge1xuICAgIC8vTE9DQUwgVkFSUyAoc2V0IGFsbCB0aGVtZWFibGUgcHJvcGVydGllcywgYWx3YXlzIGluY2x1ZGUgIWRlZmF1bHQpXG4gICAgJGZkLWFjdGlvbi1iYXItYmFja2dyb3VuZC1jb2xvcjogZmQtY29sb3IoYmFja2dyb3VuZCwgMikgIWRlZmF1bHQ7XG4gICAgJGZkLWFjdGlvbi1iYXItYm9yZGVyLWNvbG9yOiBmZC1jb2xvcihuZXV0cmFsLCAzKSAhZGVmYXVsdDtcblxuICAgICRmZC1hY3Rpb24tYmFyLWhlaWdodDogZmQtc3BhY2UoMTkpICFkZWZhdWx0O1xuICAgICRmZC1hY3Rpb24tYmFyLXRyYW5zaXRpb24tcGFyYW1zOiAwLjI1cyBlYXNlLWluICFkZWZhdWx0O1xuXG4gICAgLy9CTE9DSyBCQVNFICoqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKipcbiAgICAvL3NldCBhbGwgQkxPQ0sgcmVzZXQgYW5kIGJhc2VsaW5lIHN0eWxlc1xuICAgIEBpbmNsdWRlIHJlc2V0O1xuICAgIGhlaWdodDogJGZkLWFjdGlvbi1iYXItaGVpZ2h0O1xuICAgIGJhY2tncm91bmQtY29sb3I6ICRmZC1hY3Rpb24tYmFyLWJhY2tncm91bmQtY29sb3I7XG4gICAgYm9yZGVyLXN0eWxlOiBzb2xpZDtcbiAgICBib3JkZXItd2lkdGg6IDFweCAwO1xuICAgIGJvcmRlci1jb2xvcjogJGZkLWFjdGlvbi1iYXItYm9yZGVyLWNvbG9yO1xuICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgYWxpZ24taXRlbXM6IGNlbnRlcjtcbiAgICAmX19uYXZpZ2F0aW9uIHtcblxuICAgIH1cbiAgICAmX190aXRsZSB7XG4gICAgICAgIEBpbmNsdWRlIHJlc2V0O1xuICAgICAgICBAaW5jbHVkZSBmZC10eXBlKDMsIGhlYWRlciwgbWVkKTtcbiAgICAgICAgZmxleDogMTtcbiAgICAgICAgbWFyZ2luLWJvdHRvbTogMDtcbiAgICAgICAgJjpmaXJzdC1jaGlsZCB7XG4gICAgICAgICAgICBwYWRkaW5nLWxlZnQ6IGZkLXNwYWNlKDYpO1xuICAgICAgICB9XG4gICAgfVxuICAgICZfX2FjdGlvbnMge1xuICAgICAgICBAaW5jbHVkZSByZXNldDtcbiAgICAgICAgZGlzcGxheTogZmxleDtcbiAgICAgICAgdHJhbnNpdGlvbjogb3BhY2l0eSAkZmQtYWN0aW9uLWJhci10cmFuc2l0aW9uLXBhcmFtcztcbiAgICAgICAgdmlzaWJpbGl0eTogdmlzaWJsZTtcbiAgICAgICAgJi5pcy1kaXNhYmxlZCxcbiAgICAgICAgJlthcmlhLWhpZGRlbj1cInRydWVcIl0ge1xuICAgICAgICAgICAgb3BhY2l0eTogMDtcbiAgICAgICAgICAgIHZpc2liaWxpdHk6IGhpZGRlbjtcbiAgICAgICAgfVxuICAgIH1cbiAgICAmX19hY3Rpb24taXRlbSB7XG5cbiAgICB9XG59XG4iLCJAaW1wb3J0IFwiLi4vY29yZS9zZXR0aW5nc1wiO1xuQGltcG9ydCBcIi4uL2NvcmUvbWl4aW5zXCI7XG5AaW1wb3J0IFwiLi4vY29yZS9mdW5jdGlvbnNcIjtcblxuLyohXG4uZmQtYmFkZ2UrKCggLS1zdWNjZXNzIHwgLS13YXJuaW5nIHwgLS1lcnJvciApLCAtLXBpbGwpXG4qL1xuJGJsb2NrOiBucyhiYWRnZSk7XG5cbi4jeyRibG9ja30ge1xuICAgIEBpbmNsdWRlIHJlc2V0O1xuICAgIEBpbmNsdWRlIGZkLXR5cGUoLTMpO1xuICAgIGxpbmUtaGVpZ2h0OiBmZC1zcGFjZShyZWcpO1xuICAgIGJvcmRlci1yYWRpdXM6IDVweDtcbiAgICBib3JkZXItd2lkdGg6IDFweDtcbiAgICBib3JkZXItc3R5bGU6IHNvbGlkO1xuICAgIHBhZGRpbmc6IGZkLXNwYWNlKDEpIGZkLXNwYWNlKDIpO1xuICAgIHZlcnRpY2FsLWFsaWduOiBtaWRkbGU7XG4gICAgJi0tcGlsbCB7XG4gICAgICAgIGJvcmRlci1yYWRpdXM6IDEyLjVweDtcbiAgICB9XG4gICAgJi0tc3VjY2VzcyB7XG4gICAgICAgIGNvbG9yOiAkZmQtY29sb3ItLXN1Y2Nlc3M7XG4gICAgfVxuICAgICYtLXdhcm5pbmcge1xuICAgICAgICBjb2xvcjogJGZkLWNvbG9yLS13YXJuaW5nO1xuICAgIH1cbiAgICAmLS1lcnJvciB7XG4gICAgICAgIGNvbG9yOiAkZmQtY29sb3ItLWVycm9yO1xuICAgIH1cbn1cbiIsIkBpbXBvcnQgXCIuLi9jb3JlL3NldHRpbmdzXCI7XG5AaW1wb3J0IFwiLi4vY29yZS9taXhpbnNcIjtcbkBpbXBvcnQgXCIuLi9jb3JlL2Z1bmN0aW9uc1wiO1xuLyohXG4gICAgY2FyZCBzdHJ1Y3R1cmVcbiAgICAuZmQtY2FyZCsoLS1idXR0b24sLS12ZXJ0aWNhbCkrKC5pcy1kaXNhYmxlZHxbYXJpYS1kaXNhYmxlZD10cnVlXSlcbiAgICAgICAgLmZkLWNhcmRfX21lZGlhKygtLXJvdW5kLC0tZmlsbClcbiAgICAgICAgLmZkLWNhcmRfX2NvbnRlbnRcbiAgICAgICAgICAgIC5mZC1jYXJkX19oZWFkZXIsIC5mZC1jYXJkX19kZXNjcmlwdGlvbiwgLmZkLWNhcmRfX3N0YXR1c1xuICAgICAgICAuZmQtY2FyZF9fYWN0aW9uc1xuKi9cblxuLy9zZXQgY29tcG9uZW50IG5hbWUgdXNpbmcgbmFtZXNwYWNlIGZ1bmN0aW9uLCB0aGVuIHVzZSAjeyRibG9ja30gYmVsb3dcbiRibG9jazogbnMoY2FyZCk7XG4uI3skYmxvY2t9IHtcbiAgICBAaW5jbHVkZSByZXNldDtcblxuICAgIC8vZGltZW5zaW9uc1xuICAgICRmZC1jYXJkLW1lZGlhLXdpZHRoOiA3NXB4ICFkZWZhdWx0O1xuICAgIC8vY29sb3JzXG4gICAgJGZkLWNhcmQtY29sb3ItYm9yZGVyOiBmZC1jb2xvcihuZXV0cmFsLCAzKSAhZGVmYXVsdDtcbiAgICAkZmQtY2FyZC1saW5rLWNvbG9yOiBmZC1jb2xvcihhY3Rpb24sIDEpICFkZWZhdWx0O1xuICAgICRmZC1jYXJkLWNvbG9yLWJvcmRlci1kaXNhYmxlZDogbGlnaHRlbihmZC1jb2xvcihuZXV0cmFsLCAyKSwgNSUpICFkZWZhdWx0O1xuICAgICRmZC1jYXJkLWNvbG9yLWRpc2FibGVkOiBmZC1jb2xvcih0ZXh0LCAzKSAhZGVmYXVsdDtcbiAgICAkZmQtY2FyZC1iYWNrZ3JvdW5kLWNvbG9yOiBmZC1jb2xvcihiYWNrZ3JvdW5kKSAhZGVmYXVsdDtcbiAgICAkZmQtY2FyZC1iYWNrZ3JvdW5kLWNvbG9yLWRpc2FibGVkOiBmZC1jb2xvcihuZXV0cmFsLCAxKSAhZGVmYXVsdDtcbiAgICAkZmQtY2FyZC1iYWNrZ3JvdW5kLWNvbG9yLWhvdmVyOiAkZmQtY2FyZC1iYWNrZ3JvdW5kLWNvbG9yICFkZWZhdWx0O1xuICAgICRmZC1jYXJkLXNoYWRvdy1ob3ZlcjogMCAwIDVweCAwIHJnYmEoMTM4LCAxNDMsIDE2MSwgMC40KSAhZGVmYXVsdDtcbiAgICAkZmQtY2FyZC1wYWRkaW5nOiBmZC1zcGFjZShyZWcsIHRydWUpICFkZWZhdWx0O1xuICAgICRmZC1jYXJkLWNvbG9yLWxpbms6ICRmZC1jb2xvci0tbGluayAhZGVmYXVsdDtcbiAgICAkZmQtY2FyZC1tYXJnaW4tYm90dG9tOiAkZmQtbWFyZ2luLWJvdHRvbSAhZGVmYXVsdDtcbiAgICAvL2FuaW1cbiAgICAkZmQtY2FyZC10cmFuc2l0aW9uLXBhcmFtczogJGZkLWFuaW1hdGlvbi0tc3BlZWQgZWFzZS1pbiAhZGVmYXVsdDtcbiAgICAkZmQtY2FyZC10aW1lLWhvdmVyOiAkZmQtYW5pbWF0aW9uLS1zcGVlZCFkZWZhdWx0O1xuXG4gICAgZGlzcGxheTogZmxleDtcbiAgICBtYXJnaW4tYm90dG9tOiAkZmQtY2FyZC1tYXJnaW4tYm90dG9tO1xuICAgIGJvcmRlci1zdHlsZTogc29saWQ7XG4gICAgYm9yZGVyLXdpZHRoOiAxcHg7XG4gICAgYm9yZGVyLWNvbG9yOiAkZmQtY2FyZC1jb2xvci1ib3JkZXI7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogJGZkLWNhcmQtYmFja2dyb3VuZC1jb2xvcjtcbiAgICAvL01PRElGSUNBVElPTlNcbiAgICAmLS12ZXJ0aWNhbCB7XG4gICAgICAgIGRpc3BsYXk6IGJsb2NrO1xuICAgICAgICAuI3skYmxvY2t9X19tZWRpYSB7XG4gICAgICAgICAgICB3aWR0aDogMTAwJTtcbiAgICAgICAgICAgIGhlaWdodDogMzcwcHg7XG4gICAgICAgICAgICBtYXJnaW46IDA7XG4gICAgICAgIH1cbiAgICB9XG4gICAgJi0tYnV0dG9uLFxuICAgICZbcm9sZT1cImJ1dHRvblwiXSB7XG4gICAgICAgIGN1cnNvcjogZGVmYXVsdDtcbiAgICAgICAgLiN7JGJsb2NrfV9faGVhZGVyIHtcbiAgICAgICAgICAgIGNvbG9yOiAkZmQtY2FyZC1jb2xvci1saW5rO1xuICAgICAgICB9XG4gICAgfVxuICAgICYtLWNvbXBhY3Qge1xuICAgICAgICAuI3skYmxvY2t9X19tZWRpYSB7XG4gICAgICAgICAgICBtYXJnaW46ICRmZC1jYXJkLXBhZGRpbmcvMiAwICRmZC1jYXJkLXBhZGRpbmcvMiAkZmQtY2FyZC1wYWRkaW5nLzI7XG4gICAgICAgICAgICAmLS1maWxsIHtcbiAgICAgICAgICAgICAgICBtYXJnaW46IDA7XG4gICAgICAgICAgICAgICAgd2lkdGg6ICRmZC1jYXJkLW1lZGlhLXdpZHRoICsgJGZkLWNhcmQtcGFkZGluZyozLzI7XG4gICAgICAgICAgICB9XG4gICAgICAgIH1cbiAgICAgICAgLiN7JGJsb2NrfV9fY29udGVudCB7XG4gICAgICAgICAgICBwYWRkaW5nOiAkZmQtY2FyZC1wYWRkaW5nLzIgJGZkLWNhcmQtcGFkZGluZy8yO1xuICAgICAgICB9XG4gICAgICAgIEBhdC1yb290ICYuI3skYmxvY2t9LS12ZXJ0aWNhbCB7XG4gICAgICAgICAgICAuI3skYmxvY2t9X19tZWRpYSB7XG4gICAgICAgICAgICAgICAgbWFyZ2luOiAwO1xuICAgICAgICAgICAgfVxuICAgICAgICB9XG4gICAgfVxuICAgIC8vRUZGRUNUUyAqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG4gICAgJi0tYnV0dG9uLFxuICAgICZbcm9sZT1cImJ1dHRvblwiXSB7XG4gICAgICAgIGN1cnNvcjogcG9pbnRlcjtcbiAgICAgICAgdHJhbnNpdGlvbjogYmFja2dyb3VuZC1jb2xvciAkZmQtY2FyZC10cmFuc2l0aW9uLXBhcmFtcywgYm9yZGVyLWNvbG9yICRmZC1jYXJkLXRyYW5zaXRpb24tcGFyYW1zLCBib3gtc2hhZG93ICRmZC1jYXJkLXRyYW5zaXRpb24tcGFyYW1zO1xuICAgICAgICAmOmhvdmVyIHtcbiAgICAgICAgICAgIGJvcmRlci1jb2xvcjogJGZkLWNhcmQtY29sb3ItbGluaztcbiAgICAgICAgICAgIGJhY2tncm91bmQtY29sb3I6ICRmZC1jYXJkLWJhY2tncm91bmQtY29sb3ItaG92ZXI7XG4gICAgICAgICAgICBib3gtc2hhZG93OiAkZmQtY2FyZC1zaGFkb3ctaG92ZXI7XG4gICAgICAgICAgICB0ZXh0LWRlY29yYXRpb246IG5vbmU7XG4gICAgICAgICAgICBjb2xvcjogaW5oZXJpdDtcbiAgICAgICAgfVxuICAgIH1cblxuICAgIC8vU1RBVEVTICoqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKipcbiAgICAmW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdLFxuICAgICYuaXMtZGlzYWJsZWQge1xuICAgICAgICBiYWNrZ3JvdW5kLWNvbG9yOiAkZmQtY2FyZC1iYWNrZ3JvdW5kLWNvbG9yLWRpc2FibGVkICFpbXBvcnRhbnQ7XG4gICAgICAgIGJvcmRlci1jb2xvcjogJGZkLWNhcmQtY29sb3ItYm9yZGVyLWRpc2FibGVkICFpbXBvcnRhbnQ7XG4gICAgICAgIGJveC1zaGFkb3c6IG5vbmUgIWltcG9ydGFudDtcbiAgICAgICAgY3Vyc29yOiBkZWZhdWx0O1xuICAgICAgICAqIHtcbiAgICAgICAgICAgIGNvbG9yOiAkZmQtY2FyZC1jb2xvci1kaXNhYmxlZCAhaW1wb3J0YW50O1xuICAgICAgICB9XG4gICAgfVxuXG4gICAgLy9FTEVNRU5UU1xuICAgICZfX21lZGlhIHtcbiAgICAgICAgYmFja2dyb3VuZC1yZXBlYXQ6IG5vLXJlcGVhdDtcbiAgICAgICAgYmFja2dyb3VuZC1wb3NpdGlvbjogY2VudGVyIGNlbnRlcjtcbiAgICAgICAgYmFja2dyb3VuZC1zaXplOiBjb3ZlcjtcbiAgICAgICAgbWluLXdpZHRoOiAkZmQtY2FyZC1tZWRpYS13aWR0aDtcbiAgICAgICAgbWluLWhlaWdodDogJGZkLWNhcmQtbWVkaWEtd2lkdGg7XG4gICAgICAgIG1hcmdpbjogJGZkLWNhcmQtcGFkZGluZyAwICRmZC1jYXJkLXBhZGRpbmcgJGZkLWNhcmQtcGFkZGluZztcbiAgICAgICAgLy9FTEVNRU5UIE1PRElGSUVSU1xuICAgICAgICAmLS1maWxsIHtcbiAgICAgICAgICAgIG1hcmdpbjogMDtcbiAgICAgICAgICAgIHdpZHRoOiAkZmQtY2FyZC1tZWRpYS13aWR0aCArICRmZC1jYXJkLXBhZGRpbmcqMztcbiAgICAgICAgICAgIGJhY2tncm91bmQtc2l6ZTogY292ZXI7XG4gICAgICAgICAgICAmICsgLiN7JGJsb2NrfV9fY29udGVudCB7XG4gICAgICAgICAgICAgICAgcGFkZGluZy1sZWZ0OiAkZmQtY2FyZC1wYWRkaW5nLzI7XG4gICAgICAgICAgICB9XG4gICAgICAgIH1cbiAgICAgICAgJi0tcm91bmQge1xuICAgICAgICAgICAgYm9yZGVyLXJhZGl1czogNTAlO1xuICAgICAgICB9XG4gICAgfVxuICAgICZfX2NvbnRlbnQge1xuICAgICAgICBwYWRkaW5nOiAoJGZkLWNhcmQtcGFkZGluZykgJGZkLWNhcmQtcGFkZGluZztcbiAgICAgICAgbWF4LXdpZHRoOiAxMDAlO1xuICAgICAgICBmbGV4OiAxO1xuICAgICAgICBvdmVyZmxvdzogaGlkZGVuO1xuICAgIH1cbiAgICAmX19oZWFkZXIge1xuICAgICAgICBjb2xvcjogJGZkLWNvbG9yO1xuICAgICAgICBAaW5jbHVkZSBmZC10eXBlKDEpO1xuICAgICAgICBtYXJnaW4tYm90dG9tOiAxcHg7XG4gICAgfVxuICAgICZfX2Rlc2NyaXB0aW9uIHtcbiAgICAgICAgQGluY2x1ZGUgZmQtdHlwZSgtMik7XG4gICAgICAgIG1hcmdpbi1ib3R0b206IGZkLXNwYWNlKHMpO1xuICAgICAgICAvL1RPRE86IFRoaXMgaXMgYnJlYWtpbmcgdGhlIGNhcmQgZ3JvdXAgbGF5b3V0cywgbmVlZCBhIGRpZmZlcmVudCBhcHByb2FjaFxuICAgICAgICAvL3doaXRlLXNwYWNlOiBub3dyYXA7XG4gICAgICAgIC8vbWF4LXdpZHRoOiAxMDAlO1xuICAgICAgICAvL3dpZHRoOiAxMDAlO1xuICAgICAgICBvdmVyZmxvdzogaGlkZGVuO1xuICAgICAgICB0ZXh0LW92ZXJmbG93OiBlbGxpcHNpcztcbiAgICB9XG4gICAgJl9fc3RhdHVzIHtcbiAgICAgICAgQGluY2x1ZGUgZmQtdHlwZSgtMyk7XG4gICAgfVxuICAgICZfX2FjdGlvbnMge1xuICAgICAgICBwYWRkaW5nOiAkZmQtY2FyZC1wYWRkaW5nICRmZC1jYXJkLXBhZGRpbmcvMjtcbiAgICB9XG4gICAgYSB7XG4gICAgICAgIGNvbG9yOiAkZmQtY2FyZC1saW5rLWNvbG9yO1xuICAgICAgICAmOmhvdmVye1xuICAgICAgICAgICAgY29sb3I6ICRmZC1jYXJkLWxpbmstY29sb3I7XG4gICAgICAgIH1cbiAgICB9XG59XG4iLCJAaW1wb3J0IFwiLi4vY29yZS9zZXR0aW5nc1wiO1xuQGltcG9ydCBcIi4uL2NvcmUvbWl4aW5zXCI7XG5AaW1wb3J0IFwiLi4vY29yZS9mdW5jdGlvbnNcIjtcblxuLyohXG4uZmQtY2FyZC1ncm91cCsoLS0yY29sIHwgLS00Y29sKVxuKi9cbiRibG9jazogbnMoY2FyZC1ncm91cCk7XG5cbi4jeyRibG9ja30ge1xuICAgIC8vTE9DQUwgVkFSUyAoc2V0IGFsbCB0aGVtZWFibGUgcHJvcGVydGllcywgYWx3YXlzIGluY2x1ZGUgIWRlZmF1bHQpXG4gICAgJGZkLWNhcmQtZ3JvdXAtaXRlbXMtcGVyLWdyb3VwOiAzICFkZWZhdWx0O1xuICAgICRmZC1jYXJkLWdyb3VwLXdpZHRoLS1ndXR0ZXI6IGZkLXNwYWNlKHJlZykgIWRlZmF1bHQ7XG5cbiAgICBAaW5jbHVkZSByZXNldDtcbiAgICBAaW5jbHVkZSBmZC1jbGVhcmZpeDtcbiAgICAkZ3V0dGVyXzogJGZkLWNhcmQtZ3JvdXAtd2lkdGgtLWd1dHRlcjtcbiAgICAkaV86ICRmZC1jYXJkLWdyb3VwLWl0ZW1zLXBlci1ncm91cDtcbiAgICBkaXNwbGF5OiBmbGV4O1xuICAgIGZsZXgtd3JhcDogd3JhcDtcbiAgICBmbGV4LWRpcmVjdGlvbjogY29sdW1uO1xuICAgICY6bGFzdC1jaGlsZCB7XG4gICAgICAgIG1hcmdpbi1ib3R0b206IC0kZmQtbWFyZ2luLWJvdHRvbTtcbiAgICB9XG4gICAgQGluY2x1ZGUgZmQtc2NyZWVuKHMpIHtcbiAgICAgICAgZmxleC1kaXJlY3Rpb246IHJvdztcbiAgICAgICAgJiA+ICoge1xuICAgICAgICAgICAgZmxleDogMTtcbiAgICAgICAgICAgIG1hcmdpbi1yaWdodDogJGd1dHRlcl87XG4gICAgICAgICAgICBtaW4td2lkdGg6IGNhbGMoKDEwMCUgLSAjeyRndXR0ZXJffSojeyRpXyAtIDF9KSAvICN7JGlffSk7XG4gICAgICAgICAgICBtYXgtd2lkdGg6IGNhbGMoKDEwMCUgLSAjeyRndXR0ZXJffSojeyRpXyAtIDF9KSAvICN7JGlffSk7XG4gICAgICAgICAgICAmOm50aC1jaGlsZCgjeyRpX31uKSB7XG4gICAgICAgICAgICAgICAgbWFyZ2luLXJpZ2h0OiAwO1xuICAgICAgICAgICAgfVxuICAgICAgICB9XG4gICAgICAgIC8vQkxPQ0sgTU9ESUZJRVJTICoqKioqKioqKioqKlxuICAgICAgICBAZWFjaCAkbiBpbiAyLCA0IHtcbiAgICAgICAgICAgICYtLSN7JG59Y29sIHtcbiAgICAgICAgICAgICAgICAmID4gKiB7XG4gICAgICAgICAgICAgICAgICAgICRqXzogJG47XG4gICAgICAgICAgICAgICAgICAgIG1pbi13aWR0aDogY2FsYygoMTAwJSAtICN7JGd1dHRlcl99KiN7JGpfIC0gMX0pIC8gI3skal99KTtcbiAgICAgICAgICAgICAgICAgICAgbWF4LXdpZHRoOiBjYWxjKCgxMDAlIC0gI3skZ3V0dGVyX30qI3skal8gLSAxfSkgLyAjeyRqX30pO1xuICAgICAgICAgICAgICAgICAgICAvL3Jlc2V0IHRoZSBkZWZhdWx0c1xuICAgICAgICAgICAgICAgICAgICAmOm50aC1jaGlsZCgjeyRpX31uKyN7JGlffSkge1xuICAgICAgICAgICAgICAgICAgICAgICAgbWFyZ2luLXJpZ2h0OiAkZ3V0dGVyXztcbiAgICAgICAgICAgICAgICAgICAgfVxuICAgICAgICAgICAgICAgICAgICAmOm50aC1jaGlsZCgjeyRqX31uKyN7JGpffSkge1xuICAgICAgICAgICAgICAgICAgICAgICAgbWFyZ2luLXJpZ2h0OiAwO1xuICAgICAgICAgICAgICAgICAgICB9XG4gICAgICAgICAgICAgICAgfVxuICAgICAgICAgICAgfVxuICAgICAgICB9XG4gICAgfVxuXG59XG4iLCJAaW1wb3J0IFwiLi4vY29yZS9zZXR0aW5nc1wiO1xuQGltcG9ydCBcIi4uL2NvcmUvbWl4aW5zXCI7XG5AaW1wb3J0IFwiLi4vY29yZS9mdW5jdGlvbnNcIjtcblxuLyohXG4uZmQtZm9ybVxuICAgIC5mZC1mb3JtX19zZXQ/XG4gICAgICAgIC5mZC1mb3JtX19sZWdlbmQoLmlzLXJlcXVpcmVkKVxuICAgICAgICAuZmQtZm9ybV9fZ3JvdXA/XG4gICAgICAgICAgICAuZmQtZm9ybV9faXRlbSsoLS1jaGVjaywgLS1pbmxpbmUpXG4gICAgICAgICAgICAgICAgLmZkLWZvcm1fX2xhYmVsKC5pcy1yZXF1aXJlZClcbiAgICAgICAgICAgICAgICAuZmQtZm9ybV9fY29udHJvbFxuICAgICAgICAgICAgLmZkLWZvcm1fX21lc3NhZ2UoLS1oZWxwLCAtLWVycm9yLCAtLXdhcm5pbmcpXG4qL1xuJGJsb2NrOiBucyhmb3JtKTtcblxuLiN7JGJsb2NrfSB7XG4gICAgLy9MT0NBTCBWQVJTIChzZXQgYWxsIHZhcnMgdXNlZCBpbiBjb21wb25lbnQsIGFsd2F5cyBpbmNsdWRlICFkZWZhdWx0KVxuICAgICRmZC1mb3JtLWxhYmVsLWZvbnQtc2l6ZTogLTEgIWRlZmF1bHQ7XG4gICAgJGZkLWZvcm0tbGFiZWwtZm9udC1zaXplLS1jaGVjazogMCAhZGVmYXVsdDtcbiAgICAkZmQtZm9ybS1sYWJlbC1jb2xvcjogZmQtY29sb3IodGV4dCwgMykgIWRlZmF1bHQ7XG4gICAgJGZkLWZvcm0tbWVzc2FnZS1mb250LXNpemU6IC0xICFkZWZhdWx0O1xuICAgICRmZC1mb3JtLW1lc3NhZ2UtY29sb3I6IGZkLWNvbG9yKHRleHQsIDIpICFkZWZhdWx0O1xuICAgICRmZC1mb3JtLWl0ZW0tZ3V0dGVyOiAkZmQtd2lkdGgtLWd1dHRlciAhZGVmYXVsdDtcbiAgICAkZmQtZm9ybS1pdGVtLW1hcmdpbi1ib3R0b206IGZkLXNwYWNlKDgpICFkZWZhdWx0O1xuXG4gICAgJl9fZ3JvdXAge1xuICAgICAgICBAaW5jbHVkZSBmZC1jbGVhcmZpeDtcbiAgICAgICAgQGluY2x1ZGUgZmQtbGFzdC1jaGlsZDtcbiAgICAgICAgLiN7JGJsb2NrfV9faXRlbSB7XG4gICAgICAgICAgICBAaW5jbHVkZSBmZC1sYXN0LWNoaWxkO1xuICAgICAgICAgICAgbWFyZ2luLXJpZ2h0OiAkZmQtZm9ybS1pdGVtLWd1dHRlcjtcbiAgICAgICAgfVxuICAgIH1cbiAgICAmX19zZXQge1xuICAgICAgICBtYXJnaW4tYm90dG9tOiAkZmQtZm9ybS1pdGVtLW1hcmdpbi1ib3R0b207XG4gICAgICAgIC4jeyRibG9ja31fX2l0ZW0ge1xuICAgICAgICAgICAgJi0taW5saW5lIHtcbiAgICAgICAgICAgICAgICBtYXJnaW4tYm90dG9tOiAwO1xuICAgICAgICAgICAgfVxuICAgICAgICB9XG4gICAgICAgIC4jeyRibG9ja31fX21lc3NhZ2Uge1xuICAgICAgICAgICAgbWFyZ2luLXRvcDogZmQtc3BhY2UoMik7XG4gICAgICAgIH1cbiAgICB9XG4gICAgJl9faXRlbSB7XG4gICAgICAgIEBpbmNsdWRlIGZkLWxhc3QtY2hpbGQ7XG4gICAgICAgIG1hcmdpbi1ib3R0b206ICRmZC1mb3JtLWl0ZW0tbWFyZ2luLWJvdHRvbTtcbiAgICAgICAgJi0tY2hlY2sge1xuICAgICAgICAgICAgQGluY2x1ZGUgZmQtY2xlYXJmaXg7XG4gICAgICAgICAgICBwb3NpdGlvbjogcmVsYXRpdmU7XG4gICAgICAgICAgICBkaXNwbGF5OiBibG9jaztcbiAgICAgICAgICAgIC4jeyRibG9ja31fX2xhYmVsIHtcbiAgICAgICAgICAgICAgICBAaW5jbHVkZSBmZC10eXBlKCRmZC1mb3JtLWxhYmVsLWZvbnQtc2l6ZS0tY2hlY2spO1xuICAgICAgICAgICAgICAgIG1hcmdpbi1ib3R0b206IDA7XG4gICAgICAgICAgICAgICAgdmVydGljYWwtYWxpZ246IG1pZGRsZTtcbiAgICAgICAgICAgICAgICBkaXNwbGF5OiBmbGV4O1xuICAgICAgICAgICAgICAgIGFsaWduLWl0ZW1zOiBjZW50ZXI7XG4gICAgICAgICAgICAgICAgbGluZS1oZWlnaHQ6ICRmZC1mb3Jtcy1oZWlnaHQtLWlucHV0LWNoZWNrO1xuICAgICAgICAgICAgfVxuICAgICAgICAgICAgLiN7JGJsb2NrfV9fY29udHJvbCB7XG4gICAgICAgICAgICAgICAgZmxvYXQ6IGxlZnQ7XG4gICAgICAgICAgICAgICAgdmVydGljYWwtYWxpZ246IG1pZGRsZTtcbiAgICAgICAgICAgICAgICBtYXJnaW4tcmlnaHQ6IGZkLXNwYWNlKDMpO1xuICAgICAgICAgICAgfVxuICAgICAgICAgICAgLiN7JGJsb2NrfV9faGVscCB7XG4gICAgICAgICAgICAgICAgZmxvYXQ6IG5vbmU7XG4gICAgICAgICAgICAgICAgbWFyZ2luLWxlZnQ6IGZkLXNwYWNlKDMpO1xuICAgICAgICAgICAgfVxuICAgICAgICB9XG4gICAgICAgICYtLWlubGluZSB7XG4gICAgICAgICAgICBmbG9hdDogbGVmdDtcbiAgICAgICAgICAgIC4jeyRibG9ja31fX2xhYmVsIHtcbiAgICAgICAgICAgICAgICBtYXJnaW4tdG9wOiBmZC1zcGFjZSgxKTtcbiAgICAgICAgICAgICAgICB3aWR0aDogYXV0bztcbiAgICAgICAgICAgIH1cbiAgICAgICAgfVxuICAgIH1cbiAgICAmX19sYWJlbCwgJl9fbGVnZW5kIHtcbiAgICAgICAgQGluY2x1ZGUgZmQtdHlwZSgkZmQtZm9ybS1sYWJlbC1mb250LXNpemUpO1xuICAgICAgICBkaXNwbGF5OiBibG9jaztcbiAgICAgICAgbWFyZ2luLWJvdHRvbTogZmQtc3BhY2UoMik7XG4gICAgICAgIGJvcmRlcjogMDtcbiAgICAgICAgY29sb3I6ICRmZC1mb3JtLWxhYmVsLWNvbG9yO1xuICAgICAgICAmLmlzLXJlcXVpcmVkIHtcbiAgICAgICAgICAgIEBpbmNsdWRlIGZkLXdlaWdodChib2xkKTtcbiAgICAgICAgfVxuICAgIH1cbiAgICAmX19jb250cm9sIHtcbiAgICAgICAgbWluLXdpZHRoOiAkZmQtZm9ybXMtaGVpZ2h0LS1pbnB1dC1jaGVjaztcbiAgICB9XG4gICAgJl9fbGVnZW5kIHtcbiAgICAgICAgbWFyZ2luLWJvdHRvbTogZmQtc3BhY2UoNSk7XG4gICAgfVxuICAgICZfX2hlbHAge1xuICAgICAgICBmbG9hdDogcmlnaHQ7XG4gICAgfVxuICAgICZfX21lc3NhZ2Uge1xuICAgICAgICBjbGVhcjogYm90aDtcbiAgICAgICAgZGlzcGxheTogYmxvY2s7XG4gICAgICAgIEBpbmNsdWRlIGZkLXR5cGUoJGZkLWZvcm0tbWVzc2FnZS1mb250LXNpemUpO1xuICAgICAgICBjb2xvcjogJGZkLWZvcm0tbWVzc2FnZS1jb2xvcjtcbiAgICAgICAgcGFkZGluZzogZmQtc3BhY2UoMSkgMDtcbiAgICAgICAgZm9udC1zdHlsZTogaXRhbGljO1xuICAgICAgICBwb3NpdGlvbjogcmVsYXRpdmU7XG4gICAgICAgIC8vYWRqdXN0IGZvciBjaGVja3NcbiAgICAgICAgQGF0LXJvb3Qge1xuICAgICAgICAgICAgLiN7JGJsb2NrfV9faXRlbS0tY2hlY2sgKyAmIHtcbiAgICAgICAgICAgICAgICB0cmFuc2Zvcm06IHRyYW5zbGF0ZVkoLShmZC1zcGFjZSgzKSkpO1xuICAgICAgICAgICAgICAgIG1hcmdpbi1ib3R0b206IC0oZmQtc3BhY2UoMykpO1xuICAgICAgICAgICAgfVxuICAgICAgICAgICAgLiN7JGJsb2NrfV9faXRlbS0taW5saW5lLiN7JGJsb2NrfV9faXRlbS0tY2hlY2sgKyAmIHtcbiAgICAgICAgICAgICAgICB0cmFuc2Zvcm06IHRyYW5zbGF0ZVkoZmQtc3BhY2UoMikpO1xuICAgICAgICAgICAgICAgIG1hcmdpbi1ib3R0b206IGZkLXNwYWNlKDIpO1xuICAgICAgICAgICAgfVxuICAgICAgICB9XG4gICAgICAgICY6OmJlZm9yZSB7XG4gICAgICAgICAgICB3aWR0aDogMThweDtcbiAgICAgICAgICAgIGhlaWdodDogMThweDtcbiAgICAgICAgICAgIGZvbnQtc3R5bGU6IG5vcm1hbDtcbiAgICAgICAgICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICAgICAgICAgIGxlZnQ6IDA7XG4gICAgICAgICAgICBjb2xvcjogZmQtY29sb3IodGV4dC1pbnZlcnNlKTtcbiAgICAgICAgICAgIGJvcmRlci1yYWRpdXM6IDUwJTtcbiAgICAgICAgICAgIGJhY2tncm91bmQtY29sb3I6IGZkLWNvbG9yKHRleHQsIDMpO1xuICAgICAgICAgICAgdGV4dC1hbGlnbjogY2VudGVyO1xuICAgICAgICB9XG4gICAgICAgICYtLWhlbHAge1xuICAgICAgICAgICAgcGFkZGluZy1sZWZ0OiBmZC1zcGFjZSg3KTtcbiAgICAgICAgICAgICY6OmJlZm9yZSB7XG4gICAgICAgICAgICAgICAgY29udGVudDogXCI/XCI7XG4gICAgICAgICAgICB9XG4gICAgICAgIH1cbiAgICAgICAgJi0td2FybmluZywgJi0tZXJyb3Ige1xuICAgICAgICAgICAgcGFkZGluZy1sZWZ0OiBmZC1zcGFjZSg5KTtcbiAgICAgICAgICAgIGNvbG9yOiBmZC1jb2xvcih0ZXh0KTtcbiAgICAgICAgICAgICY6OmJlZm9yZSB7XG4gICAgICAgICAgICAgICAgY29udGVudDogXCIhXCI7XG4gICAgICAgICAgICAgICAgbGVmdDogZmQtc3BhY2UoMik7XG4gICAgICAgICAgICB9XG4gICAgICAgIH1cbiAgICAgICAgJi0td2FybmluZyB7XG4gICAgICAgICAgICBiYWNrZ3JvdW5kLWNvbG9yOiBzY2FsZS1jb2xvcigkZmQtY29sb3ItLXdhcm5pbmcsICRsaWdodG5lc3M6IDcwJSk7XG4gICAgICAgICAgICAmOjpiZWZvcmUge1xuICAgICAgICAgICAgICAgIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50O1xuICAgICAgICAgICAgICAgIGJvcmRlci1yYWRpdXM6IDA7XG4gICAgICAgICAgICAgICAgQGluY2x1ZGUgdHJpYW5nbGUoMjBweCAxOHB4LCAkZmQtY29sb3ItLXdhcm5pbmcsIHVwKTtcbiAgICAgICAgICAgICAgICB0ZXh0LWluZGVudDogLTAuMWVtO1xuICAgICAgICAgICAgfVxuICAgICAgICB9XG4gICAgICAgICYtLWVycm9yIHtcbiAgICAgICAgICAgIGJhY2tncm91bmQtY29sb3I6IHNjYWxlLWNvbG9yKCRmZC1jb2xvci0tZXJyb3IsICRsaWdodG5lc3M6IDcwJSk7XG4gICAgICAgICAgICAmOjpiZWZvcmUge1xuICAgICAgICAgICAgICAgIGJhY2tncm91bmQtY29sb3I6ICRmZC1jb2xvci0tZXJyb3I7XG4gICAgICAgICAgICAgICAgY29sb3I6IGZkLWNvbG9yKHRleHQtaW52ZXJzZSk7XG4gICAgICAgICAgICB9XG4gICAgICAgIH1cbiAgICB9XG59XG4iLCJAaW1wb3J0IFwiLi4vY29yZS9zZXR0aW5nc1wiO1xuQGltcG9ydCBcIi4uL2NvcmUvbWl4aW5zXCI7XG5AaW1wb3J0IFwiLi4vY29yZS9mdW5jdGlvbnNcIjtcbkBpbXBvcnQgXCJtaXhpbnNcIjtcblxuLyohXG4uZmQtaW5wdXQtZ3JvdXArKC0taW5saW5lKVxuICAgIC5mZC1pbnB1dC1ncm91cF9fYWRkb24rKClcbiAgICAgICAgLmZkLWlucHV0LWdyb3VwX19idXR0b25cbiovXG4kYmxvY2s6IG5zKGlucHV0LWdyb3VwKTtcblxuLiN7JGJsb2NrfSB7XG5cbiAgICAvL0xPQ0FMIFZBUlMgKHNldCBhbGwgdmFycyB1c2VkIGluIGNvbXBvbmVudCwgYWx3YXlzIGluY2x1ZGUgIWRlZmF1bHQpXG5cbiAgICAvL0JMT0NLIEJBU0UgKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKlxuICAgIC8vc2V0IGFsbCBCTE9DSyByZXNldCBhbmQgYmFzZWxpbmUgc3R5bGVzXG4gICAgQGluY2x1ZGUgcmVzZXQ7XG4gICAgZGlzcGxheTogZmxleDtcbiAgICB2ZXJ0aWNhbC1hbGlnbjogYm90dG9tO1xuICAgIG1heC1oZWlnaHQ6ICRmZC1mb3Jtcy1oZWlnaHQtLWlucHV0LXRleHQ7XG5cbiAgICAvL0VMRU1FTlRTICoqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKipcbiAgICAvL3NldCBhbGwgRUxFTUVOVCBiYXNlbGluZSBzdHlsZXNcbiAgICAmIFt0eXBlPVwibnVtYmVyXCJdIHtcbiAgICAgICAgJjo6LXdlYmtpdC1vdXRlci1zcGluLWJ1dHRvbixcbiAgICAgICAgJjo6LXdlYmtpdC1pbm5lci1zcGluLWJ1dHRvbiB7XG4gICAgICAgICAgICAtd2Via2l0LWFwcGVhcmFuY2U6IG5vbmU7XG4gICAgICAgICAgICBtYXJnaW46IDA7XG4gICAgICAgIH1cbiAgICAgICAgLW1vei1hcHBlYXJhbmNlOiB0ZXh0ZmllbGQ7XG4gICAgfVxuICAgICYgW3R5cGU9XCJzZWFyY2hcIl0ge1xuICAgICAgICBiYWNrZ3JvdW5kLWltYWdlOiB1cmwoJ2RhdGE6aW1hZ2Uvc3ZnK3htbDtiYXNlNjQsUEhOMlp5QjRiV3h1Y3owaWFIUjBjRG92TDNkM2R5NTNNeTV2Y21jdk1qQXdNQzl6ZG1jaUlIZHBaSFJvUFNJeU5pSWdhR1ZwWjJoMFBTSXlOaUkrUEhCaGRHZ2dabWxzYkMxeWRXeGxQU0psZG1WdWIyUmtJaUJtYVd4c1BTSWpORVExUVRaRElpQmtQU0pOT1M0M05UUWdNVGt1TkRrMllUa3VOamcwSURrdU5qZzBJREFnTUNBd0lEWXVNRGszTFRJdU1UVTRiRGd1TWpnNUlEZ3VNelJoTVM0d09EUWdNUzR3T0RRZ01DQXdJREFnTVM0MU16VXRNUzQxTWpsc0xUZ3VNeTA0TGpNMVlUa3VOamc1SURrdU5qZzVJREFnTUNBd0lESXVNVEl0Tmk0d05UUmpNQzAxTGpNM055MDBMak0yT1MwNUxqYzFNUzA1TGpjME1TMDVMamMxTVZNdU1ERXpJRFF1TXpZNExqQXhNeUE1TGpjME5YTTBMak0yT1NBNUxqYzFNU0E1TGpjME1TQTVMamMxTVhwdE1DMHhOeTR6TXpWak5DNHhOemNnTUNBM0xqVTNOeUF6TGpRd01pQTNMalUzTnlBM0xqVTROQ0F3SURRdU1UZ3lMVE11TkNBM0xqVTROQzAzTGpVM055QTNMalU0TkMwMExqRTNPQ0F3TFRjdU5UYzNMVE11TkRBeUxUY3VOVGMzTFRjdU5UZzBJREF0TkM0eE9ESWdNeTR6T1RrdE55NDFPRFFnTnk0MU56Y3ROeTQxT0RSNklpOCtQQzl6ZG1jKycpO1xuICAgICAgICBiYWNrZ3JvdW5kLXJlcGVhdDogbm8tcmVwZWF0O1xuICAgICAgICBiYWNrZ3JvdW5kLXBvc2l0aW9uOiBmZC1zcGFjZSg0KSBjZW50ZXI7XG4gICAgICAgIHBhZGRpbmctbGVmdDogZmQtc3BhY2UoMTUpO1xuICAgICAgICBwYWRkaW5nLXJpZ2h0OiBmZC1zcGFjZSgxNSk7XG4gICAgICAgICY6Oi13ZWJraXQtc2VhcmNoLWRlY29yYXRpb24ge1xuICAgICAgICAgICAgLXdlYmtpdC1hcHBlYXJhbmNlOiBub25lO1xuICAgICAgICAgICAgbWFyZ2luOiAwO1xuICAgICAgICB9XG4gICAgICAgICY6Oi13ZWJraXQtc2VhcmNoLWNhbmNlbC1idXR0b24ge1xuICAgICAgICAgICAgLXdlYmtpdC1hcHBlYXJhbmNlOiBub25lO1xuICAgICAgICAgICAgbWFyZ2luOiAwO1xuICAgICAgICB9XG4gICAgICAgIC1tb3otYXBwZWFyYW5jZTogdGV4dGZpZWxkO1xuICAgIH1cbiAgICAmLS1pbmxpbmUge1xuICAgICAgICBkaXNwbGF5OiBpbmxpbmUtZmxleDtcbiAgICB9XG4gICAgJi0tbm8tYm9yZGVyIHtcbiAgICAgICAgaW5wdXQge1xuICAgICAgICAgICAgYm9yZGVyLWNvbG9yOiB0cmFuc3BhcmVudDtcbiAgICAgICAgfVxuICAgIH1cbiAgICAmX19hZGRvbiB7XG4gICAgICAgIEBpbmNsdWRlIGZkLXR5cGUoLTIsIGJvZHksIGJvbGQsIG5vcm1hbCk7XG4gICAgICAgIGNvbG9yOiBmZC1jb2xvcih0ZXh0LCAzKTtcbiAgICAgICAgcGFkZGluZzogMCBmZC1zcGFjZSg0KTtcbiAgICAgICAgYm9yZGVyLXN0eWxlOiBzb2xpZDtcbiAgICAgICAgYm9yZGVyLXdpZHRoOiAxcHg7XG4gICAgICAgIGJvcmRlci1jb2xvcjogJGZkLWZvcm1zLWJvcmRlci1jb2xvcjtcbiAgICAgICAgYmFja2dyb3VuZC1jb2xvcjogZmQtY29sb3IobmV1dHJhbCwgMSk7XG4gICAgICAgIGp1c3RpZnktY29udGVudDogY2VudGVyO1xuICAgICAgICBkaXNwbGF5OiBmbGV4O1xuICAgICAgICBmbGV4LWRpcmVjdGlvbjogY29sdW1uO1xuXG4gICAgICAgIC8vRUxFTUVOVCBNT0RJRklFUlMgKioqKioqKioqKioqXG4gICAgICAgIC8vZWFjaCBtb2QgTVVTVCBleHRlbmQgdGhlIGVsZW1lbnQgYmFzZVxuICAgICAgICAmOmZpcnN0LWNoaWxkIHtcbiAgICAgICAgICAgIGJvcmRlci1yaWdodC13aWR0aDogMDtcbiAgICAgICAgfVxuICAgICAgICAmOmxhc3QtY2hpbGQge1xuICAgICAgICAgICAgYm9yZGVyLWxlZnQtd2lkdGg6IDA7XG4gICAgICAgIH1cbiAgICAgICAgJi0tYnV0dG9uIHtcbiAgICAgICAgICAgIHBhZGRpbmc6IDA7XG4gICAgICAgIH1cbiAgICAgICAgQGF0LXJvb3Qge1xuICAgICAgICAgICAgW3JlYWRvbmx5XSArICYge1xuICAgICAgICAgICAgICAgIGJvcmRlci10b3AtY29sb3I6IHRyYW5zcGFyZW50O1xuICAgICAgICAgICAgICAgIGJvcmRlci1yaWdodC1jb2xvcjogdHJhbnNwYXJlbnQ7XG4gICAgICAgICAgICB9XG4gICAgICAgIH1cbiAgICAgICAgQGF0LXJvb3Qge1xuICAgICAgICAgICAgW3R5cGU9XCJzZWFyY2hcIl0gKyAmIHtcbiAgICAgICAgICAgICAgICBib3JkZXI6IDA7XG4gICAgICAgICAgICAgICAgd2lkdGg6IDA7XG4gICAgICAgICAgICB9XG4gICAgICAgIH1cblxuICAgIH1cbiAgICAmX19idXR0b24ge1xuICAgICAgICBAaW5jbHVkZSBmZC1idXR0b24tcmVzZXQ7XG4gICAgICAgIGZsZXg6IDE7XG4gICAgICAgIHdpZHRoOiAxMDAlO1xuICAgICAgICBkaXNwbGF5OiBibG9jaztcbiAgICAgICAgbWluLXdpZHRoOiBmZC1zcGFjZSgxMik7XG4gICAgICAgICYtLXN0ZXAtdXAsICYtLXN0ZXAtZG93biAge1xuICAgICAgICAgICAgZm9udC1zaXplOiAxMHB4O1xuICAgICAgICAgICAgJjo6YWZ0ZXIge1xuICAgICAgICAgICAgICAgIGNvbnRlbnQ6IFwiXCI7XG4gICAgICAgICAgICAgICAgcG9zaXRpb246IHJlbGF0aXZlO1xuICAgICAgICAgICAgfVxuICAgICAgICB9XG4gICAgICAgICYtLXN0ZXAtdXAge1xuICAgICAgICAgICAgYm9yZGVyLWJvdHRvbTogc29saWQgMXB4ICRmZC1mb3Jtcy1ib3JkZXItY29sb3I7XG4gICAgICAgICAgICAmOjphZnRlciB7XG4gICAgICAgICAgICAgICAgQGluY2x1ZGUgdHJpYW5nbGUoMTNweCA4cHgsIGJsYWNrLCB1cCk7XG4gICAgICAgICAgICAgICAgdG9wOiAtMTBweDtcbiAgICAgICAgICAgIH1cbiAgICAgICAgfVxuICAgICAgICAmLS1zdGVwLWRvd24gIHtcbiAgICAgICAgICAgICY6OmFmdGVyIHtcbiAgICAgICAgICAgICAgICBAaW5jbHVkZSB0cmlhbmdsZSgxM3B4IDhweCwgYmxhY2ssIGRvd24pO1xuICAgICAgICAgICAgICAgIHRvcDogMTBweDtcbiAgICAgICAgICAgIH1cbiAgICAgICAgfVxuICAgICAgICAmLS1jbGVhciB7XG4gICAgICAgICAgICBiYWNrZ3JvdW5kLWltYWdlOiB1cmwoJ2RhdGE6aW1hZ2Uvc3ZnK3htbDtiYXNlNjQsUEhOMlp5QjRiV3h1Y3owaWFIUjBjRG92TDNkM2R5NTNNeTV2Y21jdk1qQXdNQzl6ZG1jaUlIZHBaSFJvUFNJeU5pSWdhR1ZwWjJoMFBTSXlOaUkrUEhCaGRHZ2dabWxzYkMxeWRXeGxQU0psZG1WdWIyUmtJaUJtYVd4c1BTSWpNREE1UTBSR0lpQmtQU0pOTVRNZ01FTTFMamd5SURBZ01DQTFMamd5SURBZ01UTnpOUzQ0TWlBeE15QXhNeUF4TXlBeE15MDFMamd5SURFekxURXpVekl3TGpFNElEQWdNVE1nTUhwdE5TNHhPVFVnTVRjdU16azJZUzQxTmpRdU5UWTBJREFnTVNBeExTNDNPVGt1TnprNVRERXpJREV6TGpjNU9Xd3ROQzR6T1RZZ05DNHpPVFpoTGpVMk5DNDFOalFnTUNBeElERXRMamM1T1MwdU56azVUREV5TGpJd01TQXhNeUEzTGpnd05TQTRMall3TkdFdU5UWTBMalUyTkNBd0lERWdNU0F1TnprNUxTNDNPVGxNTVRNZ01USXVNakF4YkRRdU16azJMVFF1TXprMllTNDFOalF1TlRZMElEQWdNU0F4SUM0M09Ua3VOems1VERFekxqYzVPU0F4TTJ3MExqTTVOaUEwTGpNNU5ub2lMejQ4TDNOMlp6ND0nKTtcbiAgICAgICAgICAgIGJhY2tncm91bmQtcmVwZWF0OiBuby1yZXBlYXQ7XG4gICAgICAgICAgICBiYWNrZ3JvdW5kLXBvc2l0aW9uOiBjZW50ZXI7XG4gICAgICAgICAgICBwb3NpdGlvbjogcmVsYXRpdmU7XG4gICAgICAgICAgICBsZWZ0OiAtKGZkLXNwYWNlKDEzKSk7XG4gICAgICAgIH1cbiAgICB9XG5cblxufVxuIiwiQGltcG9ydCBcIi4uL2NvcmUvc2V0dGluZ3NcIjtcbkBpbXBvcnQgXCIuLi9jb3JlL21peGluc1wiO1xuQGltcG9ydCBcIi4uL2NvcmUvZnVuY3Rpb25zXCI7XG5cbi8qIVxuLmZkLWxhYmVsKygtLXN1Y2Nlc3MgfCAtLXdhcm5pbmcgfCAtLWVycm9yKVxuKi9cbiRibG9jazogbnMobGFiZWwpO1xuXG4uI3skYmxvY2t9IHtcbiAgICBAaW5jbHVkZSByZXNldDtcbiAgICBAaW5jbHVkZSBmZC10eXBlKC0zKTtcbiAgICAmLS1zdWNjZXNzIHtcbiAgICAgICAgY29sb3I6ICRmZC1jb2xvci0tc3VjY2VzcztcbiAgICB9XG4gICAgJi0td2FybmluZyB7XG4gICAgICAgIGNvbG9yOiAkZmQtY29sb3ItLXdhcm5pbmc7XG4gICAgfVxuICAgICYtLWVycm9yIHtcbiAgICAgICAgY29sb3I6ICRmZC1jb2xvci0tZXJyb3I7XG4gICAgfVxufVxuIiwiQGltcG9ydCBcIi4uL2NvcmUvc2V0dGluZ3NcIjtcbkBpbXBvcnQgXCIuLi9jb3JlL21peGluc1wiO1xuQGltcG9ydCBcIi4uL2NvcmUvZnVuY3Rpb25zXCI7XG5AaW1wb3J0IFwiLi9idXR0b25cIjtcbkBpbXBvcnQgXCIuL2Ryb3Bkb3duXCI7XG4vLyBAaW1wb3J0IFwiLi4vaWNvbnNcIjtcbi8qIVxuLmZkLXRvb2xiYXIrKClcbiAgICAuZmQtdG9vbGJhcl9fcm93XG4gICAgICAgIC5mZC10b29sYmFyX19ncm91cFxuICAgICAgICAuZmQtdG9vbGJhcl9faXRlbVxuKi9cbiRibG9jazogbnModG9vbGJhcik7XG5cbi4jeyRibG9ja30ge1xuICAgIC8vTE9DQUwgVkFSUyAoc2V0IGFsbCB0aGVtZWFibGUgcHJvcGVydGllcywgYWx3YXlzIGluY2x1ZGUgIWRlZmF1bHQpXG4gICAgJGZkLXRvb2xiYXItYmFja2dyb3VuZC1jb2xvcjogZmQtY29sb3IoYmFja2dyb3VuZCwgMikgIWRlZmF1bHQ7XG4gICAgJGZkLXRvb2xiYXItYm9yZGVyLWNvbG9yOiBmZC1jb2xvcihuZXV0cmFsLCAzKSAhZGVmYXVsdDtcbiAgICAkZmQtdG9vbGJhci1ncm91cC1oZWlnaHQ6IGZkLXNwYWNlKDEzKSAhZGVmYXVsdDtcbiAgICAvL2FuaW1cbiAgICAkZmQtdG9vbGJhci1yb3ctdHJhbnNpdGlvbi1wYXJhbXM6IDAuMTVzIGVhc2UtaW4gIWRlZmF1bHQ7XG5cbiAgICAvL0JMT0NLIEJBU0UgKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKlxuICAgIC8vc2V0IGFsbCBCTE9DSyByZXNldCBhbmQgYmFzZWxpbmUgc3R5bGVzXG4gICAgQGluY2x1ZGUgcmVzZXQ7XG4gICAgbWluLWhlaWdodDogJGZkLXRvb2xiYXItZ3JvdXAtaGVpZ2h0O1xuICAgIGJhY2tncm91bmQtY29sb3I6ICRmZC10b29sYmFyLWJhY2tncm91bmQtY29sb3I7XG4gICAgYm9yZGVyLWNvbG9yOiAkZmQtdG9vbGJhci1ib3JkZXItY29sb3I7XG4gICAgYm9yZGVyLXN0eWxlOiBzb2xpZDtcbiAgICBib3JkZXItd2lkdGg6IDFweCAwO1xuICAgIC8vbWFyZ2luLWJvdHRvbTogZmQtc3BhY2UobSk7XG5cbiAgICAmIFtyb2xlPVwic2VwYXJhdG9yXCJdIHtcbiAgICAgICAgZGlzcGxheTogaW5saW5lLWJsb2NrO1xuICAgICAgICB2ZXJ0aWNhbC1hbGlnbjogbWlkZGxlO1xuICAgICAgICBtYXgtd2lkdGg6IDFweDtcbiAgICAgICAgLy93aGl0ZS1zcGFjZTogbm93cmFwO1xuICAgICAgICBoZWlnaHQ6ICRmZC10b29sYmFyLWdyb3VwLWhlaWdodDtcbiAgICAgICAgYm9yZGVyLWxlZnQ6IHNvbGlkIDFweCAkZmQtdG9vbGJhci1ib3JkZXItY29sb3I7XG4gICAgfVxuXG4gICAgZGlzcGxheTogZmxleDtcbiAgICBmbGV4LXdyYXA6IHdyYXA7XG4gICAgJl9fZ3JvdXAge1xuICAgICAgICBtaW4taGVpZ2h0OiAkZmQtdG9vbGJhci1ncm91cC1oZWlnaHQ7XG4gICAgICAgIC8vIG1heC1oZWlnaHQ6ICRmZC10b29sYmFyLWdyb3VwLWhlaWdodDtcbiAgICAgICAgb3ZlcmZsb3c6IHZpc2libGU7XG4gICAgICAgIHRyYW5zaXRpb246IGFsbCAkZmQtdG9vbGJhci1yb3ctdHJhbnNpdGlvbi1wYXJhbXM7XG4gICAgICAgIHdpZHRoOiAxMDAlO1xuICAgICAgICAmLS12aWV3IHtcbiAgICAgICAgICAgIG9yZGVyOiA1O1xuICAgICAgICAgICAgZGlzcGxheTogZmxleDtcbiAgICAgICAgICAgIGFsaWduLWl0ZW1zOiBjZW50ZXI7XG4gICAgICAgICAgICBib3JkZXItdG9wOiBzb2xpZCAxcHggJGZkLXRvb2xiYXItYm9yZGVyLWNvbG9yO1xuICAgICAgICAgICAgQGluY2x1ZGUgZmQtc2NyZWVuKHMpIHtcbiAgICAgICAgICAgICAgICBib3JkZXItdG9wOiBub25lO1xuICAgICAgICAgICAgfVxuICAgICAgICB9XG4gICAgICAgICYtLWZpbHRlciB7XG4gICAgICAgICAgICBkaXNwbGF5OiBmbGV4O1xuICAgICAgICB9XG4gICAgICAgICYtLWZpbHRlci1vcHRpb25zIHtcbiAgICAgICAgICAgIGJhY2tncm91bmQtY29sb3I6IGZkLWNvbG9yKGJhY2tncm91bmQsIDEpO1xuICAgICAgICAgICAgYm9yZGVyLXRvcDogc29saWQgMXB4ICRmZC10b29sYmFyLWJvcmRlci1jb2xvcjtcbiAgICAgICAgfVxuICAgICAgICAmLS1hcHBsaWVkLWZpbHRlcnMge1xuICAgICAgICAgICAgYm9yZGVyLXRvcDogc29saWQgMXB4ICRmZC10b29sYmFyLWJvcmRlci1jb2xvcjtcbiAgICAgICAgICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgICAgICAgICBhbGlnbi1pdGVtczogY2VudGVyO1xuICAgICAgICB9XG4gICAgICAgIEBpbmNsdWRlIGZkLXNjcmVlbihzKSB7XG4gICAgICAgICAgICAmLS1maWx0ZXIge1xuICAgICAgICAgICAgICAgIHdpZHRoOiBhdXRvO1xuICAgICAgICAgICAgfVxuICAgICAgICAgICAgJi0tdmlldyB7XG4gICAgICAgICAgICAgICAgd2lkdGg6IGF1dG87XG4gICAgICAgICAgICAgICAgb3JkZXI6IDA7XG4gICAgICAgICAgICAgICAgbWFyZ2luLWxlZnQ6IGF1dG87XG4gICAgICAgICAgICB9XG4gICAgICAgICAgICAmLS12aWV3LWFzIHtcbiAgICAgICAgICAgICAgICBkaXNwbGF5OiBibG9jaztcbiAgICAgICAgICAgICAgICBtYXJnaW4tbGVmdDogYXV0bztcbiAgICAgICAgICAgIH1cbiAgICAgICAgfVxuICAgICAgICAmW2FyaWEtaGlkZGVuPVwidHJ1ZVwiXSB7XG4gICAgICAgICAgICBkaXNwbGF5OiBub25lO1xuICAgICAgICAgICAgYm9yZGVyOiBub25lO1xuICAgICAgICB9XG4gICAgfVxuICAgICZfX3BhZ2luYXRpb24ge1xuICAgICAgICBtYXJnaW46IDAgYXV0bztcbiAgICAgICAgQGluY2x1ZGUgZmQtc2NyZWVuKHMpIHtcbiAgICAgICAgICAgIG1hcmdpbi1yaWdodDogZmQtc3BhY2UoNSk7XG4gICAgICAgIH1cbiAgICB9XG4gICAgJl9fdmlldy1hcyB7XG4gICAgICAgIGRpc3BsYXk6IG5vbmU7XG4gICAgICAgIEBpbmNsdWRlIGZkLXNjcmVlbihzKSB7XG4gICAgICAgICAgICBkaXNwbGF5OiBibG9jaztcbiAgICAgICAgICAgIGJvcmRlci1sZWZ0OiBzb2xpZCAxcHggJGZkLXRvb2xiYXItYm9yZGVyLWNvbG9yO1xuICAgICAgICB9XG4gICAgfVxuICAgICZfX2J1dHRvbiB7XG4gICAgICAgICZbYXJpYS1leHBhbmRlZD1cInRydWVcIl0ge1xuICAgICAgICAgICAgYmFja2dyb3VuZC1jb2xvcjogZmQtY29sb3IoYmFja2dyb3VuZCwgMSk7XG4gICAgICAgIH1cbiAgICB9XG4gICAgLy9maWx0ZXJcbiAgICAmX19hcHBsaWVkLWZpbHRlci1saXN0IHtcbiAgICAgICAgbWFyZ2luLWxlZnQ6IGZkLXNwYWNlKDUpO1xuICAgICAgICBsaXN0LXN0eWxlOiBub25lO1xuICAgICAgICBtYXJnaW4tYm90dG9tOiAwO1xuICAgICAgICBmbGV4LXdyYXA6IHdyYXA7XG4gICAgICAgIEBpbmNsdWRlIGZkLXNjcmVlbih4cykge1xuICAgICAgICAgICAgZGlzcGxheTogaW5saW5lLWZsZXg7XG4gICAgICAgICAgICBhbGlnbi1pdGVtczogY2VudGVyO1xuICAgICAgICB9XG4gICAgfVxuICAgICZfX2FwcGxpZWQtZmlsdGVyLWl0ZW0ge1xuICAgICAgICBAaW5jbHVkZSBmZC10eXBlKC0zLCBib2R5LCByZWcsIG5vbmUpO1xuICAgICAgICBsaW5lLWhlaWdodDogaW5oZXJpdDtcbiAgICAgICAgZGlzcGxheTogZmxleDtcbiAgICAgICAgYWxpZ24taXRlbXM6IGNlbnRlcjtcbiAgICAgICAgbWFyZ2luLXJpZ2h0OiBmZC1zcGFjZSg1KTtcbiAgICAgICAgQGluY2x1ZGUgZmQtc2NyZWVuKHhzKSB7XG4gICAgICAgICAgICBkaXNwbGF5OiBpbmxpbmUtZmxleDtcbiAgICAgICAgfVxuICAgICAgICAmOjphZnRlciB7XG4gICAgICAgICAgICBjb250ZW50OiBcIuKAolwiO1xuICAgICAgICB9XG4gICAgICAgICY6bGFzdC1jaGlsZCB7XG4gICAgICAgICAgICAmOjphZnRlciB7XG4gICAgICAgICAgICAgICAgZGlzcGxheTogbm9uZTtcbiAgICAgICAgICAgIH1cbiAgICAgICAgfVxuICAgIH1cbiAgICAmX19hcHBsaWVkLWZpbHRlci1jbGVhciB7XG4gICAgICAgIEBpbmNsdWRlIGZkLXR5cGUoLTMsIGJvZHksIHNlbWkpO1xuICAgIH1cblxufVxuIiwiQGltcG9ydCBcIi4uL2NvcmUvc2V0dGluZ3NcIjtcbkBpbXBvcnQgXCIuLi9jb3JlL21peGluc1wiO1xuQGltcG9ydCBcIi4uL2NvcmUvZnVuY3Rpb25zXCI7XG5cbkBmb250LWZhY2Uge1xuICAgIGZvbnQtZmFtaWx5OiBcIkZ1bmRhbWVudGFsSWNvbnNcIjtcbiAgICBzcmM6IHVybChcIkZ1bmRhbWVudGFsSWNvbnMud29mZjJcIikgZm9ybWF0KFwid29mZjJcIiksXG4gICAgICAgIHVybChcIkZ1bmRhbWVudGFsSWNvbnMud29mZlwiKSBmb3JtYXQoXCJ3b2ZmXCIpO1xuICAgIGZvbnQtd2VpZ2h0OiBub3JtYWw7XG4gICAgZm9udC1zdHlsZTogbm9ybWFsO1xufVxuXG4vL2ljb24gbWFwXG4kdG4taWNvbnM6IChcblxuICAgIGFkZDogXCJcXGVhMDFcIixcblxuICAgIGFycm93OiBcIlxcZWEwMlwiLFxuXG4gICAgYmFja2Fycm93OiBcIlxcZWEwM1wiLFxuXG4gICAgY2F1dGlvbjogXCJcXGVhMDRcIixcblxuICAgIGNoYW5nZTogXCJcXGVhMDVcIixcblxuICAgIGNoZWNrZWQ6IFwiXFxlYTA2XCIsXG5cbiAgICBjaGV2cm9uOiBcIlxcZWEwN1wiLFxuXG4gICAgY2xvbmU6IFwiXFxlYTA4XCIsXG5cbiAgICBjbG9zZTogXCJcXGVhMDlcIixcblxuICAgIGNvbGxhcHNlOiBcIlxcZWEwYVwiLFxuXG4gICAgZGVsZXRlOiBcIlxcZWEwYlwiLFxuXG4gICAgZG9uZTogXCJcXGVhMGNcIixcblxuICAgIGRvdWJsZWNoZXZyb246IFwiXFxlYTBkXCIsXG5cbiAgICBkcmFnZHJvcGxpc3Q6IFwiXFxlYTBlXCIsXG5cbiAgICBkcmFnZHJvcG9iamVjdDogXCJcXGVhMGZcIixcblxuICAgIGVkaXQ6IFwiXFxlYTEwXCIsXG5cbiAgICBleHBhbmQ6IFwiXFxlYTExXCIsXG5cbiAgICBmZWVkYmFjazogXCJcXGVhMTJcIixcblxuICAgIGZpbHRlcjogXCJcXGVhMTNcIixcblxuICAgIGZpbHRlcnJlbW92ZTogXCJcXGVhMTRcIixcblxuICAgIGdyaWQ6IFwiXFxlYTE1XCIsXG5cbiAgICBoZWxwOiBcIlxcZWExNlwiLFxuXG4gICAgaW5mb29uOiBcIlxcZWExN1wiLFxuXG4gICAgbGluazogXCJcXGVhMThcIixcblxuICAgIGxpc3Q6IFwiXFxlYTE5XCIsXG5cbiAgICBsb2NhbGl6YXRpb246IFwiXFxlYTFhXCIsXG5cbiAgICBsb2NrOiBcIlxcZWExYlwiLFxuXG4gICAgbWF4aW1pemU6IFwiXFxlYTFjXCIsXG5cbiAgICBtaW5pbWl6ZTogXCJcXGVhMWRcIixcblxuICAgIG1vcmU6IFwiXFxlYTFlXCIsXG5cbiAgICBub2ltYWdlOiBcIlxcZWExZlwiLFxuXG4gICAgb3B0aW9uczogXCJcXGVhMjBcIixcblxuICAgIHNlYXJjaDogXCJcXGVhMjFcIixcblxuICAgIHNvcnQ6IFwiXFxlYTIyXCIsXG5cbiAgICBzeW5jOiBcIlxcZWEyM1wiLFxuXG4gICAgdG9wOiBcIlxcZWEyNFwiLFxuXG4gICAgdmlzaWJpbGl0eW9mZjogXCJcXGVhMjVcIixcblxuICAgIHZpc2liaWxpdHlvbjogXCJcXGVhMjZcIixcblxuICAgIHdhcm5pbmc6IFwiXFxlYTI3XCIsXG5cbikgIWRlZmF1bHQ7XG5cbiRibG9jazogbnMoaWNvbik7XG5cblxuLy9UT0RPOiBmaW5pc2ggbWl4aW5cbi8vIEBtaXhpbiBpY29uKCRrZXksICRzaXplKSB7XG4vLyAgICAgQGlmIG1hcC1oYXMta2V5KCR0bi1pY29ucywgJHNpemUpIHtcbi8vICAgICAgICAgJjo6YmVmb3JlIHtcbi8vICAgICAgICAgICAgIGNvbnRlbnQ6IG1hcC1nZXQoJHRuLWljb25zLCAka2V5KTtcbi8vICAgICAgICAgICAgIEBjb250ZW50O1xuLy8gICAgICAgICB9XG4vLyAgICAgfSBAZWxzZSB7XG4vLyAgICAgICAgIEB3YXJuIFwiVW5rbm93biBgI3ska2V5fWAgaW4gJHRuLWljb25zIG1hcFwiO1xuLy8gICAgIH1cbi8vIH1cblxuLy8gW2NsYXNzKj1cIiN7JGJsb2NrfVwiXSB7XG4vL1xuLy8gfVxuXG4uI3skYmxvY2t9IHtcbiAgICAkdG4taWNvbi1zaXplOiAxLjEyNXJlbSAhZGVmYXVsdDsgICAgICAgICAvLzE4cHhcbiAgICAkdG4taWNvbi1zaXplLS1tZWRpdW06IDEuNjI1cmVtICFkZWZhdWx0OyAvLzI2cHhcbiAgICAkdG4taWNvbi1zaXplLS1sYXJnZTogMnJlbSAhZGVmYXVsdDsgICAgICAvLzMycHhcbiAgICBmb250LXNpemU6ICR0bi1pY29uLXNpemU7XG4gICAgZm9udC1mYW1pbHk6IFwiRnVuZGFtZW50YWxJY29uc1wiO1xuICAgIGxpbmUtaGVpZ2h0OiAxO1xuICAgIGZvbnQtc3R5bGU6IG5vcm1hbDtcbiAgICBmb250LXdlaWdodDogbm9ybWFsO1xuICAgIHRleHQtYWxpZ246IGNlbnRlcjtcbiAgICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gICAgdGV4dC1kZWNvcmF0aW9uOiBpbmhlcml0O1xuICAgIHRleHQtdHJhbnNmb3JtOiBub25lO1xuICAgIHRleHQtcmVuZGVyaW5nOiBvcHRpbWl6ZUxlZ2liaWxpdHk7XG4gICAgLXdlYmtpdC1mb250LXNtb290aGluZzogYW50aWFsaWFzZWQ7XG4gICAgLW1vei1vc3gtZm9udC1zbW9vdGhpbmc6IGdyYXlzY2FsZTtcbiAgICAmLS1tZWRpdW0ge1xuICAgICAgICBmb250LXNpemU6ICR0bi1pY29uLXNpemUtLW1lZGl1bTtcbiAgICB9XG4gICAgJi0tbGFyZ2Uge1xuICAgICAgICBmb250LXNpemU6ICR0bi1pY29uLXNpemUtLWxhcmdlO1xuICAgIH1cbiAgICAmOjpiZWZvcmUge1xuICAgICAgICBkaXNwbGF5OiBpbmxpbmU7XG4gICAgICAgIHRleHQtYWxpZ246IGNlbnRlcjtcbiAgICB9XG5cbiAgICBAZWFjaCAka2V5LCAkdmFsdWUgaW4gJHRuLWljb25zIHtcbiAgICAgICAgJi0tI3ska2V5fSB7XG4gICAgICAgICAgICAmOjpiZWZvcmUge1xuICAgICAgICAgICAgICAgIGNvbnRlbnQ6ICR2YWx1ZTtcbiAgICAgICAgICAgIH1cbiAgICAgICAgfVxuICAgIH1cbn1cbiIsIkBpbXBvcnQgXCIuLi9jb3JlL3NldHRpbmdzXCI7XG5AaW1wb3J0IFwiLi4vY29yZS9taXhpbnNcIjtcbkBpbXBvcnQgXCIuLi9jb3JlL2Z1bmN0aW9uc1wiO1xuQGltcG9ydCBcIi4uL2NvbXBvbmVudHMvYnV0dG9uXCI7XG5AaW1wb3J0IFwiLi4vaWNvbnNcIjtcbkBpbXBvcnQgXCJtaXhpbnNcIjtcblxuLyohXG4uZmQtcGFnaW5hdGlvblxuKi9cblxuJGJsb2NrOiBucyhwYWdpbmF0aW9uKTtcblxuLiN7JGJsb2NrfSB7XG4gICRmZC1wYWdpbmF0aW9uLWNvbG9yOiBmZC1jb2xvcih0ZXh0LWludmVyc2UsIDIpICFkZWZhdWx0O1xuICAkZmQtcGFnaW5hdGlvbi1jb2xvci0tdGV4dDogJGZkLWNvbG9yLS1saW5rICFkZWZhdWx0O1xuICAkZmQtcGFnaW5hdGlvbi1jb2xvci0tYWN0aXZlOiAkZmQtcGFnaW5hdGlvbi1jb2xvciAhZGVmYXVsdDtcbiAgJGZkLXBhZ2luYXRpb24tY29sb3ItLWRpc2FibGVkOiBmZC1jb2xvcih0ZXh0LCAxKSAhZGVmYXVsdDtcbiAgJGZkLXBhZ2luYXRpb24tbmF2LWNvbG9yLS1kaXNhYmxlZDogZmQtY29sb3IodGV4dCwgMikgIWRlZmF1bHQ7XG5cbiAgQGluY2x1ZGUgcmVzZXQ7XG4gIEBpbmNsdWRlIGZkLXR5cGUoLTEpO1xuICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gIG1hcmdpbi1ib3R0b206IDA7XG4gIHBhZGRpbmctbGVmdDogMDtcbiAgbGlzdC1zdHlsZTogbm9uZTtcbiAgJl9fbGluayB7XG4gICAgY29sb3I6ICRmZC1wYWdpbmF0aW9uLWNvbG9yLS10ZXh0O1xuICAgIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50O1xuICAgIHBhZGRpbmctbGVmdDogZmQtc3BhY2UoMyk7XG4gICAgcGFkZGluZy1yaWdodDogZmQtc3BhY2UoMyk7XG4gICAgcG9zaXRpb246IHJlbGF0aXZlO1xuICAgICY6OmFmdGVyIHtcbiAgICAgICAgY29udGVudDogXCJcIjtcbiAgICAgICAgYm9yZGVyLWJvdHRvbTogc29saWQgMnB4IHRyYW5zcGFyZW50O1xuICAgICAgICB3aWR0aDogY2FsYygxMDAlIC0gI3tmZC1zcGFjZSgyKX0qMik7O1xuICAgICAgICBoZWlnaHQ6IDJweDtcbiAgICAgICAgcG9zaXRpb246IGFic29sdXRlO1xuICAgICAgICBib3R0b206IC02cHg7XG4gICAgICAgIGxlZnQ6IDA7XG4gICAgICAgIG1hcmdpbi1sZWZ0OiBmZC1zcGFjZSgyKTtcbiAgICB9XG4gICAgJjpob3ZlcixcbiAgICAmOmZvY3VzIHtcbiAgICAgIGNvbG9yOiBkYXJrZW4oJGZkLXBhZ2luYXRpb24tY29sb3ItLXRleHQsIDUpO1xuICAgICAgdGV4dC1kZWNvcmF0aW9uOiBub25lO1xuICAgICAgJjo6YWZ0ZXIge1xuICAgICAgICAgIGJvcmRlci1ib3R0b20tY29sb3I6IGRhcmtlbigkZmQtcGFnaW5hdGlvbi1jb2xvci0tdGV4dCwgNSk7XG4gICAgICB9XG4gICAgfVxuICAgICY6YWN0aXZlLFxuICAgICZbYXJpYS1zZWxlY3RlZD1cInRydWVcIl0sXG4gICAgJi5pcy1zZWxlY3RlZHtcbiAgICAgIGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50O1xuICAgICAgb3V0bGluZTogbm9uZTtcbiAgICAgIGJveC1zaGFkb3c6IG5vbmU7XG4gICAgICAmOjphZnRlciB7XG4gICAgICAgICAgYm9yZGVyLWJvdHRvbS1jb2xvcjogdHJhbnNwYXJlbnQ7XG4gICAgICB9XG4gICAgfVxuICAgICZbYXJpYS1kaXNhYmxlZD1cInRydWVcIl0sXG4gICAgJi5pcy1kaXNhYmxlZCB7XG4gICAgICBjb2xvcjogJGZkLXBhZ2luYXRpb24tbmF2LWNvbG9yLS1kaXNhYmxlZDtcbiAgICAgIHRleHQtZGVjb3JhdGlvbjogbm9uZTtcbiAgICAgIGN1cnNvcjogZGVmYXVsdDtcbiAgICAgICY6OmFmdGVyIHtcbiAgICAgICAgICBib3JkZXItYm90dG9tLWNvbG9yOiB0cmFuc3BhcmVudDtcbiAgICAgIH1cbiAgICB9XG4gICAgJjphY3RpdmUsXG4gICAgJlthcmlhLXNlbGVjdGVkPVwidHJ1ZVwiXSxcbiAgICAmLmlzLXNlbGVjdGVkIHtcbiAgICAgIGNvbG9yOiAkZmQtcGFnaW5hdGlvbi1jb2xvci0tZGlzYWJsZWQ7XG4gICAgICB0ZXh0LWRlY29yYXRpb246IG5vbmU7XG4gICAgICBjdXJzb3I6IGRlZmF1bHQ7XG4gICAgfVxuICB9XG5cbiAgJl9faXRlbXtcbiAgICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gICAgLmZkLWljb24tLWNoZXZyb24tYmFja3tcbiAgICAgIEBleHRlbmQgLmZkLWljb24tLWNoZXZyb247XG4gICAgICBAaW5jbHVkZSByb3RhdGUoMTgwKTtcbiAgICB9XG4gIH1cbiAgJl9fbW9yZXtcbiAgICBAaW5jbHVkZSBmZC10eXBlKC0zKTtcbiAgICBjb2xvcjogJGZkLXBhZ2luYXRpb24tY29sb3ItLWRpc2FibGVkO1xuICAgIHZlcnRpY2FsLWFsaWduOiBzdWI7XG4gICAgcGFkZGluZy1sZWZ0OiBmZC1zcGFjZSgzKTtcbiAgICBwYWRkaW5nLXJpZ2h0OiBmZC1zcGFjZSgzKTtcbiAgICAmOmhvdmVyLFxuICAgICY6Zm9jdXMge1xuICAgICAgYmFja2dyb3VuZC1jb2xvcjogdHJhbnNwYXJlbnQ7XG4gICAgICBjb2xvcjogJGZkLXBhZ2luYXRpb24tY29sb3ItLWRpc2FibGVkO1xuICAgICAgY3Vyc29yOiBkZWZhdWx0O1xuICAgIH1cbiAgfVxuICAmX190b3RhbHtcbiAgICBjb2xvcjogJGZkLXBhZ2luYXRpb24tbmF2LWNvbG9yLS1kaXNhYmxlZDtcbiAgfVxufVxuIiwiQGltcG9ydCBcIi4uL2NvcmUvc2V0dGluZ3NcIjtcbkBpbXBvcnQgXCIuLi9jb3JlL21peGluc1wiO1xuQGltcG9ydCBcIi4uL2NvcmUvZnVuY3Rpb25zXCI7XG5cbi8qIVxuLmZkLXRhYmxlXG4gICAgdGhlYWRcbiAgICB0Ym9keVxuICAgICAgICB0cisoW2FyaWEtc2VsZWN0ZWRdKVxuKi9cbiRibG9jazogbnModGFibGUpO1xuXG4uI3skYmxvY2t9IHtcbiAgICAvL0xPQ0FMIFZBUlMgKHNldCBhbGwgdGhlbWVhYmxlIHByb3BlcnRpZXMsIGFsd2F5cyBpbmNsdWRlICFkZWZhdWx0KVxuICAgICRmZC10YWJsZS1ib3JkZXItY29sb3I6IGZkLWNvbG9yKG5ldXRyYWwsIDMpICFkZWZhdWx0O1xuICAgICRmZC10YWJsZS1saW5rLWNvbG9yOiBmZC1jb2xvcihhY3Rpb24sIDEpICFkZWZhdWx0O1xuICAgICRmZC10YWJsZS1jZWxsLXNwYWNpbmc6ICRmZC13aWR0aC0tZ3V0dGVyICFkZWZhdWx0O1xuICAgICRmZC10YWJsZS1jZWxsLXBhZGRpbmc6IGZkLXNwYWNlKDMpICFkZWZhdWx0O1xuICAgICRmZC10YWJsZS10cmFuc2l0aW9uLXBhcmFtczogJGZkLWFuaW1hdGlvbi0tc3BlZWQgZWFzZS1pbiAhZGVmYXVsdDtcblxuICAgIC8vQkxPQ0sgQkFTRSAqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG4gICAgLy9zZXQgYWxsIEJMT0NLIHJlc2V0IGFuZCBiYXNlbGluZSBzdHlsZXNcbiAgICBAaW5jbHVkZSByZXNldDtcbiAgICBAaW5jbHVkZSBmZC1sYXN0LWNoaWxkO1xuICAgIHdpZHRoOiAxMDAlO1xuICAgIG1heC13aWR0aDogMTAwJTtcbiAgICBib3JkZXItY29sbGFwc2U6IGNvbGxhcHNlO1xuICAgIG1hcmdpbi1ib3R0b206ICRmZC1tYXJnaW4tYm90dG9tO1xuICAgIGJvcmRlci10b3A6IHNvbGlkIDFweCAkZmQtdGFibGUtYm9yZGVyLWNvbG9yO1xuICAgIHRyIHtcbiAgICAgICAgdHJhbnNpdGlvbjogYmFja2dyb3VuZC1jb2xvciAkZmQtdGFibGUtdHJhbnNpdGlvbi1wYXJhbXM7XG4gICAgICAgICY6aG92ZXIge1xuICAgICAgICAgICAgYmFja2dyb3VuZC1jb2xvcjogbGlnaHRlbihmZC1jb2xvcihuZXV0cmFsLCAzKSwgMTApO1xuICAgICAgICB9XG4gICAgICAgICYuaXMtc2VsZWN0ZWQsXG4gICAgICAgICZbYXJpYS1zZWxlY3RlZD1cInRydWVcIl0ge1xuICAgICAgICAgICAgYmFja2dyb3VuZC1jb2xvcjogbGlnaHRlbihmZC1jb2xvcihuZXV0cmFsLCAzKSwgNSk7XG4gICAgICAgIH1cbiAgICB9XG4gICAgdGhlYWQge1xuICAgICAgICBAaW5jbHVkZSBmZC10eXBlKC0xKTtcbiAgICAgICAgY29sb3I6IGZkLWNvbG9yKHRleHQsIDIpO1xuICAgICAgICB0ciB7XG4gICAgICAgICAgICAmOmhvdmVyIHtcbiAgICAgICAgICAgICAgICBiYWNrZ3JvdW5kLWNvbG9yOiBpbmhlcml0O1xuICAgICAgICAgICAgfVxuICAgICAgICB9XG4gICAgICAgIHRkLFxuICAgICAgICB0aCB7XG4gICAgICAgICAgICBib3JkZXI6IG5vbmU7XG4gICAgICAgIH1cbiAgICB9XG4gICAgdGQsXG4gICAgdGgge1xuICAgICAgICB0ZXh0LWFsaWduOiBsZWZ0O1xuICAgICAgICBwYWRkaW5nOiAkZmQtdGFibGUtY2VsbC1wYWRkaW5nICRmZC10YWJsZS1jZWxsLXNwYWNpbmcgJGZkLXRhYmxlLWNlbGwtcGFkZGluZyAwO1xuICAgICAgICAmOmZpcnN0LWNoaWxkIHtcbiAgICAgICAgICAgIHBhZGRpbmctbGVmdDogJGZkLXRhYmxlLWNlbGwtc3BhY2luZztcbiAgICAgICAgfVxuICAgICAgICBib3JkZXItc3R5bGU6IHNvbGlkO1xuICAgICAgICBib3JkZXItd2lkdGg6IDFweCAwO1xuICAgICAgICBib3JkZXItY29sb3I6ICRmZC10YWJsZS1ib3JkZXItY29sb3I7XG4gICAgfVxuICAgIGEge1xuICAgICAgICBjb2xvcjogJGZkLXRhYmxlLWxpbmstY29sb3I7XG4gICAgICAgICY6aG92ZXJ7XG4gICAgICAgICAgICBjb2xvcjogJGZkLXRhYmxlLWxpbmstY29sb3I7XG4gICAgICAgIH1cbiAgICB9XG5cbn1cbiIsIkBpbXBvcnQgXCIuLi9jb3JlL3NldHRpbmdzXCI7XG5AaW1wb3J0IFwiLi4vY29yZS9taXhpbnNcIjtcbkBpbXBvcnQgXCIuLi9jb3JlL2Z1bmN0aW9uc1wiO1xuXG4vKiFcbi5mZC10YWJzKygpXG4gICAgLmZkLXRhYnNfX2l0ZW0/XG4gICAgLmZkLXRhYnNfX2xpbmsrKCguaXMtc2VsZWN0ZWR8W2FyaWEtc2VsZWN0ZWQ9dHJ1ZV0pLCguaXMtZGlzYWJsZWR8W2FyaWEtZGlzYWJsZWQ9dHJ1ZV0pKVxuLmZkLXRhYnNfX3BhbmVsKyhbYXJpYS1leHBhbmRlZF18LmlzLWV4cGFuZGVkKVxuKi9cblxuJGJsb2NrOiBucyh0YWJzKTtcblxuLiN7JGJsb2NrfSB7XG4gICAgJGZkLXRhYnMtbWFyZ2luLWJvdHRvbTogZmQtc3BhY2UobSkgIWRlZmF1bHQ7XG4gICAgJGZkLXRhYnMtYm9yZGVyLXdpZHRoOiAxcHggIWRlZmF1bHQ7XG4gICAgJGZkLXRhYnMtYm9yZGVyLWNvbG9yOiBmZC1jb2xvcihuZXV0cmFsLCAzKSAhZGVmYXVsdDtcbiAgICAkZmQtdGFicy1saW5rLXBhZGRpbmc6IGZkLXNwYWNlKDMpICFkZWZhdWx0O1xuICAgICRmZC10YWJzLWxpbmstcGFkZGluZy0tc2lkZTogZmQtc3BhY2UoNSkgIWRlZmF1bHQ7XG4gICAgJGZkLXRhYnMtbGluay1ib3JkZXItd2lkdGg6IDJweCAhZGVmYXVsdDtcbiAgICAkZmQtdGFicy1saW5rLWJvcmRlci1jb2xvcjogZmQtY29sb3IoYWN0aW9uLCAxKSAhZGVmYXVsdDtcbiAgICAkZmQtdGFicy1saW5rLXRyYW5zaXRpb24tcGFyYW1zOiAkZmQtYW5pbWF0aW9uLS1zcGVlZCBlYXNlLWluICFkZWZhdWx0O1xuXG4gICAgQGluY2x1ZGUgcmVzZXQ7XG4gICAgZGlzcGxheTogZmxleDtcbiAgICBmbGV4LXdyYXA6IHdyYXA7XG4gICAgcGFkZGluZy1sZWZ0OiAwO1xuICAgIG1hcmdpbi1ib3R0b206ICRmZC10YWJzLW1hcmdpbi1ib3R0b207XG4gICAgbGlzdC1zdHlsZTogbm9uZTtcbiAgICBib3JkZXItYm90dG9tOiBzb2xpZCAkZmQtdGFicy1ib3JkZXItd2lkdGggJGZkLXRhYnMtYm9yZGVyLWNvbG9yO1xuXG4gICAgJl9faXRlbSB7XG5cbiAgICB9XG4gICAgJl9fbGluayB7XG4gICAgICAgIGRpc3BsYXk6IGJsb2NrO1xuICAgICAgICBwYWRkaW5nOiAkZmQtdGFicy1saW5rLXBhZGRpbmcgJGZkLXRhYnMtbGluay1wYWRkaW5nLS1zaWRlO1xuICAgICAgICBAaW5jbHVkZSBmZC10eXBlKDEsaGVhZGVyLG1lZCx1cHBlcmNhc2UpO1xuICAgICAgICBjb2xvcjogJGZkLWNvbG9yLS1saW5rO1xuICAgICAgICBib3JkZXItYm90dG9tOiBzb2xpZCAkZmQtdGFicy1saW5rLWJvcmRlci13aWR0aCB0cmFuc3BhcmVudDtcbiAgICAgICAgdHJhbnNpdGlvbjogYWxsICRmZC10YWJzLWxpbmstdHJhbnNpdGlvbi1wYXJhbXM7XG4gICAgICAgIGN1cnNvcjogcG9pbnRlcjtcbiAgICAgICAgJjpob3ZlciB7XG4gICAgICAgICAgICBib3JkZXItYm90dG9tOiBzb2xpZCAkZmQtdGFicy1saW5rLWJvcmRlci13aWR0aCAkZmQtdGFicy1saW5rLWJvcmRlci1jb2xvcjtcbiAgICAgICAgICAgIGNvbG9yOiAkZmQtY29sb3ItLWxpbmstaG92ZXI7XG4gICAgICAgIH1cbiAgICAgICAgJi5pcy1zZWxlY3RlZCxcbiAgICAgICAgJlthcmlhLXNlbGVjdGVkPVwidHJ1ZVwiXSB7XG4gICAgICAgICAgICBjb2xvcjogJGZkLWNvbG9yO1xuICAgICAgICAgICAgYm9yZGVyLWJvdHRvbTogc29saWQgJGZkLXRhYnMtbGluay1ib3JkZXItd2lkdGggJGZkLXRhYnMtbGluay1ib3JkZXItY29sb3I7XG4gICAgICAgIH1cbiAgICAgICAgJi5pcy1kaXNhYmxlZCxcbiAgICAgICAgJlthcmlhLWRpc2FibGVkPVwidHJ1ZVwiXSB7XG4gICAgICAgICAgICBjb2xvcjogJGZkLWNvbG9yLS1saW5rLWRpc2FibGVkO1xuICAgICAgICAgICAgY3Vyc29yOiBub3QtYWxsb3dlZDtcbiAgICAgICAgICAgICY6aG92ZXIge1xuICAgICAgICAgICAgICAgIGJvcmRlci1ib3R0b20tY29sb3I6IHRyYW5zcGFyZW50O1xuICAgICAgICAgICAgfVxuICAgICAgICB9XG4gICAgfVxuICAgICZfX3BhbmVsIHtcbiAgICAgICAgJlthcmlhLWV4cGFuZGVkPVwiZmFsc2VcIl0ge1xuICAgICAgICAgICAgZGlzcGxheTogbm9uZTtcbiAgICAgICAgfVxuICAgICAgICAmLmlzLWV4cGFuZGVkLFxuICAgICAgICAmW2FyaWEtZXhwYW5kZWQ9XCJ0cnVlXCJdIHtcbiAgICAgICAgICAgIGRpc3BsYXk6IGJsb2NrO1xuICAgICAgICB9XG5cbiAgICB9XG5cbn1cbiIsIkBpbXBvcnQgXCIuLi9jb3JlL3NldHRpbmdzXCI7XG5AaW1wb3J0IFwiLi4vY29yZS9taXhpbnNcIjtcbkBpbXBvcnQgXCIuLi9jb3JlL2Z1bmN0aW9uc1wiO1xuQGltcG9ydCBcIi4uL2NvbXBvbmVudHMvYnV0dG9uXCI7XG4vKiFcbi5mZC1tb2RhbFxuICAgIC5mZC1tb2RhbF9faGVhZGVyXG4gICAgICAgIC5mZC1mb3JtX190aXRsZVxuICAgIC5mZC1mb3JtX19ib2R5XG4gICAgLmZkLWZvcm1fX2Zvb3Rlci1pdGVtc1xuICAgICAgLmZkLW1vZGFsX19idXR0b24tcHJpbWFyeVxuICAgICAgLmZkLW1vZGFsX19idXR0b24tc2Vjb25kYXJ5XG4qL1xuJGJsb2NrOiBucyhtb2RhbCk7XG4gICRmZC1tb2RhbC1ib3JkZXItY29sb3I6IGZkLWNvbG9yKG5ldXRyYWwsIDMpICFkZWZhdWx0O1xuICAkZmQtbW9kYWwtaW5uZXItcGFkZGluZzogZmQtc3BhY2UoMTApICFkZWZhdWx0O1xuICAkZmQtbW9kYWwtaW5uZXItY29udGVudC1iYWNrZ3JvdW5kOiBmZC1jb2xvcihiYWNrZ3JvdW5kLCAxKSAhZGVmYXVsdDtcblxuXG4uI3skYmxvY2t9IHtcbiAgd2lkdGg6IDcwMHB4O1xuICBtYXJnaW46IGZkLXNwYWNlKDgpIGF1dG87XG4gICZfX2NvbnRlbnR7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogJGZkLW1vZGFsLWlubmVyLWNvbnRlbnQtYmFja2dyb3VuZDtcbiAgICBidXR0b257XG4gICAgICBmbG9hdDogcmlnaHQ7XG4gICAgfVxuICB9XG4gICZfX2hlYWRlcntcbiAgICBib3JkZXItYm90dG9tOiAxcHggc29saWQgJGZkLW1vZGFsLWJvcmRlci1jb2xvcjtcbiAgICBwYWRkaW5nLWxlZnQ6ICRmZC1tb2RhbC1pbm5lci1wYWRkaW5nO1xuICAgIHBhZGRpbmctdG9wOiAkZmQtbW9kYWwtaW5uZXItcGFkZGluZztcbiAgICBwYWRkaW5nLXJpZ2h0OiAkZmQtbW9kYWwtaW5uZXItcGFkZGluZy8yO1xuICB9XG4gICZfX3RpdGxle1xuICAgICAgQGluY2x1ZGUgZmQtdHlwZSg0LGhlYWRlciwgbWVkKTtcbiAgfVxuICAmX19ib2R5e1xuICAgIHBhZGRpbmc6ICRmZC1tb2RhbC1pbm5lci1wYWRkaW5nO1xuICB9XG4gICZfX2Zvb3Rlci1pdGVtcyB7XG4gICAgZGlzcGxheTogYmxvY2s7XG4gICAgb3ZlcmZsb3c6IGF1dG87XG4gICAgYm9yZGVyLXRvcDogMXB4IHNvbGlkICRmZC1tb2RhbC1ib3JkZXItY29sb3I7XG4gICAgcGFkZGluZzogJGZkLW1vZGFsLWlubmVyLXBhZGRpbmc7XG4gICAgcGFkZGluZy10b3A6ICRmZC1tb2RhbC1pbm5lci1wYWRkaW5nLzI7XG4gIH1cbiAgJl9fYnV0dG9uLXByaW1hcnkge1xuICAgIEBleHRlbmQgLmZkLWJ1dHRvbjtcbiAgfVxuICAmX19idXR0b24tc2Vjb25kYXJ5IHtcbiAgICBAZXh0ZW5kIC5mZC1idXR0b247XG4gICAgQGV4dGVuZCAuZmQtYnV0dG9uLS10ZXh0O1xuICB9XG59XG4iLCJAaW1wb3J0IFwiLi4vY29yZS9zZXR0aW5nc1wiO1xuQGltcG9ydCBcIi4uL2NvcmUvbWl4aW5zXCI7XG5AaW1wb3J0IFwiLi4vY29yZS9mdW5jdGlvbnNcIjtcbkBpbXBvcnQgXCIuL21peGluc1wiO1xuXG4vKiFcbi5mZC10cmVlKygtLWhlYWRlcilcbiAgICAuZmQtdHJlZV9fZ3JvdXArKC0tc3VibGV2ZWwtMS4uLi02LCAoW2FyaWEtaGlkZGVuXSB8IC5pcy1oaWRkZW4pKVxuICAgIC5mZC10cmVlX19pdGVtXG4gICAgICAgIC5mZC10cmVlX19yb3crKC0taGVhZGVyLCAoW2FyaWEtc2VsZWN0ZWRdIHwgLmlzLXNlbGVjdGVkKSlcbiAgICAgICAgICAgIC5mZC10cmVlX19jb2wrKC0tY29udHJvbCwgLS1hY3Rpb25zKVxuICAgICAgICAgICAgICAgIC5mZC10cmVlX19jb250cm9sKyhbYXJpYS1wcmVzc2VkXSB8IC5pcy1wcmVzc2VkKVxuKi9cbiRibG9jazogbnModHJlZSk7XG5cbi4jeyRibG9ja30ge1xuICAgIC8vTE9DQUwgVkFSUyAoc2V0IGFsbCB0aGVtZWFibGUgcHJvcGVydGllcywgYWx3YXlzIGluY2x1ZGUgIWRlZmF1bHQpXG4gICAgJGZkLXRyZWUtYm9yZGVyLWNvbG9yOiBmZC1jb2xvcihuZXV0cmFsLCAzKSAhZGVmYXVsdDtcbiAgICAkZmQtdHJlZS1saW5rLWNvbG9yOiBmZC1jb2xvcihhY3Rpb24sIDEpICFkZWZhdWx0O1xuICAgICRmZC10cmVlLWNlbGwtc3BhY2luZzogJGZkLXdpZHRoLS1ndXR0ZXIgIWRlZmF1bHQ7XG4gICAgJGZkLXRyZWUtY2VsbC1wYWRkaW5nOiBmZC1zcGFjZSgzKSAhZGVmYXVsdDtcbiAgICAkZmQtdHJlZS1jb250cm9sLXdpZHRoOiAxOHB4ICFkZWZhdWx0O1xuICAgICRmZC10cmVlLWNvbnRyb2wtbWFyZ2luLXJpZ2h0OiBmZC1zcGFjZSgyKSAhZGVmYXVsdDtcbiAgICAkZmQtdHJlZS10cmFuc2l0aW9uLXBhcmFtczogJGZkLWFuaW1hdGlvbi0tc3BlZWQgZWFzZS1pbiAhZGVmYXVsdDtcblxuICAgIEBpbmNsdWRlIHJlc2V0O1xuICAgIEBpbmNsdWRlIGZkLWxhc3QtY2hpbGQ7XG4gICAgcG9zaXRpb246IHJlbGF0aXZlO1xuICAgIHdpZHRoOiAxMDAlO1xuICAgIG1heC13aWR0aDogMTAwJTtcbiAgICBib3JkZXItYm90dG9tOiBzb2xpZCAxcHggJGZkLXRyZWUtYm9yZGVyLWNvbG9yO1xuICAgIG1hcmdpbi1ib3R0b206ICRmZC1tYXJnaW4tYm90dG9tO1xuICAgIG1hcmdpbi1sZWZ0OiAwO1xuICAgICY6bGFzdC1jaGlsZCB7XG4gICAgICAgIG1hcmdpbi1ib3R0b206IDA7XG4gICAgfVxuICAgICYtLWhlYWRlciB7XG4gICAgICAgIGJvcmRlci1ib3R0b206IDA7XG4gICAgICAgIGJvcmRlci10b3A6IHNvbGlkIDFweCAkZmQtdHJlZS1ib3JkZXItY29sb3I7XG4gICAgICAgIG1hcmdpbi1ib3R0b206IDA7XG4gICAgfVxuICAgICZfX2dyb3VwIHtcbiAgICAgICAgLy9zZWUgYWRkdCdsIGdyb3VwIGNsYXNzZXMgdW5kZXIgX19jb2wtLWZpcnN0IGJlbG93XG4gICAgICAgIHRyYW5zaXRpb246IG9wYWNpdHkgJGZkLWFuaW1hdGlvbi0tc3BlZWQgbGluZWFyO1xuICAgICAgICBtYXgtaGVpZ2h0OiBhdXRvO1xuICAgICAgICBvcGFjaXR5OiAxO1xuICAgICAgICBtYXJnaW4tYm90dG9tOiAwO1xuICAgICAgICBtYXJnaW4tbGVmdDogMDtcbiAgICAgICAgJi5pcy1oaWRkZW4sXG4gICAgICAgICZbYXJpYS1oaWRkZW49XCJ0cnVlXCJdIHtcbiAgICAgICAgICAgIG1heC1oZWlnaHQ6IDA7XG4gICAgICAgICAgICBvcGFjaXR5OiAwO1xuICAgICAgICAgICAgb3ZlcmZsb3c6IGhpZGRlbjtcbiAgICAgICAgfVxuICAgIH1cbiAgICAmX19pdGVtIHtcbiAgICAgICAgYm9yZGVyLXRvcDogc29saWQgMXB4ICRmZC10cmVlLWJvcmRlci1jb2xvcjtcbiAgICAgICAgbWFyZ2luLWJvdHRvbTogMDtcbiAgICAgICAgbGlzdC1zdHlsZTogbm9uZTtcbiAgICB9XG4gICAgJl9fcm93IHtcbiAgICAgICAgcGFkZGluZzogMCAkZmQtdHJlZS1jZWxsLXNwYWNpbmc7XG4gICAgICAgIGRpc3BsYXk6IGZsZXg7XG4gICAgICAgIGFsaWduLWl0ZW1zOiBjZW50ZXI7XG4gICAgICAgIHBvc2l0aW9uOiByZWxhdGl2ZTtcbiAgICAgICAgdHJhbnNpdGlvbjogYmFja2dyb3VuZC1jb2xvciAkZmQtdHJlZS10cmFuc2l0aW9uLXBhcmFtcztcbiAgICAgICAgJjpob3ZlciB7XG4gICAgICAgICAgICBiYWNrZ3JvdW5kLWNvbG9yOiBsaWdodGVuKGZkLWNvbG9yKG5ldXRyYWwsIDMpLCAxMCk7XG4gICAgICAgIH1cbiAgICAgICAgJi0taGVhZGVyIHtcbiAgICAgICAgICAgIEBpbmNsdWRlIGZkLXR5cGUoLTEpO1xuICAgICAgICAgICAgQGluY2x1ZGUgZmQtd2VpZ2h0KGJvbGQpO1xuICAgICAgICAgICAgY29sb3I6IGZkLWNvbG9yKHRleHQsIDIpO1xuICAgICAgICAgICAgJjpob3ZlciB7XG4gICAgICAgICAgICAgICAgYmFja2dyb3VuZC1jb2xvcjogdHJhbnNwYXJlbnQ7XG4gICAgICAgICAgICB9XG4gICAgICAgIH1cbiAgICAgICAgJi5pcy1zZWxlY3RlZCxcbiAgICAgICAgJlthcmlhLXNlbGVjdGVkPVwidHJ1ZVwiXSB7XG4gICAgICAgICAgICBiYWNrZ3JvdW5kLWNvbG9yOiBsaWdodGVuKGZkLWNvbG9yKG5ldXRyYWwsIDMpLCA1KTtcbiAgICAgICAgfVxuICAgIH1cbiAgICAkX3Jvd19wYWRkaW5nOiAkZmQtdHJlZS1jb250cm9sLXdpZHRoICsgJGZkLXRyZWUtY29udHJvbC1tYXJnaW4tcmlnaHQgKyA0O1xuICAgICZfX2NvbCB7XG4gICAgICAgIGZsZXg6IDE7XG4gICAgICAgIHBhZGRpbmc6ICRmZC10cmVlLWNlbGwtcGFkZGluZyAwO1xuICAgICAgICAvL3BhZCB0byBhY2NvdW50IGZvciBjb250cm9sXG4gICAgICAgIHBhZGRpbmctbGVmdDogJF9yb3dfcGFkZGluZztcbiAgICAgICAgJi0tY29udHJvbCB7XG4gICAgICAgICAgICBmbGV4OiBhdXRvO1xuICAgICAgICAgICAgd2lkdGg6IDI1JTtcbiAgICAgICAgICAgIC8vc2V0cyA4IHN1YmxldmVscyBvZiBpbmRlbnRhdGlvbiBiYXNlZCBvbiBfX2dyb3VwIGxldmVsXG4gICAgICAgICAgICBAYXQtcm9vdCB7XG4gICAgICAgICAgICAgICAgQGVhY2ggJGkgaW4gMSwyLDMsNCw1LDYsNyw4IHtcbiAgICAgICAgICAgICAgICAgICAgLiN7JGJsb2NrfV9fZ3JvdXAtLXN1YmxldmVsLSN7JGl9ICYge1xuICAgICAgICAgICAgICAgICAgICAgICAgcGFkZGluZy1sZWZ0OiAkX3Jvd19wYWRkaW5nICogKCRpICsgMSk7XG4gICAgICAgICAgICAgICAgICAgIH1cbiAgICAgICAgICAgICAgICB9XG5cbiAgICAgICAgICAgIH1cbiAgICAgICAgfVxuICAgICAgICAmLS1hY3Rpb25zIHtcbiAgICAgICAgICAgIHBhZGRpbmctdG9wOiAwO1xuICAgICAgICAgICAgcGFkZGluZy1ib3R0b206IDA7XG4gICAgICAgICAgICB0ZXh0LWFsaWduOiByaWdodDtcbiAgICAgICAgfVxuICAgIH1cblxuICAgICZfX2NvbnRyb2wge1xuICAgICAgICBAaW5jbHVkZSBmZC1idXR0b24tcmVzZXQ7XG4gICAgICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICAgICAgdG9wOiBjYWxjKDUwJSAtICN7JGZkLXRyZWUtY29udHJvbC13aWR0aH0vMik7XG4gICAgICAgIG1hcmdpbi1sZWZ0OiAtI3skX3Jvd19wYWRkaW5nfTtcbiAgICAgICAgd2lkdGg6ICRmZC10cmVlLWNvbnRyb2wtd2lkdGg7XG4gICAgICAgIGhlaWdodDogJGZkLXRyZWUtY29udHJvbC13aWR0aDtcbiAgICAgICAgbWFyZ2luLXJpZ2h0OiBmZC1zcGFjZSgzKTtcbiAgICAgICAgYmFja2dyb3VuZDogdXJsKCRmZC1mb3Jtcy1zZWxlY3QtYmFja2dyb3VuZC1pbWFnZS0tYWN0aXZlKSBuby1yZXBlYXQgNTAlO1xuICAgICAgICBiYWNrZ3JvdW5kLXNpemU6IGNvbnRhaW47XG4gICAgICAgIHRyYW5zZm9ybTogcm90YXRlKC05MGRlZyk7XG4gICAgICAgIHZlcnRpY2FsLWFsaWduOiBtaWRkbGU7XG4gICAgICAgIHRyYW5zaXRpb246IHRyYW5zZm9ybSAkZmQtYW5pbWF0aW9uLS1zcGVlZCBsaW5lYXI7XG4gICAgICAgICZbYXJpYS1wcmVzc2VkPVwidHJ1ZVwiXSxcbiAgICAgICAgJi5pcy1wcmVzc2VkIHtcbiAgICAgICAgICAgIHRyYW5zZm9ybTogcm90YXRlKDApO1xuICAgICAgICB9XG4gICAgfVxuICAgIGEge1xuICAgICAgICBjb2xvcjogJGZkLXRyZWUtbGluay1jb2xvcjtcbiAgICAgICAgJjpob3ZlcntcbiAgICAgICAgICAgIGNvbG9yOiAkZmQtdHJlZS1saW5rLWNvbG9yO1xuICAgICAgICB9XG4gICAgfVxuXG59XG4iLCJAaW1wb3J0IFwiLi4vY29yZS9zZXR0aW5nc1wiO1xuQGltcG9ydCBcIi4uL2NvcmUvbWl4aW5zXCI7XG5AaW1wb3J0IFwiLi4vY29yZS9mdW5jdGlvbnNcIjtcbkBpbXBvcnQgXCIuLi9jb21wb25lbnRzL21peGluc1wiO1xuXG4vKiFcbi5mZC1saXN0LWdyb3VwXG4gIC5mZC1saXN0LWdyb3VwX19pdGVtXG4gICAgICAuZmQtbGlzdC1ncm91cF9fYWN0aW9uXG4qL1xuJGJsb2NrOiBucyhsaXN0LWdyb3VwKTtcblxuLiN7JGJsb2NrfSB7XG4gICAgLy9MT0NBTCBWQVJTIChzZXQgYWxsIHZhcnMgdXNlZCBpbiBjb21wb25lbnQsIGFsd2F5cyBpbmNsdWRlICFkZWZhdWx0KVxuICAgICRmZC1saXN0LWdyb3VwLWJvcmRlci1jb2xvcjogbGlnaHRlbihmZC1jb2xvcihuZXV0cmFsLCAyKSwgNSUpICFkZWZhdWx0O1xuICAgICRmZC1saXN0LWdyb3VwLWJhY2tncm91bmQtY29sb3I6IG5vbmUgIWRlZmF1bHQ7XG4gICAgJGZkLWxpc3QtZ3JvdXAtYmFja2dyb3VuZC1jb2xvci0taG92ZXI6IGxpZ2h0ZW4oZmQtY29sb3IobmV1dHJhbCwgMyksIDEwKSAhZGVmYXVsdDtcbiAgICAkZmQtbGlzdC1ncm91cC1pdGVtLXBhZGRpbmc6IGZkLXNwYWNlKDQpICFkZWZhdWx0O1xuICAgICRmZC1saXN0LWdyb3VwLWFjdGlvbi1oZWlnaHQ6IGZkLXNwYWNlKDEwKSAhZGVmYXVsdDtcbiAgICAkZmQtbGlzdC1ncm91cC10cmFuc2l0aW9uLXBhcmFtczogJGZkLWFuaW1hdGlvbi0tc3BlZWQgZWFzZS1pbiAhZGVmYXVsdDtcblxuICAgIEBpbmNsdWRlIHJlc2V0O1xuXG4gICAgbWFyZ2luLWxlZnQ6IDA7XG4gICAgJl9faXRlbSB7XG4gICAgICAgIGxpc3Qtc3R5bGU6IG5vbmU7XG4gICAgICAgIGJvcmRlcjogMXB4IHNvbGlkICRmZC1saXN0LWdyb3VwLWJvcmRlci1jb2xvcjtcbiAgICAgICAgYm9yZGVyLXRvcDogbm9uZTtcbiAgICAgICAgcGFkZGluZzogJGZkLWxpc3QtZ3JvdXAtaXRlbS1wYWRkaW5nO1xuICAgICAgICBkaXNwbGF5OiBmbGV4O1xuICAgICAgICBwb3NpdGlvbjogcmVsYXRpdmU7XG4gICAgICAgIGJhY2tncm91bmQtY29sb3I6ICRmZC1saXN0LWdyb3VwLWJhY2tncm91bmQtY29sb3I7XG4gICAgICAgIHRyYW5zaXRpb246IGJhY2tncm91bmQtY29sb3IgJGZkLWxpc3QtZ3JvdXAtdHJhbnNpdGlvbi1wYXJhbXM7XG4gICAgICAgICY6Zmlyc3QtY2hpbGQge1xuICAgICAgICAgICAgYm9yZGVyLXRvcDogMXB4IHNvbGlkICRmZC1saXN0LWdyb3VwLWJvcmRlci1jb2xvcjtcbiAgICAgICAgfVxuICAgICAgICAmOmhvdmVye1xuICAgICAgICAgICAgYmFja2dyb3VuZC1jb2xvcjogJGZkLWxpc3QtZ3JvdXAtYmFja2dyb3VuZC1jb2xvci0taG92ZXI7XG4gICAgICAgIH1cbiAgICB9XG4gICAgJl9fYWN0aW9uIHtcbiAgICAgICAgZmxleDogMTtcbiAgICAgICAgdGV4dC1hbGlnbjogcmlnaHQ7XG4gICAgICAgIHBvc2l0aW9uOiByZWxhdGl2ZTtcbiAgICAgICAgZGlzcGxheTogaW5saW5lLWJsb2NrO1xuICAgICAgICBtYXgtaGVpZ2h0OiAkZmQtbGlzdC1ncm91cC1hY3Rpb24taGVpZ2h0O1xuICAgICAgICBwYWRkaW5nLXRvcDogZmQtc3BhY2UoYmFzZSk7XG4gICAgICAgIHRvcDogLSRmZC1saXN0LWdyb3VwLWl0ZW0tcGFkZGluZztcbiAgICAgICAgbWFyZ2luLWJvdHRvbTogLSRmZC1saXN0LWdyb3VwLWl0ZW0tcGFkZGluZyAqIDI7XG4gICAgICAgIHJpZ2h0OiAtJGZkLWxpc3QtZ3JvdXAtaXRlbS1wYWRkaW5nO1xuICAgIH1cbn1cbiIsIkBpbXBvcnQgXCIuLi9jb3JlL3NldHRpbmdzXCI7XG5AaW1wb3J0IFwiLi4vY29yZS9taXhpbnNcIjtcbkBpbXBvcnQgXCIuLi9jb3JlL2Z1bmN0aW9uc1wiO1xuXG4vKiFcbi5mZC10b29sdGlwXG4gICAgLmZkLXRvb2x0aXBfX2NvbnRlbnQrKGxlZnQsIHJpZ2h0LCBib3R0b20tbGVmdCwgYm90dG9tLXJpZ2h0KVxuKi9cbiRibG9jazogbnMoaW5saW5lLWhlbHApO1xuXG4uI3skYmxvY2t9IHtcblxuICAgIC8vTE9DQUwgVkFSUyAoc2V0IGFsbCB0aGVtZWFibGUgcHJvcGVydGllcywgYWx3YXlzIGluY2x1ZGUgIWRlZmF1bHQpXG4gICAgJGZkLXRvb2x0aXAtY29udGVudC1iYWNrZ3JvdW5kLWNvbG9yOiBmZC1jb2xvcih0ZXh0LCAzKSAhZGVmYXVsdDtcbiAgICAkZmQtdG9vbHRpcC1jb250ZW50LWNvbG9yOiBmZC1jb2xvcih0ZXh0LWludmVyc2UsIDEpICFkZWZhdWx0O1xuICAgICRmZC10b29sdGlwLXBhZGRpbmc6IGZkLXNwYWNlKHMpICFkZWZhdWx0O1xuICAgICRmZC10b29sdGlwLWFycm93LW9mZnNldDogKGZkLXNwYWNlKHMpKSAtIDIgIWRlZmF1bHQgO1xuICAgICRmZC10b29sdGlwLWFycm93LXdpZHRoOiAkZmQtdG9vbHRpcC1hcnJvdy1vZmZzZXQgIWRlZmF1bHQ7XG4gICAgJGZkLXRvb2x0aXAtaWNvbi1zaXplOiAxOHB4O1xuICAgICRmZC10b29sdGlwLXRyYW5zaXRpb24tcGFyYW1zOiAkZmQtYW5pbWF0aW9uLS1zcGVlZCBlYXNlLWluICFkZWZhdWx0O1xuICAgICRmZC10b29sdGlwLW1pbi13aWR0aDogMzUwcHg7XG5cbiAgICAvL0JMT0NLIEJBU0UgKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKlxuICAgIEBpbmNsdWRlIGZkLXR5cGUoLTEpO1xuICAgIHBvc2l0aW9uOiByZWxhdGl2ZTtcbiAgICAvL21hcmdpbi1sZWZ0OiBmZC1zcGFjZSh4cyk7XG4gICAgZGlzcGxheTogaW5saW5lLWJsb2NrO1xuICAgIHdpZHRoOiAkZmQtdG9vbHRpcC1pY29uLXNpemU7XG4gICAgaGVpZ2h0OiAkZmQtdG9vbHRpcC1pY29uLXNpemU7XG4gICAgdG9wOiAzcHg7XG5cbiAgICAmOjpiZWZvcmUge1xuICAgICAgICBjb250ZW50OiBcIj9cIjtcbiAgICAgICAgd2lkdGg6ICRmZC10b29sdGlwLWljb24tc2l6ZTtcbiAgICAgICAgaGVpZ2h0OiAkZmQtdG9vbHRpcC1pY29uLXNpemU7XG4gICAgICAgIGZvbnQtc3R5bGU6IG5vcm1hbDtcbiAgICAgICAgcG9zaXRpb246IGFic29sdXRlO1xuICAgICAgICBsZWZ0OiAwO1xuICAgICAgICBjb2xvcjogZmQtY29sb3IodGV4dC1pbnZlcnNlKTtcbiAgICAgICAgYm9yZGVyLXJhZGl1czogNTAlO1xuICAgICAgICBiYWNrZ3JvdW5kLWNvbG9yOiBmZC1jb2xvcih0ZXh0LCAzKTtcbiAgICAgICAgdGV4dC1hbGlnbjogY2VudGVyO1xuICAgIH1cblxuICAgIC8vRUxFTUVOVFMgKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKlxuICAgICZfX2NvbnRlbnQge1xuICAgICAgICBAaW5jbHVkZSBmZC10eXBlKC0yKVxuICAgICAgICBiYWNrZ3JvdW5kOiAkZmQtdG9vbHRpcC1jb250ZW50LWJhY2tncm91bmQtY29sb3I7XG4gICAgICAgIHBhZGRpbmc6ICRmZC10b29sdGlwLXBhZGRpbmc7XG4gICAgICAgIGRpc3BsYXk6IGJsb2NrO1xuICAgICAgICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gICAgICAgIGNvbG9yOiAkZmQtdG9vbHRpcC1jb250ZW50LWNvbG9yO1xuICAgICAgICB0b3A6ICRmZC10b29sdGlwLXBhZGRpbmcgKiAyLjU7XG4gICAgICAgIHJpZ2h0OiAtJGZkLXRvb2x0aXAtcGFkZGluZztcbiAgICAgICAgbWluLXdpZHRoOiAkZmQtdG9vbHRpcC1taW4td2lkdGg7XG4gICAgICAgIHZpc2liaWxpdHk6IGhpZGRlbjtcbiAgICAgICAgb3BhY2l0eTogMDtcbiAgICAgICAgdHJhbnNpdGlvbjogb3BhY2l0eSAkZmQtdG9vbHRpcC10cmFuc2l0aW9uLXBhcmFtcztcbiAgICAgICAgdGV4dC1hbGlnbjogbGVmdDtcbiAgICAgICAgei1pbmRleDogMTtcbiAgICAgICAgJjo6YmVmb3JlIHtcbiAgICAgICAgICAgIHdpZHRoOiAwO1xuICAgICAgICAgICAgaGVpZ2h0OiAwO1xuICAgICAgICAgICAgYm9yZGVyLXN0eWxlOiBzb2xpZDtcbiAgICAgICAgICAgIGJvcmRlci13aWR0aDogMCAkZmQtdG9vbHRpcC1hcnJvdy13aWR0aCAkZmQtdG9vbHRpcC1hcnJvdy13aWR0aCAkZmQtdG9vbHRpcC1hcnJvdy13aWR0aDtcbiAgICAgICAgICAgIGJvcmRlci1jb2xvcjogdHJhbnNwYXJlbnQgdHJhbnNwYXJlbnQgJGZkLXRvb2x0aXAtY29udGVudC1iYWNrZ3JvdW5kLWNvbG9yIHRyYW5zcGFyZW50O1xuICAgICAgICAgICAgcG9zaXRpb246IGFic29sdXRlO1xuICAgICAgICAgICAgY29udGVudDogXCJcIjtcbiAgICAgICAgICAgIHRvcDogLSgkZmQtdG9vbHRpcC1hcnJvdy1vZmZzZXQpO1xuICAgICAgICAgICAgcmlnaHQ6ICRmZC10b29sdGlwLWFycm93LW9mZnNldDtcbiAgICAgICAgfVxuICAgICAgICAmLS1sZWZ0e1xuICAgICAgICAgICAgdG9wOiAtJGZkLXRvb2x0aXAtcGFkZGluZztcbiAgICAgICAgICAgIGxlZnQ6ICRmZC10b29sdGlwLXBhZGRpbmcgKiAyLjU7XG4gICAgICAgICAgICAmOjpiZWZvcmV7XG4gICAgICAgICAgICAgICAgdG9wOiAkZmQtdG9vbHRpcC1hcnJvdy1vZmZzZXQgKyA1O1xuICAgICAgICAgICAgICAgIGxlZnQ6IC0oJGZkLXRvb2x0aXAtYXJyb3ctb2Zmc2V0ICsgNSk7XG4gICAgICAgICAgICAgICAgdHJhbnNmb3JtOiByb3RhdGUoLTkwZGVnKTtcbiAgICAgICAgICAgIH1cbiAgICAgICAgfVxuICAgICAgICAmLS1yaWdodHtcbiAgICAgICAgICAgIHRvcDogLSRmZC10b29sdGlwLXBhZGRpbmc7XG4gICAgICAgICAgICByaWdodDogJGZkLXRvb2x0aXAtcGFkZGluZyAqIDIuNTtcbiAgICAgICAgICAgICY6OmJlZm9yZXtcbiAgICAgICAgICAgICAgICB0b3A6ICRmZC10b29sdGlwLWFycm93LW9mZnNldCArIDU7XG4gICAgICAgICAgICAgICAgcmlnaHQ6IC0oJGZkLXRvb2x0aXAtYXJyb3ctb2Zmc2V0ICsgNSk7XG4gICAgICAgICAgICAgICAgdHJhbnNmb3JtOiByb3RhdGUoOTBkZWcpO1xuICAgICAgICAgICAgfVxuICAgICAgICB9XG4gICAgICAgICYtLWJvdHRvbS1sZWZ0e1xuICAgICAgICAgICAgbGVmdDogLSRmZC10b29sdGlwLWFycm93LW9mZnNldDtcbiAgICAgICAgICAgICY6OmJlZm9yZXtcbiAgICAgICAgICAgICAgICB0b3A6IC0oJGZkLXRvb2x0aXAtYXJyb3ctb2Zmc2V0KTtcbiAgICAgICAgICAgICAgICBsZWZ0OiAkZmQtdG9vbHRpcC1hcnJvdy1vZmZzZXQ7XG4gICAgICAgICAgICB9XG4gICAgICAgIH1cbiAgICB9XG4gICAgJjpob3ZlcntcbiAgICAgICAgLiN7JGJsb2NrfV9fY29udGVudHtcbiAgICAgICAgICAgIHZpc2liaWxpdHk6IHZpc2libGU7XG4gICAgICAgICAgICBvcGFjaXR5OiAxO1xuICAgICAgICAgICAgb3ZlcmZsb3c6IHZpc2libGU7XG4gICAgICAgIH1cbiAgICB9XG59XG4iLCJAaW1wb3J0IFwiLi4vY29yZS9zZXR0aW5nc1wiO1xuQGltcG9ydCBcIi4uL2NvcmUvbWl4aW5zXCI7XG5AaW1wb3J0IFwiLi4vY29yZS9mdW5jdGlvbnNcIjtcblxuLyohXG4uZmQtbmF2KygtLXZlcnRpY2FsKVxuICAgIC5mZC1uYXZfX2l0ZW1cbiAgICAuZmQtbmF2X19saW5rKygoLmlzLXNlbGVjdGVkfFthcmlhLXNlbGVjdGVkPXRydWVdKSwoLmlzLWRpc2FibGVkfFthcmlhLWRpc2FibGVkPXRydWVdKSlcbiovXG4kYmxvY2s6IG5zKG5hdik7XG5cbi4jeyRibG9ja30ge1xuICAgICRmZC1uYXYtbGluay1wYWRkaW5nOiBmZC1zcGFjZSgyKTtcbiAgICBAaW5jbHVkZSByZXNldDtcbiAgICBkaXNwbGF5OiBmbGV4O1xuICAgIGZsZXgtd3JhcDogd3JhcDtcbiAgICBwYWRkaW5nLWxlZnQ6IDA7XG4gICAgbWFyZ2luLWJvdHRvbTogMDtcbiAgICBsaXN0LXN0eWxlOiBub25lO1xuICAgIC8vTU9ESUZJRVJTICoqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKipcbiAgICAmLS12ZXJ0aWNhbCB7XG4gICAgICAgIGZsZXgtZGlyZWN0aW9uOiBjb2x1bW47XG4gICAgfVxuXG4gICAgLy9FTEVNRU5UUyAqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqXG4gICAgJl9faXRlbSB7XG5cbiAgICB9XG4gICAgJl9fbGluayB7XG4gICAgICAgIGRpc3BsYXk6IGJsb2NrO1xuICAgICAgICBwYWRkaW5nOiAkZmQtbmF2LWxpbmstcGFkZGluZztcbiAgICAgICAgJi5pcy1zZWxlY3RlZCxcbiAgICAgICAgJlthcmlhLXNlbGVjdGVkPVwidHJ1ZVwiXSB7XG4gICAgICAgICAgICBjb2xvcjogJGZkLWNvbG9yO1xuICAgICAgICB9XG4gICAgfVxuXG59XG4iLCJAaW1wb3J0IFwiLi4vY29yZS9zZXR0aW5nc1wiO1xuQGltcG9ydCBcIi4uL2NvcmUvbWl4aW5zXCI7XG5AaW1wb3J0IFwiLi4vY29yZS9mdW5jdGlvbnNcIjtcblxuLyohXG4uZmQtdG9nZ2xlKygtLW5vLWJvcmRlcilcbiAgICAuZmQtdG9nZ2xlX19jb250ZW50KygpXG4gICAgLmZkLXRvZ2dsZV9fdGl0bGUrKClcbiovXG4kYmxvY2s6IG5zKHRvZ2dsZSk7XG5cbi4jeyRibG9ja30ge1xuICAgIC8vTE9DQUwgVkFSUyAoc2V0IGFsbCB0aGVtZWFibGUgcHJvcGVydGllcywgYWx3YXlzIGluY2x1ZGUgIWRlZmF1bHQpXG4gICAgJGZkLXRvZ2dsZS1oZWlnaHQ6IGZkLXNwYWNlKDEwKSAhZGVmYXVsdDtcbiAgICAkZmQtdG9nZ2xlLWhlaWdodC0tc21hbGw6IGZkLXNwYWNlKDgpICFkZWZhdWx0O1xuICAgICRmZC10b2dnbGUtaGVpZ2h0LS1sYXJnZTogZmQtc3BhY2UoMTMpICFkZWZhdWx0O1xuICAgICRmZC10b2dnbGUtYmFja2dyb3VuZC1jb2xvcjogJGZkLWZvcm1zLWJvcmRlci1jb2xvciAhZGVmYXVsdDtcbiAgICAkZmQtdG9nZ2xlLWJhY2tncm91bmQtY29sb3ItLWNoZWNrZWQ6ICRmZC1mb3Jtcy1iYWNrZ3JvdW5kLWNvbG9yLS1jaGVjayAhZGVmYXVsdDtcbiAgICAkZmQtdG9nZ2xlLXN3aXRjaC1iYWNrZ3JvdW5kLWNvbG9yOiBmZC1jb2xvcihiYWNrZ3JvdW5kLCAxKSAhZGVmYXVsdDtcbiAgICAkZmQtdG9nZ2xlLXN3aXRjaC1iYWNrZ3JvdW5kLWNvbG9yLS1kaXNhYmxlZDogZmQtY29sb3IobmV1dHJhbCwgMikgIWRlZmF1bHQ7XG4gICAgJGZkLXRvZ2dsZS10cmFuc2l0aW9uLXBhcmFtczogJGZkLWFuaW1hdGlvbi0tc3BlZWQgZWFzZS1pbiAhZGVmYXVsdDtcblxuICAgIEBpbmNsdWRlIHJlc2V0O1xuICAgIHBvc2l0aW9uOiByZWxhdGl2ZTtcbiAgICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gICAgaGVpZ2h0OiAkZmQtdG9nZ2xlLWhlaWdodDtcbiAgICB3aWR0aDogJGZkLXRvZ2dsZS1oZWlnaHQgKiAyIC0gNHB4O1xuICAgICZfX3N3aXRjaCB7XG4gICAgICAgIGhlaWdodDogJGZkLXRvZ2dsZS1oZWlnaHQgLSA4cHg7XG4gICAgICAgIHdpZHRoOiAkZmQtdG9nZ2xlLWhlaWdodCAtIDhweDtcbiAgICAgICAgYm9yZGVyLXJhZGl1czogNTAlO1xuICAgICAgICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gICAgICAgIHRvcDogNHB4O1xuICAgICAgICBsZWZ0OiA0cHg7XG4gICAgICAgIGJhY2tncm91bmQtY29sb3I6IHdoaXRlO1xuICAgICAgICB0cmFuc2l0aW9uOiBsZWZ0ICRmZC10b2dnbGUtdHJhbnNpdGlvbi1wYXJhbXM7XG4gICAgICAgIHBvaW50ZXItZXZlbnRzOiBub25lO1xuICAgIH1cbiAgICBpbnB1dCB7XG4gICAgICAgIGJhY2tncm91bmQtY29sb3I6ICRmZC10b2dnbGUtYmFja2dyb3VuZC1jb2xvcjtcbiAgICAgICAgYm9yZGVyLXJhZGl1czogJGZkLXRvZ2dsZS1oZWlnaHQvMjtcbiAgICAgICAgd2lkdGg6IDEwMCU7XG4gICAgICAgIGhlaWdodDogMTAwJTtcbiAgICAgICAgYm9yZGVyLWNvbG9yOiB0cmFuc3BhcmVudDtcbiAgICAgICAgdmVydGljYWwtYWxpZ246IG1pZGRsZTtcbiAgICAgICAgJjpjaGVja2VkIHtcbiAgICAgICAgICAgICY6OmFmdGVyIHtcbiAgICAgICAgICAgICAgICBkaXNwbGF5OiBub25lO1xuICAgICAgICAgICAgfVxuICAgICAgICAgICAgJiArIC4jeyRibG9ja31fX3N3aXRjaCB7XG4gICAgICAgICAgICAgICAgbGVmdDogY2FsYyg1MCUgKyAycHgpO1xuICAgICAgICAgICAgfVxuICAgICAgICB9XG4gICAgICAgICZbZGlzYWJsZWRdLFxuICAgICAgICAmLmlzLWRpc2FibGVkLFxuICAgICAgICAmW2FyaWEtZGlzYWJsZWQ9XCJ0cnVlXCJdIHtcbiAgICAgICAgICAgIGJvcmRlci1jb2xvcjogJGZkLWZvcm1zLWJvcmRlci1jb2xvcjtcbiAgICAgICAgICAgICYgKyAuI3skYmxvY2t9X19zd2l0Y2gge1xuICAgICAgICAgICAgICAgIGJhY2tncm91bmQtY29sb3I6ICRmZC10b2dnbGUtc3dpdGNoLWJhY2tncm91bmQtY29sb3ItLWRpc2FibGVkO1xuICAgICAgICAgICAgfVxuICAgICAgICB9XG4gICAgfVxuICAgICYtLXNtYWxsIHtcbiAgICAgICAgaGVpZ2h0OiAkZmQtdG9nZ2xlLWhlaWdodC0tc21hbGw7XG4gICAgICAgIHdpZHRoOiAkZmQtdG9nZ2xlLWhlaWdodC0tc21hbGwgKiAyIC0gNHB4O1xuICAgICAgICBpbnB1dCB7XG4gICAgICAgICAgICBib3JkZXItcmFkaXVzOiAkZmQtdG9nZ2xlLWhlaWdodC0tc21hbGwvMjtcbiAgICAgICAgfVxuICAgICAgICAuI3skYmxvY2t9X19zd2l0Y2gge1xuICAgICAgICAgICAgaGVpZ2h0OiAkZmQtdG9nZ2xlLWhlaWdodC0tc21hbGwgLSA4cHg7XG4gICAgICAgICAgICB3aWR0aDogJGZkLXRvZ2dsZS1oZWlnaHQtLXNtYWxsIC0gOHB4O1xuICAgICAgICB9XG4gICAgfVxuICAgICYtLWxhcmdlIHtcbiAgICAgICAgaGVpZ2h0OiAkZmQtdG9nZ2xlLWhlaWdodC0tbGFyZ2U7XG4gICAgICAgIHdpZHRoOiAkZmQtdG9nZ2xlLWhlaWdodC0tbGFyZ2UgKiAyIC0gNHB4O1xuICAgICAgICBpbnB1dCB7XG4gICAgICAgICAgICBib3JkZXItcmFkaXVzOiAkZmQtdG9nZ2xlLWhlaWdodC0tbGFyZ2UvMjtcbiAgICAgICAgfVxuICAgICAgICAuI3skYmxvY2t9X19zd2l0Y2gge1xuICAgICAgICAgICAgaGVpZ2h0OiAkZmQtdG9nZ2xlLWhlaWdodC0tbGFyZ2UgLSA4cHg7XG4gICAgICAgICAgICB3aWR0aDogJGZkLXRvZ2dsZS1oZWlnaHQtLWxhcmdlIC0gOHB4O1xuICAgICAgICB9XG4gICAgfVxuXG5cblxuXG59XG4iLCJAaW1wb3J0IFwiLi4vY29yZS9zZXR0aW5nc1wiO1xuQGltcG9ydCBcIi4uL2NvcmUvbWl4aW5zXCI7XG5AaW1wb3J0IFwiLi4vY29yZS9mdW5jdGlvbnNcIjtcblxuLyohXG4uZmQtc3Bpbm5lcisoLmlzLWhpZGRlbnxbYXJpYS1oaWRkZW49dHJ1ZV0pXG5cbkluc3BpcmVkIGJ5IGxpbmUgc2NhbGUgc3Bpbm5lciBmcm9tIExvYWQgQXdlc29tZSB2MS4xLjAgKGh0dHA6Ly9naXRodWIuZGFuaWVsY2FyZG9zby5uZXQvbG9hZC1hd2Vzb21lLylcbiogQ29weXJpZ2h0IDIwMTUgRGFuaWVsIENhcmRvc28gPEBEYW5pZWxDYXJkb3NvPlxuKiBMaWNlbnNlZCB1bmRlciBNSVRcbiovXG4kYmxvY2s6IG5zKHNwaW5uZXIpO1xuXG4uI3skYmxvY2t9IHtcbiAgICAvL0xPQ0FMIFZBUlMgKHNldCBhbGwgdGhlbWVhYmxlIHByb3BlcnRpZXMsIGFsd2F5cyBpbmNsdWRlICFkZWZhdWx0KVxuICAgICRmZC1zcGlubmVyLWJhY2tncm91bmQtY29sb3I6IGZkLWNvbG9yKGFjdGlvbiwgMSkgIWRlZmF1bHQ7XG4gICAgJGZkLXNwaW5uZXItaGVpZ2h0OiA0MHB4ICFkZWZhdWx0O1xuICAgICRmZC1zcGlubmVyLXdpZHRoLS1iYXI6IDVweCAhZGVmYXVsdDtcbiAgICAkZmQtc3Bpbm5lci13aWR0aC0tZ3V0dGVyOiAzcHggIWRlZmF1bHQ7XG4gICAgJGZkLXNwaW5uZXItYW5pbWF0aW9uLXNwZWVkOiAxcyAhZGVmYXVsdDtcbiAgICAkZmQtc3Bpbm5lci1iYWNrZHJvcC1iYWNrZ3JvdW5kLWNvbG9yOiByZ2JhKGZkLWNvbG9yKGJhY2tncm91bmQsIDEpLDAuOTUpICFkZWZhdWx0O1xuXG4gICAgLy9CTE9DSyBCQVNFICoqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKipcbiAgICAvL3NldCBhbGwgQkxPQ0sgcmVzZXQgYW5kIGJhc2VsaW5lIHN0eWxlc1xuXG4gICAgJF93aWR0aDogJGZkLXNwaW5uZXItd2lkdGgtLWJhcio0ICsgJGZkLXNwaW5uZXItd2lkdGgtLWd1dHRlciozO1xuICAgICRfaGVpZ2h0OiAkZmQtc3Bpbm5lci1oZWlnaHQ7XG5cbiAgICBwb3NpdGlvbjogcmVsYXRpdmU7XG4gICAgd2lkdGg6ICRfd2lkdGg7XG4gICAgaGVpZ2h0OiAkX2hlaWdodDtcbiAgICBkaXNwbGF5OiBmbGV4O1xuICAgIGp1c3RpZnktY29udGVudDogc3BhY2UtYmV0d2VlbjtcbiAgICBtYXJnaW46IDAgYXV0bztcblxuICAgICYuaXMtaGlkZGVuLFxuICAgICZbYXJpYS1oaWRkZW49XCJ0cnVlXCJdIHtcbiAgICAgICAgZGlzcGxheTogbm9uZTtcbiAgICB9XG5cbiAgICAvL3RoaXMgaXMgdGhlIG9ubHkgZ2xvYmFsbHktYXBwbGllZCBpbnN0YW5jZSBvZiBhcmlhIGFuZCBzdGF0ZSBjbGFzc2VzLCBtYXkgd2FudCB0byByZXRoaW5rIHRoaXMsIG1heWJlIHJlcXVpcmUgYSBjbGFzcyBsaWtlIC5mZC1zcGlubmVyLWJhY2tkcm9wIHRvIGJlIHVzZWQgaW4gY29uanVuY3Rpb24gd2l0aCB0aGUgc3RhdGVcbiAgICBAYXQtcm9vdCB7XG4gICAgICAgIC5pcy1idXN5LFxuICAgICAgICBbYXJpYS1idXN5PVwidHJ1ZVwiXSB7XG4gICAgICAgICAgICBwb3NpdGlvbjogcmVsYXRpdmU7XG4gICAgICAgICAgICBtaW4taGVpZ2h0OiAkX2hlaWdodDtcbiAgICAgICAgICAgICY6OmJlZm9yZSB7XG4gICAgICAgICAgICAgICAgcG9zaXRpb246IGFic29sdXRlO1xuICAgICAgICAgICAgICAgIGJhY2tncm91bmQtY29sb3I6ICRmZC1zcGlubmVyLWJhY2tkcm9wLWJhY2tncm91bmQtY29sb3I7XG4gICAgICAgICAgICAgICAgdG9wOiAwO1xuICAgICAgICAgICAgICAgIHJpZ2h0OiAwO1xuICAgICAgICAgICAgICAgIGJvdHRvbTogMDtcbiAgICAgICAgICAgICAgICBsZWZ0OiAwO1xuICAgICAgICAgICAgICAgIHotaW5kZXg6IDE7XG4gICAgICAgICAgICAgICAgY29udGVudDogXCJcIjtcbiAgICAgICAgICAgIH1cbiAgICAgICAgICAgIC4jeyRibG9ja30ge1xuICAgICAgICAgICAgICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICAgICAgICAgICAgICB6LWluZGV4OiAyO1xuICAgICAgICAgICAgICAgIGxlZnQ6IGNhbGMoNTAlIC0gI3skX3dpZHRofS8yKTtcbiAgICAgICAgICAgICAgICB0b3A6IGNhbGMoNTAlIC0gI3skX2hlaWdodH0vMik7XG4gICAgICAgICAgICB9XG4gICAgICAgIH1cbiAgICB9XG5cbiAgICAmOjpiZWZvcmUsXG4gICAgJjo6YWZ0ZXIge1xuICAgICAgICBjb250ZW50OiBcIlwiO1xuICAgICAgICBwb3NpdGlvbjogcmVsYXRpdmU7XG4gICAgICAgIHdpZHRoOiAkZmQtc3Bpbm5lci13aWR0aC0tYmFyO1xuICAgICAgICBoZWlnaHQ6IDEwMCU7XG4gICAgICAgIGJhY2tncm91bmQtY29sb3I6ICRmZC1zcGlubmVyLWJhY2tncm91bmQtY29sb3I7XG4gICAgfVxuICAgIGRpdiB7XG4gICAgICAgICY6OmJlZm9yZSxcbiAgICAgICAgJjo6YWZ0ZXIge1xuICAgICAgICAgICAgY29udGVudDogXCJcIjtcbiAgICAgICAgICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICAgICAgICAgIHdpZHRoOiAkZmQtc3Bpbm5lci13aWR0aC0tYmFyO1xuICAgICAgICAgICAgaGVpZ2h0OiAxMDAlO1xuICAgICAgICAgICAgYmFja2dyb3VuZC1jb2xvcjogJGZkLXNwaW5uZXItYmFja2dyb3VuZC1jb2xvcjtcbiAgICAgICAgfVxuICAgICAgICAmOjpiZWZvcmUge1xuICAgICAgICAgICAgbGVmdDogJGZkLXNwaW5uZXItd2lkdGgtLWJhciArICRmZC1zcGlubmVyLXdpZHRoLS1ndXR0ZXI7XG4gICAgICAgIH1cbiAgICAgICAgJjo6YWZ0ZXIge1xuICAgICAgICAgICAgcmlnaHQ6ICRmZC1zcGlubmVyLXdpZHRoLS1iYXIgKyAkZmQtc3Bpbm5lci13aWR0aC0tZ3V0dGVyO1xuICAgICAgICB9XG4gICAgfVxuXG4gICAgLy8xXG4gICAgJjo6YmVmb3JlIHtcbiAgICAgICAgYW5pbWF0aW9uOiBsaW5lLXNjYWxlICRmZC1zcGlubmVyLWFuaW1hdGlvbi1zcGVlZCBpbmZpbml0ZSBlYXNlO1xuICAgICAgICBhbmltYXRpb24tZGVsYXk6IC0oJGZkLXNwaW5uZXItYW5pbWF0aW9uLXNwZWVkKTtcbiAgICB9XG4gICAgZGl2IHtcbiAgICAgICAgLy8yXG4gICAgICAgICY6OmJlZm9yZSB7XG4gICAgICAgICAgICBhbmltYXRpb246IGxpbmUtc2NhbGUgJGZkLXNwaW5uZXItYW5pbWF0aW9uLXNwZWVkIGluZmluaXRlIGVhc2U7XG4gICAgICAgICAgICBhbmltYXRpb24tZGVsYXk6IC0oJGZkLXNwaW5uZXItYW5pbWF0aW9uLXNwZWVkIC0gLjFzKTtcbiAgICAgICAgfVxuICAgICAgICAvLzNcbiAgICAgICAgJjo6YWZ0ZXIge1xuICAgICAgICAgICAgYW5pbWF0aW9uOiBsaW5lLXNjYWxlICRmZC1zcGlubmVyLWFuaW1hdGlvbi1zcGVlZCBpbmZpbml0ZSBlYXNlO1xuICAgICAgICAgICAgYW5pbWF0aW9uLWRlbGF5OiAtKCRmZC1zcGlubmVyLWFuaW1hdGlvbi1zcGVlZCAtIC4ycyk7XG4gICAgICAgIH1cbiAgICB9XG4gICAgLy80XG4gICAgJjo6YWZ0ZXIge1xuICAgICAgICBhbmltYXRpb246IGxpbmUtc2NhbGUgJGZkLXNwaW5uZXItYW5pbWF0aW9uLXNwZWVkIGluZmluaXRlIGVhc2U7XG4gICAgICAgIGFuaW1hdGlvbi1kZWxheTogLSgkZmQtc3Bpbm5lci1hbmltYXRpb24tc3BlZWQgLSAuM3MpO1xuICAgIH1cblxufVxuXG5Aa2V5ZnJhbWVzIGxpbmUtc2NhbGUge1xuICAgIDAlLFxuICAgIDQwJSxcbiAgICAxMDAlIHtcbiAgICAgICAgdHJhbnNmb3JtOiBzY2FsZVkoLjQpO1xuICAgIH1cbiAgICA4MCUge1xuICAgICAgICB0cmFuc2Zvcm06IHNjYWxlWSgxKTtcbiAgICB9XG59XG4iLCJAaW1wb3J0IFwiLi4vY29yZS9zZXR0aW5nc1wiO1xuQGltcG9ydCBcIi4uL2NvcmUvbWl4aW5zXCI7XG5AaW1wb3J0IFwiLi4vY29yZS9mdW5jdGlvbnNcIjtcblxuLyohXG4uZmQtaW1hZ2UrKCgtLXJvdW5kZWR8LS1jaXJjbGUpLCAoLS14c3wtLXN8LS1tfC0tbHwtLXhsfC0teHhsKSwgKC0tcHJvZHVjdHwtLXByb2ZpbGUpKVxuKi9cbiRibG9jazogbnMoaW1hZ2UpO1xuXG4uI3skYmxvY2t9IHtcbiAgICAvL0xPQ0FMIFZBUlMgKHNldCBhbGwgdGhlbWVhYmxlIHByb3BlcnRpZXMsIGFsd2F5cyBpbmNsdWRlICFkZWZhdWx0KVxuICAgICRmZC1pbWFnZS1zaXplczogKFxuICAgICAgICB4czogMjBweCxcbiAgICAgICAgczogMzZweCxcbiAgICAgICAgbTogNTJweCxcbiAgICAgICAgbDogNzJweCxcbiAgICAgICAgeGw6IDkycHgsXG4gICAgICAgIHh4bDogMTIwcHgsXG4gICAgKSAhZGVmYXVsdDtcbiAgICAkZmQtaW1hZ2UtYmFja2dyb3VuZDogdHJhbnNwYXJlbnQgIWRlZmF1bHQ7XG4gICAgJGZkLWltYWdlLWJhY2tncm91bmQtLXBsYWNlaG9sZGVyOiBmZC1jb2xvcihuZXV0cmFsLCAyKSAhZGVmYXVsdDtcbiAgICAkZmQtaW1hZ2UtYmFja2dyb3VuZC1pbWFnZS0tcHJvZmlsZTogXCJkYXRhOmltYWdlL3N2Zyt4bWw7YmFzZTY0LFBITjJaeUIzYVdSMGFEMGlOVElpSUdobGFXZG9kRDBpTlRJaUlIWnBaWGRDYjNnOUlqQWdNQ0ExTWlBMU1pSWdlRzFzYm5NOUltaDBkSEE2THk5M2QzY3Vkek11YjNKbkx6SXdNREF2YzNabklqNDhkR2wwYkdVK2RHNHRhVzFoWjJVdFltRmphMmR5YjNWdVpDMXBiV0ZuWlMwdGNISnZabWxzWlR3dmRHbDBiR1UrUEhCaGRHZ2daRDBpVFRJMklETTVkaTB4YURFeFl5MHlMamMxTkM0Mk5qY3ROaTQwTWlBeExURXhJREY2YlRBZ01HTXRNaTR4TkRnZ01DMDFMamd4TlMwdU16TXpMVEV4TFRGb01URjJNWHB0TVRFdE1VZ3hOV013TFRVdU5UVTRJRE11TkRZMExURXdMakl6TkNBNExqRTJOUzB4TVM0MU9UaEJOeTR3TURJZ055NHdNRElnTUNBd0lERWdNallnTVROaE55QTNJREFnTUNBeElESXVPRE0xSURFekxqUXdNa016TXk0MU16WWdNamN1TnpZMklETTNJRE15TGpRME1pQXpOeUF6T0hvaUlHWnBiR3d0Y25Wc1pUMGlibTl1ZW1WeWJ5SWdabWxzYkQwaUkwWkdSaUl2UGp3dmMzWm5QZz09XCIgIWRlZmF1bHQ7XG4gICAgJGZkLWltYWdlLWJhY2tncm91bmQtaW1hZ2UtLXByb2R1Y3Q6IFwiZGF0YTppbWFnZS9zdmcreG1sO2Jhc2U2NCxQSE4yWnlCM2FXUjBhRDBpTlRJaUlHaGxhV2RvZEQwaU5USWlJSFpwWlhkQ2IzZzlJakFnTUNBMU1pQTFNaUlnZUcxc2JuTTlJbWgwZEhBNkx5OTNkM2N1ZHpNdWIzSm5Mekl3TURBdmMzWm5JajQ4ZEdsMGJHVStkRzR0YVcxaFoyVXRZbUZqYTJkeWIzVnVaQzFwYldGblpTMHRjSEp2WkhWamREd3ZkR2wwYkdVK1BIQmhkR2dnWkQwaVRURXpMamczTmlBeE9DNHlNak5zTlM0NE56UXRNaTQxTlRVZ01URWdOUzQ1TXpRdE5TNHlPVEVnTWk0eE56Z3RNVEV1TlRnekxUVXVOVFUzZWsweE15QXpNeTR3TkROMkxURTBMakF6YkRFeExqa3hOeUExTGpjeGRqRTBMakE1TVd3dE1URXVOVGt0TlM0eU56VmhMalUwTGpVMElEQWdNQ0F4TFM0ek1qY3RMalE1TjNwdE15NHlOUzA1TGpJd09YWTFMalF4TjJFdU5UUXVOVFFnTUNBd0lEQWdMak14Tnk0ME9UTnNOUzQwTVRjZ01pNDNNRGhqTGpNMU9DNHhOak11TnpZMkxTNHhMamMyTmkwdU5Ea3pkaTAxTGpReE4yRXVOVFF5TGpVME1pQXdJREFnTUMwdU16RTNMUzQwT1RKc0xUVXVOREUzTFRJdU56QTVZUzQxTkRJdU5UUXlJREFnTUNBd0xTNDNOall1TkRremVtMDVMamMxTGpnNE9Xd3hNeTAxTGpjeGRqRTBMakF6WVM0MU5DNDFOQ0F3SURBZ01TMHVNekkyTGpRNU5rd3lOaUF6T0M0NE1UVldNalF1TnpJemVtMHhNaTR4TWpRdE5pNDFiQzAyTGpFMElESXVPREV6TFRFd0xqazNMVFV1T1RFM0lEUXVOemN0TWk0d056TmhMalV6Tmk0MU16WWdNQ0F3SURFZ0xqUXpNaUF3YkRFeExqa3dPQ0ExTGpFM04zb2lJR1pwYkd3dGNuVnNaVDBpYm05dWVtVnlieUlnWm1sc2JEMGlJMFpHUmlJdlBqd3ZjM1puUGc9PVwiICFkZWZhdWx0O1xuXG4gICAgLy9CTE9DSyBCQVNFICoqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKipcbiAgICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gICAgdmVydGljYWwtYWxpZ246IG1pZGRsZTtcbiAgICBiYWNrZ3JvdW5kLXJlcGVhdDogbm8tcmVwZWF0O1xuICAgIGJhY2tncm91bmQtc2l6ZTogY292ZXI7XG4gICAgYmFja2dyb3VuZC1wb3NpdGlvbjogNTAlO1xuXG4gICAgLy9CTE9DSyBNT0RJRklFUlMgKioqKioqKioqKioqXG4gICAgLy9zaXplc1xuICAgIEBlYWNoICRzaXplLCAkdmFsdWUgaW4gJGZkLWltYWdlLXNpemVzIHtcbiAgICAgICAgJi0tI3skc2l6ZX0ge1xuICAgICAgICAgICAgd2lkdGg6ICR2YWx1ZTtcbiAgICAgICAgICAgIGhlaWdodDogJHZhbHVlO1xuICAgICAgICB9XG4gICAgfVxuICAgIC8vYm9yZGVyc1xuICAgICYtLXJvdW5kZWQge1xuICAgICAgICBib3JkZXItcmFkaXVzOiA4cHg7XG4gICAgICAgICYuI3skYmxvY2t9LS14cyxcbiAgICAgICAgJi4jeyRibG9ja30tLXMge1xuICAgICAgICAgICAgYm9yZGVyLXJhZGl1czogNHB4O1xuICAgICAgICB9XG4gICAgfVxuICAgICYtLWNpcmNsZSB7XG4gICAgICAgIGJvcmRlci1yYWRpdXM6IDUwJTtcbiAgICB9XG4gICAgLy9wbGFjZWhvbGRlcnNcbiAgICAmLS1wcm9maWxlLCAmLS1wcm9kdWN0IHtcbiAgICAgICAgYmFja2dyb3VuZC1jb2xvcjogJGZkLWltYWdlLWJhY2tncm91bmQtLXBsYWNlaG9sZGVyO1xuICAgIH1cbiAgICAmLS1wcm9maWxlIHtcbiAgICAgICAgYmFja2dyb3VuZC1pbWFnZTogdXJsKCRmZC1pbWFnZS1iYWNrZ3JvdW5kLWltYWdlLS1wcm9maWxlKTtcbiAgICB9XG4gICAgJi0tcHJvZHVjdCB7XG4gICAgICAgIGJhY2tncm91bmQtaW1hZ2U6IHVybCgkZmQtaW1hZ2UtYmFja2dyb3VuZC1pbWFnZS0tcHJvZHVjdCk7XG4gICAgfVxufVxuIiwiQGltcG9ydCBcIi4uL2NvcmUvc2V0dGluZ3NcIjtcbkBpbXBvcnQgXCIuLi9jb3JlL21peGluc1wiO1xuQGltcG9ydCBcIi4uL2NvcmUvZnVuY3Rpb25zXCI7XG4vL3NldCBuYW1lc3BhY2UgdXNpbmcgZnVuY3Rpb24gdG8gYXZvaWQgaGFyZGNvZGluZyBpdFxuJG5zOiBucygpO1xuLiN7JG5zfXRleHQtdHJhbnNmb3JtLW5vbmUge1xuICAgIHRleHQtdHJhbnNmb3JtOiBub25lICFpbXBvcnRhbnQ7XG59XG4uI3skbnN9aGFzLWZvbnQtd2VpZ2h0LWJvbGQge1xuICAgIGZvbnQtd2VpZ2h0OiBib2xkICFpbXBvcnRhbnQ7XG59XG4uI3skbnN9aGFzLWZvbnQtc3R5bGUtaXRhbGljIHtcbiAgICBmb250LXN0eWxlOiBpdGFsaWMgIWltcG9ydGFudDtcbn1cbi4jeyRuc31oYXMtdGV4dC1hbGlnbi1jZW50ZXIge1xuICAgIHRleHQtYWxpZ246IGNlbnRlciAhaW1wb3J0YW50O1xufVxuLiN7JG5zfWhhcy10ZXh0LWFsaWduLXJpZ2h0IHtcbiAgICB0ZXh0LWFsaWduOiByaWdodCAhaW1wb3J0YW50O1xufVxuLiN7JG5zfWhhcy1mbG9hdC1sZWZ0IHtcbiAgICBmbG9hdDogbGVmdCAhaW1wb3J0YW50O1xufVxuLiN7JG5zfWhhcy1mbG9hdC1yaWdodCB7XG4gICAgZmxvYXQ6IHJpZ2h0ICFpbXBvcnRhbnQ7XG59XG4uI3skbnN9aGFzLWJvcmRlci1yYWRpdXMtNTBwZXJjZW50IHtcbiAgICBib3JkZXItcmFkaXVzOiA1MCUgIWltcG9ydGFudDtcbn1cbiIsIkBpbXBvcnQgXCIuLi9jb3JlL3NldHRpbmdzXCI7XG5AaW1wb3J0IFwiLi4vY29yZS9taXhpbnNcIjtcbkBpbXBvcnQgXCIuLi9jb3JlL2Z1bmN0aW9uc1wiO1xuXG4vL3NldCBuYW1lc3BhY2UgdXNpbmcgZnVuY3Rpb24gdG8gYXZvaWQgaGFyZGNvZGluZyBpdFxuJG5zOiBucygpO1xuQGVhY2ggJGtleSwgJHZhbHVlIGluICRmZC10eXBlIHtcbiAgICBAaWYgJGtleSA+IDAge1xuICAgICAgICAuI3skbnN9aGFzLXR5cGUtI3ska2V5fSB7XG4gICAgICAgICAgICBAaW5jbHVkZSBmZC10eXBlKCRrZXkpO1xuICAgICAgICB9XG4gICAgfSBAZWxzZSBpZiAka2V5IDwgMCB7XG4gICAgICAgIC4jeyRuc31oYXMtdHlwZS1taW51cyN7JGtleX0ge1xuICAgICAgICAgICAgQGluY2x1ZGUgZmQtdHlwZSgka2V5KTtcbiAgICAgICAgfVxuICAgIH0gQGVsc2Uge1xuICAgICAgICAuI3skbnN9aGFzLXR5cGUtYmFzZSxcbiAgICAgICAgLiN7JG5zfWhhcy10eXBlLSN7JGtleX0ge1xuICAgICAgICAgICAgQGluY2x1ZGUgZmQtdHlwZSgka2V5KTtcbiAgICAgICAgfVxuICAgIH1cbn1cblxuQGVhY2ggJGtleSwgJHZhbHVlIGluICRmZC1mb250cyB7XG4gICAgLiN7JG5zfWhhcy1mb250LWZhbWlseS0jeyRrZXl9IHtcbiAgICAgICAgZm9udC1mYW1pbHk6ICR2YWx1ZTtcbiAgICB9XG59XG5cbkBlYWNoICRrZXksICR2YWx1ZSBpbiAkZmQtd2VpZ2h0cyB7XG4gICAgLiN7JG5zfWhhcy1mb250LXdlaWdodC0jeyRrZXl9IHtcbiAgICAgICAgZm9udC13ZWlnaHQ6ICR2YWx1ZTtcbiAgICB9XG59XG4iLCJAaW1wb3J0IFwiLi4vY29yZS9zZXR0aW5nc1wiO1xuQGltcG9ydCBcIi4uL2NvcmUvZnVuY3Rpb25zXCI7XG4vL3NldCBuYW1lc3BhY2UgdXNpbmcgZnVuY3Rpb24gdG8gYXZvaWQgaGFyZGNvZGluZyBpdFxuJG5zOiBucygpO1xuQGVhY2ggJHR5cGUsICRzaGFkZXMgaW4gJGZkLWNvbG9ycyB7XG4gICAgQGVhY2ggJHNoYWRlLCAkdmFsdWUgaW4gJHNoYWRlcyB7XG4gICAgICAgIEBpZiAkc2hhZGUgPT0gMSB7XG4gICAgICAgICAgICAvL3NldCBkZWZhdWx0IHNlbGVjdG9yIGZvciBjb252ZW5pZW5jZVxuICAgICAgICAgICAgLiN7JG5zfWhhcy1jb2xvci0jeyR0eXBlfSxcbiAgICAgICAgICAgIC4jeyRuc31oYXMtY29sb3ItI3skdHlwZX0tI3skc2hhZGV9IHtcbiAgICAgICAgICAgICAgICBjb2xvcjogJHZhbHVlICFpbXBvcnRhbnQ7XG4gICAgICAgICAgICB9XG4gICAgICAgIH0gQGVsc2Uge1xuICAgICAgICAgICAgLiN7JG5zfWhhcy1jb2xvci0jeyR0eXBlfS0jeyRzaGFkZX0ge1xuICAgICAgICAgICAgICAgIGNvbG9yOiAkdmFsdWUgIWltcG9ydGFudDtcbiAgICAgICAgICAgIH1cbiAgICAgICAgfVxuICAgIH1cbn1cbiIsIkBpbXBvcnQgXCIuLi9jb3JlL3NldHRpbmdzXCI7XG4vL3NldCBuYW1lc3BhY2UgdXNpbmcgZnVuY3Rpb24gdG8gYXZvaWQgaGFyZGNvZGluZyBpdFxuJG5zOiBucygpO1xuLiN7JG5zfWhhcy1iYWNrZ3JvdW5kLWltYWdlIHtcbiAgICBiYWNrZ3JvdW5kLXJlcGVhdDogbm8tcmVwZWF0O1xuICAgIGJhY2tncm91bmQtcG9zaXRpb246IGNlbnRlcjtcbiAgICBiYWNrZ3JvdW5kLXNpemU6IGNvbnRhaW47XG59XG4uI3skbnN9aGFzLWJhY2tncm91bmQtZml4ZWQge1xuICAgIGJhY2tncm91bmQtcmVwZWF0OiBuby1yZXBlYXQ7XG4gICAgYmFja2dyb3VuZC1wb3NpdGlvbjogY2VudGVyO1xuICAgIGJhY2tncm91bmQtYXR0YWNobWVudDogZml4ZWQ7XG59XG4uI3skbnN9aGFzLWJhY2tncm91bmQtc2l6ZS1jb250YWluIHtcbiAgICBiYWNrZ3JvdW5kLXNpemU6IGNvbnRhaW4gIWltcG9ydGFudDtcbn1cbi4jeyRuc31oYXMtYmFja2dyb3VuZC1zaXplLWNvdmVyIHtcbiAgICBiYWNrZ3JvdW5kLXNpemU6IGNvdmVyICFpbXBvcnRhbnQ7XG59XG5AZWFjaCAkdHlwZSwgJHNoYWRlcyBpbiAkZmQtY29sb3JzIHtcbiAgICBAZWFjaCAkc2hhZGUsICR2YWx1ZSBpbiAkc2hhZGVzIHtcbiAgICAgICAgQGlmICRzaGFkZSA9PSAxIHtcbiAgICAgICAgICAgIC8vc2V0IGRlZmF1bHQgc2VsZWN0b3IgZm9yIGNvbnZlbmllbmNlXG4gICAgICAgICAgICAuI3skbnN9aGFzLWJhY2tncm91bmQtY29sb3ItI3skdHlwZX0sXG4gICAgICAgICAgICAuI3skbnN9aGFzLWJhY2tncm91bmQtY29sb3ItI3skdHlwZX0tI3skc2hhZGV9IHtcbiAgICAgICAgICAgICAgICBiYWNrZ3JvdW5kLWNvbG9yOiAkdmFsdWUgIWltcG9ydGFudDtcbiAgICAgICAgICAgIH1cbiAgICAgICAgfSBAZWxzZSB7XG4gICAgICAgICAgICAuI3skbnN9aGFzLWJhY2tncm91bmQtY29sb3ItI3skdHlwZX0tI3skc2hhZGV9IHtcbiAgICAgICAgICAgICAgICBiYWNrZ3JvdW5kLWNvbG9yOiAkdmFsdWUgIWltcG9ydGFudDtcbiAgICAgICAgICAgIH1cbiAgICAgICAgfVxuICAgIH1cbn1cbiIsIkBpbXBvcnQgXCIuLi9jb3JlL3NldHRpbmdzXCI7XG4vL3NldCBuYW1lc3BhY2UgdXNpbmcgZnVuY3Rpb24gdG8gYXZvaWQgaGFyZGNvZGluZyBpdFxuJG5zOiBucygpO1xuLiN7JG5zfWhhcy1tYXJnaW4tbm9uZSB7XG4gICAgbWFyZ2luOiAwO1xufVxuLiN7JG5zfWhhcy1wYWRkaW5nLW5vbmUge1xuICAgIHBhZGRpbmc6IDA7XG59XG5AZWFjaCAkaXRlbSBpbiB0b3AsIHJpZ2h0LCBib3R0b20sIGxlZnQge1xuICAgIC4jeyRuc31oYXMtbWFyZ2luLSN7JGl0ZW19LW5vbmUge1xuICAgICAgICBtYXJnaW4tI3skaXRlbX06IDA7XG4gICAgfVxuICAgIC4jeyRuc31oYXMtcGFkZGluZy0jeyRpdGVtfS1ub25lIHtcbiAgICAgICAgcGFkZGluZy0jeyRpdGVtfTogMDtcbiAgICB9XG59XG5AZWFjaCAka2V5LCAkdmFsdWUgaW4gJGZkLXNwYWNpbmcge1xuICAgIC4jeyRuc31oYXMtbWFyZ2luLSN7JGtleX0ge1xuICAgICAgICBtYXJnaW46ICN7JHZhbHVlfTtcbiAgICB9XG4gICAgLiN7JG5zfWhhcy1wYWRkaW5nLSN7JGtleX0ge1xuICAgICAgICBwYWRkaW5nOiAjeyR2YWx1ZX07XG4gICAgfVxuICAgIEBlYWNoICRpdGVtIGluIHRvcCwgcmlnaHQsIGJvdHRvbSwgbGVmdCB7XG4gICAgICAgIC4jeyRuc31oYXMtbWFyZ2luLSN7JGl0ZW19LSN7JGtleX0ge1xuICAgICAgICAgICAgbWFyZ2luLSN7JGl0ZW19OiAjeyR2YWx1ZX07XG4gICAgICAgIH1cbiAgICAgICAgLiN7JG5zfWhhcy1wYWRkaW5nLSN7JGl0ZW19LSN7JGtleX0ge1xuICAgICAgICAgICAgcGFkZGluZy0jeyRpdGVtfTogI3skdmFsdWV9O1xuICAgICAgICB9XG4gICAgfVxufVxuIiwiQGltcG9ydCBcIi4uL2NvcmUvc2V0dGluZ3NcIjtcbkBpbXBvcnQgXCIuLi9jb3JlL21peGluc1wiO1xuQGltcG9ydCBcIi4uL2NvcmUvZnVuY3Rpb25zXCI7XG4vL3NldCBuYW1lc3BhY2UgdXNpbmcgZnVuY3Rpb24gdG8gYXZvaWQgaGFyZGNvZGluZyBpdFxuJG5zOiBucygpO1xuLiN7JG5zfWhhcy1jbGVhcmZpeCB7XG4gICAgQGluY2x1ZGUgZmQtY2xlYXJmaXg7XG59XG4uI3skbnN9aGFzLWRpc3BsYXktZmxleCB7XG4gICAgZGlzcGxheTogZmxleDtcbn1cbi4jeyRuc31oYXMtZGlzcGxheS1ibG9jayB7XG4gICAgZGlzcGxheTogYmxvY2s7XG59XG4uI3skbnN9aGFzLWFsaWduLWl0ZW1zLWNlbnRlciB7XG4gICAgYWxpZ24taXRlbXM6IGNlbnRlcjtcbn1cbi4jeyRuc31oYXMtZmxleC1ncm93LTEge1xuICAgIGZsZXgtZ3JvdzogMTtcbn1cbiJdfQ== */


### PR DESCRIPTION
this change ensures that docs/css/fundamtental-ui.css is copied over to _site on jekyll build as the stand alone file is required by the starter pages.