### PR TITLE
#204 updates modal, add overlay example page

### DIFF
--- a/scss/components/modal.scss
+++ b/scss/components/modal.scss
@@ -1,7 +1,8 @@
 @import "./../settings";
 @import "./../mixins";
 @import "./../functions";
-//@import "../components/button";
+@import "./../icons/mixins";
+@import "./mixins";
 /*!
 .fd-modal
     .fd-modal__header
@@ -12,38 +13,49 @@
       .fd-modal__button-secondary
 */
 $block: #{$fd-namespace}-modal;
-  $fd-modal-border-color: fd-color(neutral, 3) !default;
-  $fd-modal-inner-padding: fd-space(10) !default;
-  $fd-modal-inner-content-background: fd-color(background, 1) !default;
+  $fd-modal-width: 460px !default;
+  //these are used only to roughly calculate body overflow on compact screens - this can be improved with a flex or grid solution
+  $fd-modal-header-height: 60px !default;
+  $fd-modal-footer-height: 68px !default;
 
+  $fd-modal-border-color: fd-color("neutral", 2) !default;
+  $fd-modal-padding-x: $fd-width--gutter !default;
+  $fd-modal-padding-y: fd-space(4) !default;
+  $fd-modal-inner-content-background: fd-color("background", 2) !default;
 
 .#{$block} {
   @include fd-reset;
-  max-width: 700px;
-  margin: fd-space(8) auto;
+  max-width: $fd-modal-width;
   &__content{
+    border-radius: $fd-border-radius;
     background-color: $fd-modal-inner-content-background;
-    button{
-      float: right;
-    }
   }
