### PR TITLE
#201 updates alert, improves icons mixins

### DIFF
--- a/scss/components/alert.scss
+++ b/scss/components/alert.scss
@@ -2,6 +2,7 @@
 @import "./../mixins";
 @import "./../functions";
 @import "./mixins";
+@import "./../icons/mixins";
 /*!
 .fd-alert+(--warning. --error)
     .fd-alert__close
@@ -9,41 +10,50 @@
 $block: #{$fd-namespace}-alert;
 .#{$block} {
     //SETTINGS
-    $fd-alert-background-color: fd-color(text, 3) !default;
-    $fd-alert-background-color--warning: fd-color(status, 2) !default;
-    $fd-alert-background-color--error: fd-color(status, 3) !default;
-    $fd-alert-color--warning: fd-color(text, 1) !default;
-    $fd-alert-color: fd-color(text-inverse, 1) !default;
-    $fd-alert-border-color: fd-color(neutral, 2) !default;
-    $fd-alert-height: fd-space(13) !default;
-    $fd-alert-action--clerance: 50px;
+    $fd-alert-color: fd-color("text", 1) !default;
+    $fd-alert-border-color: fd-color("neutral", 3) !default;
+    $fd-alert-border-color--warning: fd-color("status", 2) !default;
+    $fd-alert-border-color--error: fd-color("status", 3) !default;
+
+    $fd-alert-background-color: fd-color("neutral", 1) !default;
+    $fd-alert-background-color--warning: rgba($fd-alert-border-color--warning, 0.07) !default;
+    $fd-alert-background-color--error: rgba($fd-alert-border-color--error, 0.07) !default;
+
+    $fd-alert-padding-x: fd-space("xxs") !default;
+    $fd-alert-padding-y: fd-space("xs") !default;
 
     // Block
     @include fd-reset;
     color: $fd-alert-color;
     border: solid 1px $fd-alert-border-color;
     background-color: $fd-alert-background-color;
-    min-height: $fd-alert-height;
-    padding: fd-space(s);
+    padding: $fd-alert-padding-x $fd-alert-padding-y;
+    border-radius: $fd-border-radius;
 
     // Elements
     &__close {
-        @include fd-button-reset;  //removes default button chrome
-        color: fd-color(text-inverse, 1);
-        width: fd-space(m); //best practice hit space
-        height: fd-space(m);
-        float: right;
-        margin: - (fd-space(s)/2);
+      position: absolute;
+      right: fd-space(1);
+      top: 0;
+      @include fd-icon("decline", "l");
+      @include fd-button-reset;
+      color: fd-color("text", 1);
+      width: fd-space(9);
+      height: fd-space(9);
     }
 
     // Modifiers
     &--warning {
+      border-color: $fd-alert-border-color--warning;
       background-color: $fd-alert-background-color--warning;
-      color: $fd-alert-color--warning;
-
     }
     &--error {
+      border-color: $fd-alert-border-color--error;
       background-color: $fd-alert-background-color--error;
+    }
+    &--dismissible {
+      position: relative;
+      padding-right: fd-space(12);
     }
 
 

--- a/scss/icons/_mixins.scss
+++ b/scss/icons/_mixins.scss
@@ -1,5 +1,29 @@
 @import "./settings";
 
+//icon mixin
+@mixin fd-icon($key, $size: "default") {
+  @include fd-icon-base;
+  @include fd-icon-glyph($key);
+  @include fd-icon-size($size);
+}
+
+//icon base mixin
+@mixin fd-icon-base {
+  &::before {
+    font-family: "SAP-icons";
+    font-style: normal;
+    font-weight: normal;
+    text-align: center;
+    display: inline-block;
+    text-decoration: inherit;
+    text-transform: none;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    speak: none;
+  }
+}
+
 //size mixin
 @mixin fd-icon-size($size: "default") {
   &::before {
@@ -19,14 +43,13 @@
   }
 }
 
-//icon mixin
-@mixin fd-icon($key) {
-  @if map-has-key($fd-icons, $key) {
+//icon glyph mixin
+@mixin fd-icon-glyph($glyph) {
+  @if map-has-key($fd-icons, $glyph) {
     &::before {
-      content: map-get($fd-icons, $key);
-      @content;
+      content: map-get($fd-icons, $glyph);
     }
   } @else {
-      @warn "Unknown `#{$key}` in $fd-icons map";
+      @warn "Unknown `#{$glyph}` in $fd-icons map";
   }
 }

--- a/scss/icons/icon.scss
+++ b/scss/icons/icon.scss
@@ -16,22 +16,6 @@ $fd-scss-icons-path: "" !default;
 
 $block: sap-icon;
 
-%fd-icon-base {
-  &::before {
-    font-family: "SAP-icons";
-    font-style: normal;
-    font-weight: normal;
-    text-align: center;
-    display: inline-block;
-    text-decoration: inherit;
-    text-transform: none;
-    text-rendering: optimizeLegibility;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    speak: none;
-  }
-}
-
 /* data attributes for inserting icons
   <span data-sap-icon="\e001"> My Account</span>
 */
