### PR TITLE
Feature/188

### DIFF
--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -28,7 +28,7 @@ $fd-spacing: map-merge((
 $fd-fonts: () !default;
 $fd-fonts: map-merge((
     "body": #{"'72'", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"},
-    "header": #{"'72Condensed'", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"},
+    "header": #{"'72'", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"},
     "code": #{monospace},
 ), $fd-fonts);
 

--- a/scss/components.scss
+++ b/scss/components.scss
@@ -23,3 +23,4 @@
 @import "components/spinner";
 @import "components/image";
 @import "components/link";
+@import "components/identifier";

--- a/scss/components/identifier.scss
+++ b/scss/components/identifier.scss
@@ -3,7 +3,7 @@
 @import "./../functions";
 @import "./../icons/mixins";
 /*!
-.fd-image+((--rounded|--circle), (--xs|--s|--m|--l|--xl|--xxl), (--product|--profile))
+.fd-image+((--circle), (--s|--m|--l))
 */
 $block: #{$fd-namespace}-identifier;
 .#{$block} {
@@ -15,7 +15,6 @@ $block: #{$fd-namespace}-identifier;
     ) !default;
     $fd-identifier-border-radius: $fd-border-radius !default;
     $fd-identifier-background: fd-color("text", 3) !default;
-    $fd-identifier-background--placeholder: fd-color("accent", 1) !default;
 
     //BLOCK BASE *******************************************
     @at-root {

--- a/scss/components/identifier.scss
+++ b/scss/components/identifier.scss
@@ -1,58 +1,62 @@
 @import "./../settings";
 @import "./../mixins";
 @import "./../functions";
-
 /*!
-.fd-identifier+(--no-border)
-    .fd-identifier__content+()
-    .fd-identifier__title+()
+.fd-image+((--rounded|--circle), (--xs|--s|--m|--l|--xl|--xxl), (--product|--profile))
 */
 $block: #{$fd-namespace}-identifier;
-
 .#{$block} {
     //LOCAL VARS (set all themeable properties, always include !default)
-    $fd-identifier-border-color: fd-color(primary, 1) !default;
-    $fd-identifier-content-border-color: fd-color(neutral, 4) !default;
-    $fd-identifier-border-color--selected: fd-color(primary) !default;
+    $fd-identifier-sizes: (
+        s: 24px,
+        m: 36px,
+        l: 48px
+    ) !default;
+    $fd-identifier-border-radius: $fd-border-radius !default;
+
+
+    $fd-identifier-background: fd-color(neutral, 2) !default;
+
+    $fd-identifier-background--placeholder: fd-color("accent", 1) !default;
+
+    $fd-identifier-background-image--profile: "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTIiIGhlaWdodD0iNTIiIHZpZXdCb3g9IjAgMCA1MiA1MiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU+dG4taW1hZ2UtYmFja2dyb3VuZC1pbWFnZS0tcHJvZmlsZTwvdGl0bGU+PHBhdGggZD0iTTI2IDM5di0xaDExYy0yLjc1NC42NjctNi40MiAxLTExIDF6bTAgMGMtMi4xNDggMC01LjgxNS0uMzMzLTExLTFoMTF2MXptMTEtMUgxNWMwLTUuNTU4IDMuNDY0LTEwLjIzNCA4LjE2NS0xMS41OThBNy4wMDIgNy4wMDIgMCAwIDEgMjYgMTNhNyA3IDAgMCAxIDIuODM1IDEzLjQwMkMzMy41MzYgMjcuNzY2IDM3IDMyLjQ0MiAzNyAzOHoiIGZpbGwtcnVsZT0ibm9uemVybyIgZmlsbD0iI0ZGRiIvPjwvc3ZnPg==" !default;
+    $fd-identifier-background-image--product: "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTIiIGhlaWdodD0iNTIiIHZpZXdCb3g9IjAgMCA1MiA1MiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU+dG4taW1hZ2UtYmFja2dyb3VuZC1pbWFnZS0tcHJvZHVjdDwvdGl0bGU+PHBhdGggZD0iTTEzLjg3NiAxOC4yMjNsNS44NzQtMi41NTUgMTEgNS45MzQtNS4yOTEgMi4xNzgtMTEuNTgzLTUuNTU3ek0xMyAzMy4wNDN2LTE0LjAzbDExLjkxNyA1LjcxdjE0LjA5MWwtMTEuNTktNS4yNzVhLjU0LjU0IDAgMCAxLS4zMjctLjQ5N3ptMy4yNS05LjIwOXY1LjQxN2EuNTQuNTQgMCAwIDAgLjMxNy40OTNsNS40MTcgMi43MDhjLjM1OC4xNjMuNzY2LS4xLjc2Ni0uNDkzdi01LjQxN2EuNTQyLjU0MiAwIDAgMC0uMzE3LS40OTJsLTUuNDE3LTIuNzA5YS41NDIuNTQyIDAgMCAwLS43NjYuNDkzem05Ljc1Ljg4OWwxMy01LjcxdjE0LjAzYS41NC41NCAwIDAgMS0uMzI2LjQ5NkwyNiAzOC44MTVWMjQuNzIzem0xMi4xMjQtNi41bC02LjE0IDIuODEzLTEwLjk3LTUuOTE3IDQuNzctMi4wNzNhLjUzNi41MzYgMCAwIDEgLjQzMiAwbDExLjkwOCA1LjE3N3oiIGZpbGwtcnVsZT0ibm9uemVybyIgZmlsbD0iI0ZGRiIvPjwvc3ZnPg==" !default;
 
     //BLOCK BASE *******************************************
-    //set all BLOCK reset and baseline styles
     @include fd-reset;
-    border: solid 20px $fd-identifier-border-color;
+    display: inline-block;
+    vertical-align: middle;
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-position: 50%;
 
     //BLOCK MODIFIERS ************
-    //e.g., $fd-identifier--no-border
-    &--no-border {
-        border-color: transparent;
-    }
-
-    //ELEMENTS *******************************************
-    //set all ELEMENT baseline styles
-    //e.g., $fd-identifier__content
-    &__content {
-        border: solid 10px $fd-identifier-content-border-color;
-
-        //ELEMENT MODIFIERS ************
-        //e.g., $fd-identifier__content--no-border
-        &--no-border {
-            border-color: transparent;
+    //sizes
+    @each $size, $value in $fd-identifier-sizes {
+        &--#{$size} {
+            width: $value;
+            height: $value;
         }
     }
-    &__title {
-
-
+    //borders
+    &--rounded {
+        border-radius: 8px;
+        &.#{$block}--xs,
+        &.#{$block}--s {
+            border-radius: 4px;
+        }
     }
-
-    //STATES *******************************************
-    &.is-disabled,
-    &[disabled] {
-        opacity: 0.5;
+    &--circle {
+        border-radius: 50%;
     }
-    &[aria-selected="true"] {
-        border-color: $fd-identifier-border-color--selected;
+    //placeholders
+    &--profile, &--product {
+        background-color: $fd-identifier-background--placeholder;
     }
-
-
-
-
+    &--profile {
+        background-image: url($fd-identifier-background-image--profile);
+    }
+    &--product {
+        background-image: url($fd-identifier-background-image--product);
+    }
 }

--- a/scss/components/identifier.scss
+++ b/scss/components/identifier.scss
@@ -1,0 +1,58 @@
+@import "./../settings";
+@import "./../mixins";
+@import "./../functions";
+
+/*!
+.fd-identifier+(--no-border)
+    .fd-identifier__content+()
+    .fd-identifier__title+()
+*/
+$block: #{$fd-namespace}-identifier;
+
+.#{$block} {
+    //LOCAL VARS (set all themeable properties, always include !default)
+    $fd-identifier-border-color: fd-color(primary, 1) !default;
+    $fd-identifier-content-border-color: fd-color(neutral, 4) !default;
+    $fd-identifier-border-color--selected: fd-color(primary) !default;
+
+    //BLOCK BASE *******************************************
+    //set all BLOCK reset and baseline styles
+    @include fd-reset;
+    border: solid 20px $fd-identifier-border-color;
+
+    //BLOCK MODIFIERS ************
+    //e.g., $fd-identifier--no-border
+    &--no-border {
+        border-color: transparent;
+    }
+
+    //ELEMENTS *******************************************
+    //set all ELEMENT baseline styles
+    //e.g., $fd-identifier__content
+    &__content {
+        border: solid 10px $fd-identifier-content-border-color;
+
+        //ELEMENT MODIFIERS ************
+        //e.g., $fd-identifier__content--no-border
+        &--no-border {
+            border-color: transparent;
+        }
+    }
+    &__title {
+
+
+    }
+
+    //STATES *******************************************
+    &.is-disabled,
+    &[disabled] {
+        opacity: 0.5;
+    }
+    &[aria-selected="true"] {
+        border-color: $fd-identifier-border-color--selected;
+    }
+
+
+
+
+}

--- a/scss/components/identifier.scss
+++ b/scss/components/identifier.scss
@@ -1,6 +1,7 @@
 @import "./../settings";
 @import "./../mixins";
 @import "./../functions";
+@import "./../icons/mixins";
 /*!
 .fd-image+((--rounded|--circle), (--xs|--s|--m|--l|--xl|--xxl), (--product|--profile))
 */
@@ -13,50 +14,60 @@ $block: #{$fd-namespace}-identifier;
         l: 48px
     ) !default;
     $fd-identifier-border-radius: $fd-border-radius !default;
-
-
-    $fd-identifier-background: fd-color(neutral, 2) !default;
-
+    $fd-identifier-background: fd-color("text", 3) !default;
     $fd-identifier-background--placeholder: fd-color("accent", 1) !default;
 
-    $fd-identifier-background-image--profile: "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTIiIGhlaWdodD0iNTIiIHZpZXdCb3g9IjAgMCA1MiA1MiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU+dG4taW1hZ2UtYmFja2dyb3VuZC1pbWFnZS0tcHJvZmlsZTwvdGl0bGU+PHBhdGggZD0iTTI2IDM5di0xaDExYy0yLjc1NC42NjctNi40MiAxLTExIDF6bTAgMGMtMi4xNDggMC01LjgxNS0uMzMzLTExLTFoMTF2MXptMTEtMUgxNWMwLTUuNTU4IDMuNDY0LTEwLjIzNCA4LjE2NS0xMS41OThBNy4wMDIgNy4wMDIgMCAwIDEgMjYgMTNhNyA3IDAgMCAxIDIuODM1IDEzLjQwMkMzMy41MzYgMjcuNzY2IDM3IDMyLjQ0MiAzNyAzOHoiIGZpbGwtcnVsZT0ibm9uemVybyIgZmlsbD0iI0ZGRiIvPjwvc3ZnPg==" !default;
-    $fd-identifier-background-image--product: "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTIiIGhlaWdodD0iNTIiIHZpZXdCb3g9IjAgMCA1MiA1MiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU+dG4taW1hZ2UtYmFja2dyb3VuZC1pbWFnZS0tcHJvZHVjdDwvdGl0bGU+PHBhdGggZD0iTTEzLjg3NiAxOC4yMjNsNS44NzQtMi41NTUgMTEgNS45MzQtNS4yOTEgMi4xNzgtMTEuNTgzLTUuNTU3ek0xMyAzMy4wNDN2LTE0LjAzbDExLjkxNyA1LjcxdjE0LjA5MWwtMTEuNTktNS4yNzVhLjU0LjU0IDAgMCAxLS4zMjctLjQ5N3ptMy4yNS05LjIwOXY1LjQxN2EuNTQuNTQgMCAwIDAgLjMxNy40OTNsNS40MTcgMi43MDhjLjM1OC4xNjMuNzY2LS4xLjc2Ni0uNDkzdi01LjQxN2EuNTQyLjU0MiAwIDAgMC0uMzE3LS40OTJsLTUuNDE3LTIuNzA5YS41NDIuNTQyIDAgMCAwLS43NjYuNDkzem05Ljc1Ljg4OWwxMy01LjcxdjE0LjAzYS41NC41NCAwIDAgMS0uMzI2LjQ5NkwyNiAzOC44MTVWMjQuNzIzem0xMi4xMjQtNi41bC02LjE0IDIuODEzLTEwLjk3LTUuOTE3IDQuNzctMi4wNzNhLjUzNi41MzYgMCAwIDEgLjQzMiAwbDExLjkwOCA1LjE3N3oiIGZpbGwtcnVsZT0ibm9uemVybyIgZmlsbD0iI0ZGRiIvPjwvc3ZnPg==" !default;
-
     //BLOCK BASE *******************************************
-    @include fd-reset;
-    display: inline-block;
-    vertical-align: middle;
-    background-repeat: no-repeat;
-    background-size: cover;
-    background-position: 50%;
-
+    @at-root {
+      [class*="#{$block}"] {
+        @include fd-reset;
+        display: inline-block;
+        vertical-align: middle;
+        text-align: center;
+        background-repeat: no-repeat;
+        background-size: cover;
+        background-position: 50%;
+        border-radius: $fd-identifier-border-radius;
+        background-color: $fd-identifier-background;
+        color: fd-color("text-inverse", 1);
+      }
+    }
     //BLOCK MODIFIERS ************
     //sizes
     @each $size, $value in $fd-identifier-sizes {
-        &--#{$size} {
-            width: $value;
-            height: $value;
+      &--#{$size} {
+        width: $value;
+        height: $value;
+        max-width: $value;
+        max-height: $value;
+        min-width: $value;
+        min-height: $value;
+        @if $size == s {
+          @include fd-type("-3");
+          @include fd-weight("bold");
+          font-stretch: condensed;
+          @include fd-icon-size("s") {
+            line-height: $value;
+          }
         }
+        @if $size == m {
+          @include fd-type("0");
+          @include fd-icon-size("l") {
+            line-height: $value;
+          }
+        }
+        @if $size == l {
+          @include fd-type("2");
+          @include fd-icon-size("xl") {
+            line-height: $value;
+          }
+        }
+        line-height: $value;
+      }
     }
     //borders
-    &--rounded {
-        border-radius: 8px;
-        &.#{$block}--xs,
-        &.#{$block}--s {
-            border-radius: 4px;
-        }
-    }
     &--circle {
-        border-radius: 50%;
+      border-radius: 50%;
     }