-  &__header{
+  &__header {
+    position: relative;
     border-bottom: 1px solid $fd-modal-border-color;
-    padding-left: $fd-modal-inner-padding;
-    padding-top: $fd-modal-inner-padding;
-    padding-right: $fd-modal-inner-padding/2;
+    padding: $fd-modal-padding-y $fd-modal-padding-x;
   }
   &__title{
-      @include fd-type("4",header, med);
+    @include fd-type("1");
+    margin-bottom: 0;
+  }
+  &__close {
+    position: absolute;
+    right: fd-space(1);
+    top: fd-space(2);
+    @include fd-icon("decline", "l");
+    @include fd-button-reset;
+    color: fd-color("text", 1);
+    width: fd-space(9);
+    height: fd-space(9);
   }
   &__body{
-    padding: $fd-modal-inner-padding;
+    padding: $fd-modal-padding-y $fd-modal-padding-x;
+    max-height: calc(100vh - #{$fd-modal-header-height} - #{$fd-modal-footer-height});
+    overflow: scroll;
   }
-  &__footer-items {
-    display: block;
-    overflow: auto;
-    border-top: 1px solid $fd-modal-border-color;
-    padding: $fd-modal-inner-padding;
-    padding-top: $fd-modal-inner-padding/2;
+  &__footer {
+    padding: $fd-modal-padding-y $fd-modal-padding-x;
+    text-align: right;
   }
 }

--- a/scss/layout/overlay.scss
+++ b/scss/layout/overlay.scss
@@ -6,7 +6,7 @@
 */
 $block: #{$fd-namespace}-overlay;
 .#{$block} {
-  $fd-overlay-background-color: rgba(black,0.8) !default;
+  $fd-overlay-background-color: rgba(#4A505C,0.3) !default;
   position: fixed;
   display: flex;
   align-items: center;
@@ -16,7 +16,7 @@ $block: #{$fd-namespace}-overlay;
   top: 0;
   background: $fd-overlay-background-color;
   z-index: 1000;
-  color: fd-color(text-inverse);
+  //color: fd-color(text-inverse);
   &[aria-hidden="true"] {
       display: none;
   }

--- a/test/templates/index.njk
+++ b/test/templates/index.njk
@@ -45,6 +45,7 @@ li {
 <h1>Layout</h1>
 <ul>
     <li><a href="pages/app">.fd-ui .fd-app</a></li>
+    <li><a href="pages/overlay">.fd-ui__overlay</a></li>
     <li><a href="pages/page">.fd-page</a></li>
     <li><a href="pages/section">.fd-section</a></li>
     <li><a href="pages/panel">.fd-panel</a></li>

--- a/test/templates/modal/component.njk
+++ b/test/templates/modal/component.njk
@@ -6,28 +6,31 @@ modal:
     properties={},
 -->
 {% macro modal(properties={}) %}
-
-<div class="fd-modal">
-  <div class="fd-modal__content">
-      <div class="fd-modal__header">
-          <button class="fd-button fd-button--text fd-button--icon fd-button--small" aria-label="close">
-            <span class="fd-icon fd-icon--close" role="presentation"></span>
-          </button>
-          <h4 class="fd-modal__title">{{properties.header}}</h4>
-      </div>
+<div class="fd-modal" role="dialog">
+  <div class="fd-modal__content" role="document">
+      <header class="fd-modal__header">
+          <h1 class="fd-modal__title">{{properties.header}}</h1>
+          <button class="fd-modal__close" aria-label="close"></button>
+      </header>
       <div class="fd-modal__body">
             {{properties.body}}
       </div>
-      <footer class="fd-modal__footer-items">
-        {%- for item in properties.footerActions %}
-          {%- if item.type === "primary" %}
-            <button class="fd-button">{{item.label}}</button>
-          {%- else %}
-            <button class="fd-button fd-button--text">{{item.label}}</button>
-          {%- endif %}
-        {%- endfor %}
-      </footer>
+      <footer class="fd-modal__footer">
+        <div class="fd-modal__actions">
+          {%- for item in properties.actions %}
+          {{  button(
+                  {
+                      label: item.label
+                  },
+                  modifier={
+                      block: [item.type]
+                  })
+          }}
+          {%- endfor %}
+        </div>
+        </footer>
   </div>
+
 </div>
 
 {%- endmacro %}

--- a/test/templates/modal/index.njk
+++ b/test/templates/modal/index.njk
@@ -1,34 +1,31 @@
 {% extends "layout.njk" %}
 {% from "./../format.njk" import format %}
 {% from "./component.njk" import modal %}
-{% from "../button/component.njk" import button %}
 {% from "../icon/component.njk" import icon %}
-{% set css_deps = ['fonts','components/button','icons'] %}
+{% set css_deps = ['fonts','components/button','icons','layout/overlay'] %}
 
 {% block content %}
 
-<h1>Modal</h1>
+<h1>modal</h1>
 
+<p>
+NOTE: The <code>modal</code> itself does not provide the outer container. Use the <code>.fd-overlay</code> layout component in conjunction with the <code>.fd-ui__overlay</code> template container to hide and show the modal. See <a href="http://localhost:3030/pages/overlay">the overlay example</a>.
+
+</p>
 {% set example %}
-{{  modal(
-      properties={
-          header: "Modal Header",
-          body: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. ",
-          footerActions: [
-            {type: 'primary', label: 'Primary'},
-            {type: 'secondary', label: 'Secondary'}
-          ]
-        }
-    )
-}}
-{%- set btn %}
-{{  button(
-        {
-            type: '',
-            label: ''
-        }
+
+
+  {{  modal(
+        properties={
+            header: "Modal Header",
+            body: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+            actions: [
+              {type: 'secondary', label: 'Cancel'},
+              {type: '', label: 'Confirm'}
+            ]
+          }
       )
-}}{%- endset %}
+  }}
 
 {% endset %}
 {{ format(example) }}

--- a/test/templates/pages/overlay.njk
+++ b/test/templates/pages/overlay.njk
@@ -1,0 +1,42 @@
+{% extends "./layouts/app.njk" %}
+{% from "./../modal/component.njk" import modal %}
+{% from "./../button/component.njk" import button %}
+{# ui-level settings #}
+{% set fix_ui_header = false %}
+{% block ui_header -%}
+ui_header
+{%- endblock %}
+{% set hide_ui_footer = false %}
+{% set fix_ui_footer = false %}
+{% block ui_footer -%}
+ui_footer
+{%- endblock %}
+{% set show_ui_overlay = true %}
+{% block ui_overlay %}
+{# ui_overlay #}
+
+
+  {{  modal(
+        properties={
+            header: "Modal Header",
+            body: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.",
+            actions: [
+              {type: 'secondary', label: 'Cancel'},
+              {type: '', label: 'Confirm'}
+            ]
+          }
+      )
+  }}
+
+
+
+{% endblock %}
+
+{# app-level settings #}
+{% set hide_app_sidebar = false %}
+{% block app_sidebar %}
+app_sidebar
+{% endblock %}
+{% block app_main %}
+app_main
+{% endblock %}


### PR DESCRIPTION
#204 

## Updates
- Markup for the `footer` changed — the element class is now `__footer` and added an `actions` container
- Added an example page using the `.ui__overlay` and `.fd-overlay` components at http://localhost:3030/pages/overlay