### PR TITLE
#193 introduces button-group component

### DIFF
--- a/scss/components.scss
+++ b/scss/components.scss
@@ -25,3 +25,4 @@
 @import "components/side-nav";
 @import "components/link";
 @import "components/identifier";
+@import "components/button-group";

--- a/scss/components/button-group.scss
+++ b/scss/components/button-group.scss
@@ -1,0 +1,36 @@
+@import "./../settings";
+@import "./../mixins";
+@import "./../functions";
+
+/*!
+.fd-button-group+()
+    .fd-button
+*/
+$block: #{$fd-namespace}-button-group;
+
+.#{$block} {
+
+  @include fd-reset-spacing;
+  display: flex;
+  & > * {
+    &:not(:first-child):not(:last-child) {
+      border-radius: 0;
+    }
+    &:not(:last-child) {
+      border-right: none;
+    }
+    &:first-child {
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+    &:last-child {
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+    }
+  }
+
+
+
+
+
+}

--- a/scss/components/button.scss
+++ b/scss/components/button.scss
@@ -52,7 +52,7 @@ $block: #{$fd-namespace}-button;
   //set all reset and baseline block styles
   $defaults: map-get($fd-button-sizes, "default");
   @at-root {
-    [class*="#{$block}"] {
+    .#{$block}, [class*="#{$block}--"] {
       @include fd-button-reset;
       background-color: $fd-button-background-color;
       color: $fd-button-color;
@@ -214,7 +214,8 @@ $block: #{$fd-namespace}-button;
       background-color: $fd-button-background-color--secondary;
     }
   }
-  &--toolbar {
+  &--toolbar,
+  &--grouped {
     color: $fd-button-color--toolbar;
     background-color: $fd-button-background-color--toolbar;
     border: solid 1px $fd-button-border-color--toolbar;
@@ -237,6 +238,19 @@ $block: #{$fd-namespace}-button;
     &.is-disabled,
     &:disabled {
       background-color: $fd-button-background-color--secondary;
+    }
+  }
+  &--grouped {
+    &:active,
+    &.is-active,
+    &[aria-selected="true"],
+    &.is-selected,
+    &[aria-pressed="true"],
+    &.is-pressed {
+      color: $fd-button-color--main;
+      background-color: $fd-button-background-color--main;
+      //border-color: $fd-button-background-color--main;
+      border-color: $fd-button-border-color--toolbar;
     }
   }
 

--- a/scss/mixins/_mixins.scss
+++ b/scss/mixins/_mixins.scss
@@ -6,6 +6,10 @@
     color: $fd-color;
     font-family: $fd-font-family;
 }
+@mixin fd-reset-spacing {
+  padding: 0;
+  margin: 0;
+}
 
 //els
 @mixin fd-form-base {

--- a/test/templates/button-group/component.njk
+++ b/test/templates/button-group/component.njk
@@ -1,0 +1,15 @@
+{% from "../button/component.njk" import button %}
+<!--
+button_group:
+    properties={},
+    modifier={ block: [] },
+    state={},
+    aria={}
+-->
+{% macro button_group(properties={}, modifier={}, state={}, aria={}) -%}
+<div class="fd-button-group{{ modifier.block | modifier('button-group') }}{{ state | state }}"{{ aria | aria }} role="group" aria-label="{{properties.label}}">
+{%- for item in properties.buttons %}
+  {{ button( item.properties,item.modifier,aria=item.aria) }}
+{%- endfor %}
+</div>
+{%- endmacro %}

--- a/test/templates/button-group/data.json
+++ b/test/templates/button-group/data.json
@@ -1,0 +1,37 @@
+{
+    "id": "button-group",
+    "name": "Button Group",
+    "properties": {
+        "label": "Group label",
+        "buttons": [
+          {
+            "properties": {
+                "label": "Left"
+            },
+            "aria": {
+                "pressed": true
+            }
+          },
+          {
+            "properties": {
+                "label": "Middle"
+            }
+          },
+          {
+            "properties": {
+                "label": "Right"
+            }
+          }
+        ]
+    },
+    "modifier": {
+
+    },
+    "state": {
+
+    },
+    "aria": {
+
+    }
+
+}

--- a/test/templates/button-group/index.njk
+++ b/test/templates/button-group/index.njk
@@ -1,0 +1,106 @@
+{% extends "layout.njk" %}
+{% from "./../format.njk" import format %}
+{% from "../button/component.njk" import button %}
+{% from "./component.njk" import button_group %}
+
+<!-- include add'tl css from src/styles/, e.g., ['helpers','components/button'] -->
+{% set css_deps = ['components/button','icons'] %}
+
+{% block content %}
+<style media="screen">
+  .fd-button-group {
+    margin-bottom: 10px;
+  }
+</style>
+    <h1>button-group</h1>
+<p>NOTE: The button groups require the buttons to have the modifier class <code>.fd-button--grouped</code>
+
+</p>
+
+    {% for size in ["xs","s","compact","default","l"] %}
+      {%- set modifier = { block: ["grouped", size] } %}
+      {%- if size == "default" %}
+        {%- set modifier = { block: ["grouped"] } %}
+      {%- endif %}
+<h2> {{size}}</h2>
+
+{% set example %}
+{{  button_group(
+properties={
+  label: data.properties.label,
+  buttons: [
+    {
+      "properties": {
+          "icon": "survey"
+      },
+      "modifier": modifier
+    },
+    {
+      "properties": {
+          "icon": "pie-chart"
+      },
+      "modifier": modifier,
+      "aria": {
+          "pressed": true
+      }
+    },
+    {
+      "properties": {
+          "icon": "pool"
+      },
+      "modifier": modifier
+    }
+]
+
+},
+modifier={
+
+},
+state={},
+aria={}
+)
+}}
+
+{{  button_group(
+      properties={
+          label: data.properties.label,
+          buttons: [
+            {
+              properties: {
+                  label: "Left"
+              },
+              modifier: modifier,
+              aria: {
+                  pressed: true
+              }
+            },
+            {
+              properties: {
+                  label: "Middle"
+              },
+              modifier: modifier
+            },
+            {
+              properties: {
+                  label: "Right"
+              },
+              modifier: modifier
+            }
+          ]
+        },
+        modifier={},
+        state=data.state,
+        aria=data.aria
+    )
+}}
+
+
+    {% endset %}
+    {{ format(example) }}
+
+
+    {% endfor %}
+
+
+
+{% endblock %}

--- a/test/templates/index.njk
+++ b/test/templates/index.njk
@@ -17,6 +17,7 @@ li {
     <li><a href="alert">.fd-alert</a></li>
     <li><a href="badge">.fd-badge</a> | <a href="label">.fd-label</a></li>
     <li><a href="button">.fd-button</a></li>
+    <li><a href="button-group">.fd-button-group</a></li>
     <li><a href="breadcrumb">.fd-breadcrumb</a></li>
     <li><a href="card">.fd-card</a></li>
     <li><a href="card-group">.fd-card-group</a></li>


### PR DESCRIPTION
#193

localhost:3030/button-group

Not a perfect match to the design. I retained the borders for the `pressed` state since it's tricky to rain the exact size but remove adjacent borders. Not impossible but we can circle back and do it later.