-    //placeholders
-    &--profile, &--product {
-        background-color: $fd-identifier-background--placeholder;
-    }
-    &--profile {
-        background-image: url($fd-identifier-background-image--profile);
-    }
-    &--product {
-        background-image: url($fd-identifier-background-image--product);
-    }
+
 }

--- a/scss/components/image.scss
+++ b/scss/components/image.scss
@@ -2,7 +2,7 @@
 @import "./../mixins";
 @import "./../functions";
 /*!
-.fd-image+((--rounded|--circle), (--xs|--s|--m|--l|--xl|--xxl), (--product|--profile))
+.fd-image+((--circle), (--s|--m|--l))
 */
 $block: #{$fd-namespace}-image;
 .#{$block} {
@@ -12,40 +12,35 @@ $block: #{$fd-namespace}-image;
       m: 36px,
       l: 48px
     ) !default;
-    $fd-image-background: transparent !default;
-    $fd-image-background--placeholder: fd-color(neutral, 2) !default;
-    $fd-image-background-image--profile: "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTIiIGhlaWdodD0iNTIiIHZpZXdCb3g9IjAgMCA1MiA1MiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU+dG4taW1hZ2UtYmFja2dyb3VuZC1pbWFnZS0tcHJvZmlsZTwvdGl0bGU+PHBhdGggZD0iTTI2IDM5di0xaDExYy0yLjc1NC42NjctNi40MiAxLTExIDF6bTAgMGMtMi4xNDggMC01LjgxNS0uMzMzLTExLTFoMTF2MXptMTEtMUgxNWMwLTUuNTU4IDMuNDY0LTEwLjIzNCA4LjE2NS0xMS41OThBNy4wMDIgNy4wMDIgMCAwIDEgMjYgMTNhNyA3IDAgMCAxIDIuODM1IDEzLjQwMkMzMy41MzYgMjcuNzY2IDM3IDMyLjQ0MiAzNyAzOHoiIGZpbGwtcnVsZT0ibm9uemVybyIgZmlsbD0iI0ZGRiIvPjwvc3ZnPg==" !default;
-    $fd-image-background-image--product: "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTIiIGhlaWdodD0iNTIiIHZpZXdCb3g9IjAgMCA1MiA1MiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU+dG4taW1hZ2UtYmFja2dyb3VuZC1pbWFnZS0tcHJvZHVjdDwvdGl0bGU+PHBhdGggZD0iTTEzLjg3NiAxOC4yMjNsNS44NzQtMi41NTUgMTEgNS45MzQtNS4yOTEgMi4xNzgtMTEuNTgzLTUuNTU3ek0xMyAzMy4wNDN2LTE0LjAzbDExLjkxNyA1LjcxdjE0LjA5MWwtMTEuNTktNS4yNzVhLjU0LjU0IDAgMCAxLS4zMjctLjQ5N3ptMy4yNS05LjIwOXY1LjQxN2EuNTQuNTQgMCAwIDAgLjMxNy40OTNsNS40MTcgMi43MDhjLjM1OC4xNjMuNzY2LS4xLjc2Ni0uNDkzdi01LjQxN2EuNTQyLjU0MiAwIDAgMC0uMzE3LS40OTJsLTUuNDE3LTIuNzA5YS41NDIuNTQyIDAgMCAwLS43NjYuNDkzem05Ljc1Ljg4OWwxMy01LjcxdjE0LjAzYS41NC41NCAwIDAgMS0uMzI2LjQ5NkwyNiAzOC44MTVWMjQuNzIzem0xMi4xMjQtNi41bC02LjE0IDIuODEzLTEwLjk3LTUuOTE3IDQuNzctMi4wNzNhLjUzNi41MzYgMCAwIDEgLjQzMiAwbDExLjkwOCA1LjE3N3oiIGZpbGwtcnVsZT0ibm9uemVybyIgZmlsbD0iI0ZGRiIvPjwvc3ZnPg==" !default;
+    $fd-image-border-radius: $fd-border-radius !default;
 
     //BLOCK BASE *******************************************