@@ -42,7 +26,7 @@ $block: sap-icon;
 
 /* class per icon */
 [class*="#{$block}"] {
-  @extend %fd-icon-base;
+  @include fd-icon-base;
 }
 
 .#{$block} {
@@ -64,7 +48,7 @@ $block: sap-icon;
   }
   @each $key, $value in $fd-icons {
       &--#{$key} {
-        @include fd-icon($key);
+        @include fd-icon-glyph($key);
       }
   }
 }

--- a/test/templates/alert/component.njk
+++ b/test/templates/alert/component.njk
@@ -1,18 +1,14 @@
 {#
     see ./data.json for object structure
 #}
+{% import "./../utils.njk" as utils %}
 
-{% from "../icon/component.njk" import icon %}
 {% macro alert(properties={}, modifier={}) -%}
-<div class="fd-alert{{ modifier.block | modifier('alert') }}" role="alert" id="{{properties.id}}">
-  {%- if properties.text %}
-  <button class="fd-alert__close" aria-controls="{{properties.id}}">
-    {{ icon('close') }}
-  </button>
+{%- set _id = utils.id() %}
+<div class="fd-alert{{ modifier.block | modifier('alert') }}{{ 'dismissible' | modifier('alert') if properties.dismissible }}" role="alert"{{ ' id="'+_id+'"' if properties.dismissible }}>
+  {%- if properties.dismissible %}
+  <button class="fd-alert__close" aria-controls="{{ _id }}" aria-label="Close"></button>
   {%- endif %}
-  {%- if properties.text %}
   {{ properties.text }}
-  {%- endif %}
 </div>
-
 {%- endmacro %}

--- a/test/templates/alert/data.json
+++ b/test/templates/alert/data.json
@@ -1,10 +1,9 @@
 {
     "properties": {
         "text": "Alert Text",
-        "dismissible": true,
-        "id": "alert-id"
+        "dismissible": true
     },
     "modifier": {
-        "block": ["warning", "error"]
+        "block": ["warning", "error", "dismissible"]
     }
 }

--- a/test/templates/alert/index.njk
+++ b/test/templates/alert/index.njk
@@ -4,7 +4,7 @@
 {% from "./component.njk" import alert %}
 
 <!-- include add'tl css from src/styles/ -->
-{% set css_deps = ['fonts', 'icons', 'components/button'] %}
+{% set css_deps = ['fonts', 'icons', 'components/button', 'components/link'] %}
 
 
 
@@ -15,8 +15,7 @@
 {% set example %}
 {{  alert(
         properties={
-            text: "default_alert_text",
-            id: "defautl-alert"
+            text: 'Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et. <a href="#" class="fd-link">Pellentesque <span class="sap-icon--arrow-right sap-icon--s"></span></a>'
         },
         modifier={
             block: []
@@ -26,9 +25,7 @@
 <br>
 {{  alert(
         properties={
-            text: "warning_alert_text",
-            id: "warning-alert"
-
+            text: 'Suspendisse potenti. Donec ante velit ornare at augue quis tristique laoreet sem.'
         },
         modifier={
             block: ["warning"]
@@ -38,8 +35,47 @@
 <br>
 {{  alert(
         properties={
-            text: "error_alert_text",
-            id: "error-alert"
+            text: 'Pellentesque metus lacus commodo eget justo ut rutrum varius nunc. Sed non rhoncus risus. <a href="#" class="fd-link">Metus <span class="sap-icon--arrow-right sap-icon--s"></span></a>'
+        },
+        modifier={
+            block: ["error"]
+        }
+    )
+}}
+{% endset %}
+{{- format(example) -}}
+
+<br><br>
+
+<h1>dismissible</h1>
+
+{% set example %}
+{{  alert(
+        properties={
+            text: 'Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et mattis erat vel aliquet in sem urna et sagittis diam in vehicula.',
+            dismissible: true
+        },
+        modifier={
+            block: []
+        }
+    )
+}}
+<br>
+{{  alert(
+        properties={
+            text: 'Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et. <a href="#" class="fd-link">Metus <span class="sap-icon--arrow-right sap-icon--s"></span></a>',
+            dismissible: true
+        },
+        modifier={
+            block: ["warning"]
+        }
+    )
+}}
+<br>
+{{  alert(
+        properties={
+            text: 'Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet sem urna et. Pellentesque metus in sem lacus commodo eget justo ut rutrum varius nunc. Sed non rhoncus risus. <a href="#" class="fd-link">Pellentesque <span class="sap-icon--arrow-right sap-icon--s"></span></a>',
+            dismissible: true
         },
         modifier={
             block: ["error"]


### PR DESCRIPTION
#201 

Matches https://zpl.io/2poQdgl

## Updates
- Adds `--dismissible` modifier to prevent content wrapping around the close button (this class modified is **required** now)
- Improved the icons mixins so you can use `@include fd-icon("decline", "l")`and it will add all the relevant styles needed meaning you don't need to use an empty icon span. See [this](https://github.com/SAP/fundamental/pull/218/files#diff-d7fd5b7374da98196ff1a3e856af6cf5R38).