-    @include fd-reset;
-    display: inline-block;
-    vertical-align: middle;
-    background-repeat: no-repeat;
-    background-size: cover;
-    background-position: 50%;
-
+    @at-root {
+      [class*="#{$block}"] {
+        @include fd-reset;
+        display: inline-block;
+        vertical-align: middle;
+        background-repeat: no-repeat;
+        background-size: cover;
+        background-position: 50%;
+        border-radius: $fd-image-border-radius;
+      }
+    }
     //BLOCK MODIFIERS ************
     //sizes
     border-radius: $fd-border-radius;
     @each $size, $value in $fd-image-sizes {
-        &--#{$size} {
-            width: $value;
-            height: $value;
-        }
+      &--#{$size} {
+        width: $value;
+        height: $value;
+        max-width: $value;
+        max-height: $value;
+        min-width: $value;
+        min-height: $value;
+      }
     }
     //borders
     &--circle {
-        border-radius: 50%;
-    }
-    //placeholders
-    &--profile, &--product {
-        background-color: $fd-image-background--placeholder;
-    }
-    &--profile {
-        background-image: url($fd-image-background-image--profile);
-    }
-    &--product {
-        background-image: url($fd-image-background-image--product);
+      border-radius: 50%;
     }
 }

--- a/scss/components/image.scss
+++ b/scss/components/image.scss
@@ -28,7 +28,6 @@ $block: #{$fd-namespace}-image;
     }
     //BLOCK MODIFIERS ************
     //sizes
-    border-radius: $fd-border-radius;
     @each $size, $value in $fd-image-sizes {
       &--#{$size} {
         width: $value;

--- a/scss/components/image.scss
+++ b/scss/components/image.scss
@@ -8,12 +8,9 @@ $block: #{$fd-namespace}-image;
 .#{$block} {
     //LOCAL VARS (set all themeable properties, always include !default)
     $fd-image-sizes: (
-        xs: 20px,
-        s: 36px,
-        m: 52px,
-        l: 72px,
-        xl: 92px,
-        xxl: 120px,
+      s: 24px,
+      m: 36px,
+      l: 48px
     ) !default;
     $fd-image-background: transparent !default;
     $fd-image-background--placeholder: fd-color(neutral, 2) !default;
@@ -30,6 +27,7 @@ $block: #{$fd-namespace}-image;
 
     //BLOCK MODIFIERS ************
     //sizes
+    border-radius: $fd-border-radius;
     @each $size, $value in $fd-image-sizes {
         &--#{$size} {
             width: $value;
@@ -37,13 +35,6 @@ $block: #{$fd-namespace}-image;
         }
     }
     //borders
-    &--rounded {
-        border-radius: 8px;
-        &.#{$block}--xs,
-        &.#{$block}--s {
-            border-radius: 4px;
-        }
-    }
     &--circle {
         border-radius: 50%;
     }

--- a/scss/helpers/_general.scss
+++ b/scss/helpers/_general.scss
@@ -26,6 +26,9 @@
 .#{$fd-namespace}-has-float-right {
     float: right !important;
 }
+.#{$fd-namespace}-has-border-radius-0 {
+    border-radius: 0 !important;
+}
 .#{$fd-namespace}-has-border-radius-50percent {
     border-radius: 50% !important;
 }

--- a/scss/icons/_mixins.scss
+++ b/scss/icons/_mixins.scss
@@ -40,6 +40,7 @@
       font-size: map-get($fd-icons-sizes, "default");
       line-height: $fd-line-height;
     }
+    @content;
   }
 }
 

--- a/test/templates/identifier/component.njk
+++ b/test/templates/identifier/component.njk
@@ -5,13 +5,6 @@ identifier:
     state={},
     aria={}
 -->
-{% macro identifier(properties={}, modifier={}, state={}, aria={}) -%}
-<div class="fd-identifier{{ modifier.block | modifier('identifier') }}{{ state | state }}"{{ aria | aria }}>
-    <div class="fd-identifier__content{{ modifier.content | modifier('identifier__content') }}">
-        <h1 class="fd-identifier__title">{{ properties.title }}</h1>
-        {%- if properties.description %}
-            {{ properties.description }}
-        {%- endif %}
-    </div>
-</div>
+{% macro identifier(properties={}, modifier={}, state={}, aria={}, classes="") -%}
+<span class="{{ modifier.block | modifier('identifier') }}{{ ' sap-icon--'+properties.icon if properties.icon }}{{ state | state }}{{ classes | classes }}"{{ aria | aria }}>{{ properties.initials if properties.initials }}</span>
 {%- endmacro %}

--- a/test/templates/identifier/component.njk
+++ b/test/templates/identifier/component.njk
@@ -1,0 +1,17 @@
+<!--
+identifier:
+    properties={},
+    modifier={ block: [] },
+    state={},
+    aria={}
+-->
+{% macro identifier(properties={}, modifier={}, state={}, aria={}) -%}
+<div class="fd-identifier{{ modifier.block | modifier('identifier') }}{{ state | state }}"{{ aria | aria }}>
+    <div class="fd-identifier__content{{ modifier.content | modifier('identifier__content') }}">
+        <h1 class="fd-identifier__title">{{ properties.title }}</h1>
+        {%- if properties.description %}
+            {{ properties.description }}
+        {%- endif %}
+    </div>
+</div>
+{%- endmacro %}

--- a/test/templates/identifier/data.json
+++ b/test/templates/identifier/data.json
@@ -1,0 +1,18 @@
+{
+    "id": "identifier",
+    "name": "Identifier",
+    "properties": {
+        "title": "Identifier Label",
+        "description": "Identifier Description"
+    },
+    "modifier": {
+        "block": ["no-border"]
+    },
+    "state": {
+
+    },
+    "aria": {
+
+    }
+
+}

--- a/test/templates/identifier/data.json
+++ b/test/templates/identifier/data.json
@@ -2,7 +2,8 @@
     "id": "identifier",
     "name": "Identifier",
     "properties": {
-
+      "initials": "WW",
+      "icon": "washing-machine"
     },
     "modifier": {
         "block": ["s","m","l"]
@@ -11,7 +12,7 @@
 
     },
     "aria": {
-        "label": "Identifier label"
+      "label": "Wendy Wallace"
     }
 
 }

--- a/test/templates/identifier/data.json
+++ b/test/templates/identifier/data.json
@@ -2,17 +2,16 @@
     "id": "identifier",
     "name": "Identifier",
     "properties": {
-        "title": "Identifier Label",
-        "description": "Identifier Description"
+
     },
     "modifier": {
-        "block": ["no-border"]
+        "block": ["s","m","l"]
     },
     "state": {
 
     },
     "aria": {
-
+        "label": "Identifier label"
     }
 
 }

--- a/test/templates/identifier/index.njk
+++ b/test/templates/identifier/index.njk
@@ -4,165 +4,214 @@
 {% from "./component.njk" import identifier %}
 
 <!-- include add'tl css from src/styles/, e.g., ['helpers','components/button'] -->
-{% set css_deps = ['fonts','icons'] %}
+{% set css_deps = ['fonts','icons','helpers'] %}
 
 {% block content %}
+
+
+
+<h1>specs</h1>
+<p>Three sizes, default matches the base font size (14px)</p>
+<table>
+  <tr>
+    <td style="padding-right: 20px;">
+      {{  identifier(
+              properties={ icon: data.properties.icon },
+              modifier={ block: ["s"] },
+              classes="has-background-color-accent-12"
+          )
+      }}
+    </td>
+    <td>
+      <span>small (s) - 24px
+    </td>
+    <td>
+<code>.fd-identifier--s</code>
+
+    </td>
+  </tr>
+  <tr>
+    <td>
+      {{  identifier(
+              properties={ icon: data.properties.icon },
+              modifier={ block: ["m"] },
+              classes="has-background-color-accent-12"
+          )
+      }}
+    </td>
+    <td>
+
+  medium (m) - 36px
+    </td>
+    <td>
+<code>.fd-identifier--m</code>
+
+    </td>
+
+  </tr>
+  <tr>
+    <td style="padding-right: 20px;">
+      {{  identifier(
+              properties={ icon: data.properties.icon },
+              modifier={ block: ["l"] },
+              classes="has-background-color-accent-12"
+          )
+      }}
+    </td>
+    <td>
+
+  large (l) - 48px
+    </td>
+    <td>
+<code>.fd-identifier--l</code>
+
+    </td>
+
+  </tr>
+
+</table>
+
+<br><hr><br>
+
+
+
+
+
+
+
+
 {% set sizes = ["s","m","l"] %}
     <h1>identifier</h1>
 
-    <h2>default</h2>
+    <h2>icon</h2>
+    <p>
+Include <code>role="presentation"</code> when the identifier is only used for illustrative purposes. For example, if the icon sits right next to a label then use the role ... <br>
+< {{  identifier(
+        properties={
+          icon: "washing-machine"
+        },
+        modifier={
+            block: ["s"]
+        },
+        aria={
+          role: "presentation"
+        }
+    )
+}} Washing machine >. An icon used alone should include the <code>aria-label</code> attribute to give it meaning as in the initials examples.
+    </p>
     {%- set example %}
 {%- for size in sizes %}
 {{  identifier(
-        properties=data.properties,
+        properties={
+          icon: "washing-machine"
+        },
         modifier={
             block: size
         },
-        aria=data.aria
+        aria={
+          role: "presentation"
+        }
     )
 }}
-{% endfor %}
+{%- endfor %}
     {%- endset %}
     {{ format(example) }}
 <br><br>
-{#
-    <h2>rounded</h2>
-    {%- set example %}
+
+<h2>initials</h2>
+<p>Include <code>aria-label</code> when there is no text equivalent of the identifier. It is not necessary if the identfier is illustrative only.</p>
+{%- set example %}
+{%- for size in sizes %}
+{{  identifier(
+    properties={
+      initials: "WW"
+    },
+    modifier={
+        block: size
+    },
+    aria=data.aria
+)
+}}
+{%- endfor %}
+{%- endset %}
+{{ format(example) }}
+<br><br>
+
+    <h2>circle</h2>
+{%- set example %}
 {% for size in sizes %}
 {{  identifier(
-        properties=data.properties,
-        modifier={
-            block: [size, "rounded"]
+        properties={
+                icon: "money-bills"
         },
-        aria=data.aria
+        modifier={
+            block: [size, "circle"]
+        },
+        aria={
+          role: "presentation"
+        }
     )
 }}
-{% endfor %}
-    {%- endset %}
-    {{ format(example) }}
-
-<br><br> #}
-    <h2>circle</h2>
-    {%- set example %}
+{%- endfor %}
+<br><br>
 {% for size in sizes %}
 {{  identifier(
-        properties=data.properties,
+        properties={
+                initials: "WW"
+        },
         modifier={
             block: [size, "circle"]
         },
         aria=data.aria
     )
 }}
-{% endfor %}
+{%- endfor %}
+
     {%- endset %}
     {{ format(example) }}
 
 <br><br>
-<h1>placeholder images</h1>
 
-    <h2>profile</h2>
-    {%- set example %}
-{% for size in sizes %}
-{{  identifier(
-        properties={},
-        modifier={
-            block: [size, "profile"]
-        },
-        aria={
-            label: "John Smith"
-        }
-    )
-}}
-{% endfor %}
-    {%- endset %}
-    {{ format(example) }}
-
-<br>
+<h2>accent colors</h2>
+<p>Use helpers classes tp change the background colors, e.g., <code>.fd-has-background-color-accent-10</code>
+</p>
 {%- set example %}
-{% for size in sizes %}
+{% for num in [1,2,3,4,5,6,7,8,9,10,11,12] %}
+{%- set cls = "has-background-color-accent-"+num %}
 {{  identifier(
-    properties={},
+    properties={
+            icon: "money-bills"
+    },
     modifier={
-        block: [size, "rounded", "profile"]
+        block: ["m"]
     },
     aria={
-        label: "John Smith"
-    }
-)
-}}
-{% endfor %}
-{%- endset %}
-{{ format(example) }}
-
-<br>
-
-{%- set example %}
-{% for size in sizes %}
-{{  identifier(
-    properties={},
-    modifier={
-        block: [size, "circle", "profile"]
+      role: "presentation"
     },
-    aria={
-        label: "John Smith"
-    }
+    classes=cls
 )
 }}
-{% endfor %}
-{%- endset %}
-{{ format(example) }}
-
-    <br><br>
-    <h2>product</h2>
-
-    {%- set example %}
-{% for size in sizes %}
+{%- endfor %}
+<br><br>
+{% for num in [1,2,3,4,5,6,7,8,9,10,11,12] | reverse %}
+{%- set cls = "has-background-color-accent-"+num %}
 {{  identifier(
-        properties={},
-        modifier={
-            block: [size, "product"]
-        },
-        aria={
-            label: "Product name"
-        }
-    )
-}}
-{% endfor %}
-    {%- endset %}
-    {{ format(example) }}
-
-<br>
-{%- set example %}
-{% for size in sizes %}
-{{  identifier(
-    properties={},
-    modifier={
-        block: [size, "rounded", "product"]
+    properties={
+            initials: "WW"
     },
-    aria={
-        label: "Product name"
-    }
+    modifier={
+        block: ["m", "circle"]
+    },
+    aria=data.aria,
+    classes=cls
 )
 }}
-{% endfor %}
-{%- endset %}
-{{ format(example) }}
+{%- endfor %}
+
+
 
 <br>
 
-{%- set example %}
-{% for size in sizes %}
-{{  identifier(
-    properties={},
-    modifier={
-        block: [size, "circle", "product"]
-    },
-    aria={
-        label: "Product name"
-    }
-)
-}}
-{% endfor %}
 {%- endset %}
 {{ format(example) }}
 

--- a/test/templates/identifier/index.njk
+++ b/test/templates/identifier/index.njk
@@ -4,37 +4,168 @@
 {% from "./component.njk" import identifier %}
 
 <!-- include add'tl css from src/styles/, e.g., ['helpers','components/button'] -->
-{% set css_deps = [] %}
+{% set css_deps = ['fonts','icons'] %}
 
 {% block content %}
-
+{% set sizes = ["s","m","l"] %}
     <h1>identifier</h1>
 
-    <!-- output the component example and the code snippet -->
-    {% set example %}
-    {{  identifier(
-            properties={
-                title: "Sed bibendum sapien",
-                description: "Morbi sodales gravida pulvinar. Duis malesuada odio volutpat elementum vulputate massa magna scelerisque ante et accumsan."
-            },
-            modifier={
-                block: []
-            },
-            state={},
-            aria={}
-        )
-    }}
-    {{  identifier(
-            properties=data.properties,
-            modifier={
-                block: data.modifier.block
-            },
-            state=data.state,
-            aria=data.aria
-        )
-    }}
-    {% endset %}
+    <h2>default</h2>
+    {%- set example %}
+{%- for size in sizes %}
+{{  identifier(
+        properties=data.properties,
+        modifier={
+            block: size
+        },
+        aria=data.aria
+    )
+}}
+{% endfor %}
+    {%- endset %}
     {{ format(example) }}
+<br><br>
+{#
+    <h2>rounded</h2>
+    {%- set example %}
+{% for size in sizes %}
+{{  identifier(
+        properties=data.properties,
+        modifier={
+            block: [size, "rounded"]
+        },
+        aria=data.aria
+    )
+}}
+{% endfor %}
+    {%- endset %}
+    {{ format(example) }}
+
+<br><br> #}
+    <h2>circle</h2>
+    {%- set example %}
+{% for size in sizes %}
+{{  identifier(
+        properties=data.properties,
+        modifier={
+            block: [size, "circle"]
+        },
+        aria=data.aria
+    )
+}}
+{% endfor %}
+    {%- endset %}
+    {{ format(example) }}
+
+<br><br>
+<h1>placeholder images</h1>
+
+    <h2>profile</h2>
+    {%- set example %}
+{% for size in sizes %}
+{{  identifier(
+        properties={},
+        modifier={
+            block: [size, "profile"]
+        },
+        aria={
+            label: "John Smith"
+        }
+    )
+}}
+{% endfor %}
+    {%- endset %}
+    {{ format(example) }}
+
+<br>
+{%- set example %}
+{% for size in sizes %}
+{{  identifier(
+    properties={},
+    modifier={
+        block: [size, "rounded", "profile"]
+    },
+    aria={
+        label: "John Smith"
+    }
+)
+}}
+{% endfor %}
+{%- endset %}
+{{ format(example) }}
+
+<br>
+
+{%- set example %}
+{% for size in sizes %}
+{{  identifier(
+    properties={},
+    modifier={
+        block: [size, "circle", "profile"]
+    },
+    aria={
+        label: "John Smith"
+    }
+)
+}}
+{% endfor %}
+{%- endset %}
+{{ format(example) }}
+
+    <br><br>
+    <h2>product</h2>
+
+    {%- set example %}
+{% for size in sizes %}
+{{  identifier(
+        properties={},
+        modifier={
+            block: [size, "product"]
+        },
+        aria={
+            label: "Product name"
+        }
+    )
+}}
+{% endfor %}
+    {%- endset %}
+    {{ format(example) }}
+
+<br>
+{%- set example %}
+{% for size in sizes %}
+{{  identifier(
+    properties={},
+    modifier={
+        block: [size, "rounded", "product"]
+    },
+    aria={
+        label: "Product name"
+    }
+)
+}}
+{% endfor %}
+{%- endset %}
+{{ format(example) }}
+
+<br>
+
+{%- set example %}
+{% for size in sizes %}
+{{  identifier(
+    properties={},
+    modifier={
+        block: [size, "circle", "product"]
+    },
+    aria={
+        label: "Product name"
+    }
+)
+}}
+{% endfor %}
+{%- endset %}
+{{ format(example) }}
+
 
 
 {% endblock %}

--- a/test/templates/identifier/index.njk
+++ b/test/templates/identifier/index.njk
@@ -1,0 +1,40 @@
+{% extends "layout.njk" %}
+{% from "./../format.njk" import format %}
+{% from "../button/component.njk" import button %}
+{% from "./component.njk" import identifier %}
+
+<!-- include add'tl css from src/styles/, e.g., ['helpers','components/button'] -->
+{% set css_deps = [] %}
+
+{% block content %}
+
+    <h1>identifier</h1>
+
+    <!-- output the component example and the code snippet -->
+    {% set example %}
+    {{  identifier(
+            properties={
+                title: "Sed bibendum sapien",
+                description: "Morbi sodales gravida pulvinar. Duis malesuada odio volutpat elementum vulputate massa magna scelerisque ante et accumsan."
+            },
+            modifier={
+                block: []
+            },
+            state={},
+            aria={}
+        )
+    }}
+    {{  identifier(
+            properties=data.properties,
+            modifier={
+                block: data.modifier.block
+            },
+            state=data.state,
+            aria=data.aria
+        )
+    }}
+    {% endset %}
+    {{ format(example) }}
+
+
+{% endblock %}

--- a/test/templates/image/component.njk
+++ b/test/templates/image/component.njk
@@ -6,5 +6,5 @@ image:
     aria={}
 -->
 {% macro image(properties={}, modifier={}, state={}, aria={}) -%}
-<span class="fd-image{{ modifier.block | modifier('image') }}{{ state | state }}"{{ aria | aria }}{{ ' style="background-image: url(\'' + properties.url + '\');"' if properties.url }}></span>
+<span class="{{ modifier.block | modifier('image') }}{{ state | state }}"{{ aria | aria }}{{ ' style="background-image: url(\'' + properties.url + '\');"' if properties.url }}></span>
 {%- endmacro %}

--- a/test/templates/image/data.json
+++ b/test/templates/image/data.json
@@ -5,7 +5,7 @@
         "url": "https://placeimg.com/400/400/nature"
     },
     "modifier": {
-        "block": []
+        "block": ["s","m","l"]
     },
     "state": {
 

--- a/test/templates/image/index.njk
+++ b/test/templates/image/index.njk
@@ -7,6 +7,70 @@
 {% set css_deps = ['fonts','icons'] %}
 
 {% block content %}
+
+
+<h1>specs</h1>
+<p>Three sizes, default matches the base font size (14px)</p>
+<table>
+  <tr>
+    <td>
+      {{  image(
+        properties=data.properties,
+        modifier={ block: ["s"] }
+          )
+      }}
+    </td>
+    <td>
+      <span>small (s) - 24px
+    </td>
+    <td>
+<code>.fd-image--s</code>
+
+    </td>
+  </tr>
+  <tr>
+    <td>
+      {{  image(
+        properties=data.properties,
+        modifier={ block: ["m"] }
+          )
+      }}
+    </td>
+    <td>
+
+  medium (m) - 36px
+    </td>
+    <td>
+<code>.fd-image--m</code>
+
+    </td>
+
+  </tr>
+  <tr>
+    <td style="padding-right: 20px;">
+      {{  image(
+              properties=data.properties,
+              modifier={ block: ["l"] }
+          )
+      }}
+    </td>
+    <td>
+
+  large (l) - 48px
+    </td>
+    <td>
+<code>.fd-image--l</code>
+
+    </td>
+
+  </tr>
+
+</table>
+
+<br><hr><br>
+
+
+
 {% set sizes = ["s","m","l"] %}
     <h1>image</h1>
 

--- a/test/templates/image/index.njk
+++ b/test/templates/image/index.njk
@@ -4,7 +4,7 @@
 {% from "./component.njk" import image %}
 
 <!-- include add'tl css from src/styles/, e.g., ['helpers','components/button'] -->
-{% set css_deps = ['fonts'] %}
+{% set css_deps = ['fonts','icons'] %}
 
 {% block content %}
 {% set sizes = ["s","m","l"] %}
@@ -56,115 +56,6 @@
 {% endfor %}
     {%- endset %}
     {{ format(example) }}
-
-<br><br>
-<h1>placeholder images</h1>
-
-    <h2>profile</h2>
-    {%- set example %}
-{% for size in sizes %}
-{{  image(
-        properties={},
-        modifier={
-            block: [size, "profile"]
-        },
-        aria={
-            label: "John Smith"
-        }
-    )
-}}
-{% endfor %}
-    {%- endset %}
-    {{ format(example) }}
-
-<br>
-{%- set example %}
-{% for size in sizes %}
-{{  image(
-    properties={},
-    modifier={
-        block: [size, "rounded", "profile"]
-    },
-    aria={
-        label: "John Smith"
-    }
-)
-}}
-{% endfor %}
-{%- endset %}
-{{ format(example) }}
-
-<br>
-
-{%- set example %}
-{% for size in sizes %}
-{{  image(
-    properties={},
-    modifier={
-        block: [size, "circle", "profile"]
-    },
-    aria={
-        label: "John Smith"
-    }
-)
-}}
-{% endfor %}
-{%- endset %}
-{{ format(example) }}
-
-    <br><br>
-    <h2>product</h2>
-
-    {%- set example %}
-{% for size in sizes %}
-{{  image(
-        properties={},
-        modifier={
-            block: [size, "product"]
-        },
-        aria={
-            label: "Product name"
-        }
-    )
-}}
-{% endfor %}
-    {%- endset %}
-    {{ format(example) }}
-
-<br>
-{%- set example %}
-{% for size in sizes %}
-{{  image(
-    properties={},
-    modifier={
-        block: [size, "rounded", "product"]
-    },
-    aria={
-        label: "Product name"
-    }
-)
-}}
-{% endfor %}
-{%- endset %}
-{{ format(example) }}
-
-<br>
-
-{%- set example %}
-{% for size in sizes %}
-{{  image(
-    properties={},
-    modifier={
-        block: [size, "circle", "product"]
-    },
-    aria={
-        label: "Product name"
-    }
-)
-}}
-{% endfor %}
-{%- endset %}
-{{ format(example) }}
 
 
 

--- a/test/templates/image/index.njk
+++ b/test/templates/image/index.njk
@@ -7,7 +7,7 @@
 {% set css_deps = ['fonts'] %}
 
 {% block content %}
-{% set sizes = ["xs","s","m","l","xl","xxl"] %}
+{% set sizes = ["s","m","l"] %}
     <h1>image</h1>
 
     <h2>default</h2>
@@ -26,7 +26,7 @@
     {{ format(example) }}
 <br><br>
 
-    <h2>rounded</h2>
+    {# <h2>rounded</h2>
     {%- set example %}
 {% for size in sizes %}
 {{  image(
@@ -41,7 +41,7 @@
     {%- endset %}
     {{ format(example) }}
 
-<br><br>
+<br><br> #}
     <h2>circle</h2>
     {%- set example %}
 {% for size in sizes %}

--- a/test/templates/index.njk
+++ b/test/templates/index.njk
@@ -24,6 +24,7 @@ li {
     <li><a href="dropdown">.fd-dropdown</a></li>
     <li><a href="form">.fd-form > .fd-form__group</a></li>
     <li><a href="icon">.fd-icon</a></li>
+    <li><a href="identifier">.fd-identifier</a></li>
     <li><a href="image">.fd-image</a></li>
     <li><a href="inline-help">.fd-inline-help</a></li>
     <li><a href="input-group">.fd-input-group</a></li>


### PR DESCRIPTION
#188 

## Updates
- The placeholder images have been removed since an identifier can now be used with any icon. http://localhost:3030/image
- The identifier is a new component but sizing is the same as image. It can take an icon or initials for content. http://localhost:3030/identifier
- The `rounded` variant is now the default with no square option. A new helper `.fd-has-border-radius-0` was added which could be used to force a square.
- The heights and widths are forced with max and min declarations. I was seeing some weird behavior in flex situations where the images were being squished.


> Like the icons, I wrote these so that the base class is not required. You can simply use `.fd-image--s` and all the base styles will be applied.