### PR TITLE
Feature/209

### DIFF
--- a/scss/components.scss
+++ b/scss/components.scss
@@ -26,3 +26,4 @@
 @import "components/link";
 @import "components/identifier";
 @import "components/button-group";
+@import "components/tag";

--- a/scss/components/button-group.scss
+++ b/scss/components/button-group.scss
@@ -11,7 +11,8 @@ $block: #{$fd-namespace}-button-group;
 .#{$block} {
 
   @include fd-reset-spacing;
-  display: flex;
+  display: inline-flex;
+  vertical-align: middle;
   & > * {
     margin: 0;
     &:not(:first-child):not(:last-child) {

--- a/scss/components/button-group.scss
+++ b/scss/components/button-group.scss
@@ -13,6 +13,7 @@ $block: #{$fd-namespace}-button-group;
   @include fd-reset-spacing;
   display: flex;
   & > * {
+    margin: 0;
     &:not(:first-child):not(:last-child) {
       border-radius: 0;
     }

--- a/scss/components/tag.scss
+++ b/scss/components/tag.scss
@@ -28,6 +28,7 @@ $block: #{$fd-namespace}-tag;
     border-width: 1px;
     border-style: solid;
     border-color: $fd-tag-border-color;
+    cursor: pointer;
 
     @include fd-icon("sys-cancel","s","after") {
       color: fd-color("action",1);

--- a/scss/components/tag.scss
+++ b/scss/components/tag.scss
@@ -1,0 +1,37 @@
+@import "./../settings";
+@import "./../mixins";
+@import "./../icons/mixins";
+@import "./../functions";
+
+/*!
+.fd-tag+(--no-border)
+    .fd-tag__content+()
+    .fd-tag__title+()
+*/
+$block: #{$fd-namespace}-tag;
+
+.#{$block} {
+    //LOCAL VARS (set all themeable properties, always include !default)
+    $fd-tag-border-color: transparent !default;
+    $fd-tag-background-color: rgba(fd-color("action",1),0.07) !default;
+
+    @include fd-reset;
+    @include fd-type("-2");
+    color: fd-color("text",2);
+    background-color: $fd-tag-background-color;
+    line-height: fd-space(6);
+    vertical-align: middle;
+    display: inline-block;
+    padding-left: fd-space(2);
+    padding-right: fd-space(2);
+    border-radius: $fd-border-radius;
+    border-width: 1px;
+    border-style: solid;
+    border-color: $fd-tag-border-color;
+
+    @include fd-icon("sys-cancel","s","after") {
+      color: fd-color("action",1);
+      margin-left: fd-space(base);
+    };
+
+}

--- a/scss/icons/_mixins.scss
+++ b/scss/icons/_mixins.scss
@@ -1,15 +1,18 @@
 @import "./settings";
 
 //icon mixin
-@mixin fd-icon($key, $size: "default") {
-  @include fd-icon-base;
-  @include fd-icon-glyph($key);
-  @include fd-icon-size($size);
+@mixin fd-icon($key, $size: "default", $position: "before") {
+  @include fd-icon-base($position);
+  @include fd-icon-glyph($key, $position);
+  @include fd-icon-size($size,$position);
+  &::#{$position} {
+    @content;
+  }
 }
 
 //icon base mixin
-@mixin fd-icon-base {
-  &::before {
+@mixin fd-icon-base($position: "before") {
+  &::#{$position} {
     font-family: "SAP-icons";
     font-style: normal;
     font-weight: normal;
@@ -25,8 +28,8 @@
 }
 
 //size mixin
-@mixin fd-icon-size($size: "default") {
-  &::before {
+@mixin fd-icon-size($size: "default", $position: "before") {
+  &::#{$position} {
     @if $size != "default" {
       //explicitly
       @if map-has-key($fd-icons-sizes, $size) {
@@ -45,9 +48,9 @@
 }
 
 //icon glyph mixin
-@mixin fd-icon-glyph($glyph) {
+@mixin fd-icon-glyph($glyph, $position: "before") {
   @if map-has-key($fd-icons, $glyph) {
-    &::before {
+    &::#{$position} {
       content: map-get($fd-icons, $glyph);
     }
   } @else {

--- a/scss/layout/panel.scss
+++ b/scss/layout/panel.scss
@@ -11,15 +11,23 @@
 
 $block: #{$fd-namespace}-panel;
 .#{$block} {
-    @include fd-clearfix;
+    $fd-panel-padding: fd-space("reg") fd-space("reg") !default;
     $fd-panel-border: none !default;
     $fd-panel-background-color: fd-color("background",2) !default;
     $fd-panel-box-shadow: 0 5px 20px 0 rgba(fd-color("text"), 0.08) !default;
     $fd-panel-border-radius: $fd-border-radius !default;
+
     $fd-panel-header-border-color: fd-color("neutral",2) !default;
-    $fd-panel-header-border: solid 1px $fd-panel-header-border-color !default;
-    $fd-panel-padding: fd-space("reg") fd-space("reg") !default;
     $fd-panel-title-color: fd-color("text") !default;
+    $fd-panel-filters-padding: fd-space(3) fd-space("reg") !default;
+    $fd-panel-filters-border-color: $fd-panel-header-border-color !default;
+    $fd-panel-footer-padding: fd-space(4) fd-space("reg") !default;
+    $fd-panel-footer-border-color: $fd-panel-header-border-color !default;
+
+    //anim
+    $fd-panel-fiters-transition-params: 0.15s ease-in !default;
+
+    @include fd-clearfix;
     background-color: $fd-panel-background-color;
     box-shadow: $fd-panel-box-shadow;
     border-radius: $fd-border-radius;
@@ -29,7 +37,7 @@ $block: #{$fd-namespace}-panel;
         display: flex;
         align-items: center;
         //margin-bottom: fd-space(4);
-        border-bottom: $fd-panel-header-border;
+        border-bottom: solid 1px $fd-panel-header-border-color;
         padding: $fd-panel-padding;
     }
     &__title {
@@ -40,6 +48,18 @@ $block: #{$fd-namespace}-panel;
     }
     &__actions {
         margin-left: auto;
+    }
+    &__filters {
+        padding: $fd-panel-filters-padding;
+        border-bottom: solid 1px $fd-panel-filters-border-color;
+        transition: all $fd-panel-fiters-transition-params;
+        &.is-hidden,
+        &[aria-hidden="true"] {
+          padding-top: 0;
+          padding-bottom: 0;
+          max-height: 0;
+          overflow: hidden;
+        }
     }
     &__body {
         padding: $fd-panel-padding;
@@ -52,6 +72,7 @@ $block: #{$fd-namespace}-panel;
     &__footer {
         display: flex;
         justify-content: center;
-        padding-bottom: fd-space("reg");
+        padding: $fd-panel-footer-padding;
+        border-top: solid 1px $fd-panel-footer-border-color;
     }
 }

--- a/test/app.js
+++ b/test/app.js
@@ -157,6 +157,7 @@ function getStarterData() {
         "tree": require(`./templates/tree/data.json`),
         "table": require(`./templates/table/data.json`),
         "tabs": require(`./templates/tabs/data.json`),
+        "pagination": require(`./templates/pagination/data.json`),
         "image": require(`./templates/image/data.json`)
     }
     return data;

--- a/test/templates/index.njk
+++ b/test/templates/index.njk
@@ -39,7 +39,7 @@ li {
     <li><a href="table">.fd-table</a></li>
     <li><a href="tabs">.fd-tabs</a></li>
     <li><a href="tag">.fd-tag</a></li>
-    <li><a href="toolbar">.fd-toolbar</a></li>
+    <li><s><a href="toolbar">.fd-toolbar</a></s></li>
     <li><a href="toggle">.fd-toggle</a></li>
     <li><a href="tree">.fd-tree</a></li>
 </ul>

--- a/test/templates/index.njk
+++ b/test/templates/index.njk
@@ -38,6 +38,7 @@ li {
     <li><a href="side-nav">.fd-side-nav</a></li>
     <li><a href="table">.fd-table</a></li>
     <li><a href="tabs">.fd-tabs</a></li>
+    <li><a href="tag">.fd-tag</a></li>
     <li><a href="toolbar">.fd-toolbar</a></li>
     <li><a href="toggle">.fd-toggle</a></li>
     <li><a href="tree">.fd-tree</a></li>

--- a/test/templates/layout/component.njk
+++ b/test/templates/layout/component.njk
@@ -81,6 +81,12 @@ panel:
 </div>
 {%- endmacro %}
 
+{%- macro panel_filters(properties={}, modifier=[], aria={}, classes=[]) %}
+<div class="fd-panel__filters{{ classes | classes }}{{ modifier | modifier("panel__filters") }}"{{ aria | aria }}>
+    {{- caller() | indent -}}
+</div>
+{%- endmacro %}
+
 {%- macro panel_body(properties={}, modifier=[], aria={}, classes=[]) %}
 <div class="fd-panel__body{{ classes | classes }}{{ modifier | modifier("panel__body") }}">
     {{ caller() | indent -}}

--- a/test/templates/pages/panel.njk
+++ b/test/templates/pages/panel.njk
@@ -4,10 +4,17 @@
 
 {% from "../tree/component.njk" import tree %}
 {% from "../table/component.njk" import table %}
+{% from "../tag/component.njk" import tag %}
+{% from "../button/component.njk" import button %}
+{% from "../button-group/component.njk" import button_group %}
+{% from "../pagination/component.njk" import pagination %}
+{% from "../dropdown/component.njk" import dropdown, menu %}
 
 {% set hide_app_sidebar = false %}
 {% set hide_page_header = true %}
 {% block page_content %}
+
+
 
 {% set panel %}
 {% call layout.panel() -%}
@@ -17,9 +24,9 @@
         {%- endcall %}
     {%- endcall %}
     {% call layout.panel_body() -%}
-      <h1>.fd-panel</h1>
-      <p>Very much like a <code>.fd-section</code> but intended to be used inside of a column.</p>
-      <p>A <code>.fd-panel</code> should only be used when a title, actions and/or footer are needed with the content, otherwise the content can be placed directly inside the <code>.fd-col</code></p>
+      <p>.fd-panel__body</p>
+      <p>Very much like a <code>.fd-section</code> but intended to contain content.</p>
+      <p>Use <code>.fd-col</code>s when multiple panels are needed in a column structure.</p>
     {%- endcall %}
     {% call layout.panel_footer() -%}
 .fd-panel__footer
@@ -28,8 +35,42 @@
 {% endset %}
 
 
+{% set panel_filters %}
+{% call layout.panel() -%}
+    {% call layout.panel_header({ title: ".fd-panel__title" }) -%}
+        {% call layout.panel_actions() -%}
+.fd-panel__actions
+        {%- endcall %}
+    {%- endcall %}
+    {% call layout.panel_filters(aria={ hidden: false }) -%}
+.fd-panel__filters
+    {%- endcall %}
+    {% call layout.panel_body() -%}
+      .fd-panel__body
+    {%- endcall %}
+    {% call layout.panel_footer() -%}
+.fd-panel__footer
+    {%- endcall %}
+{%- endcall %}
+{% endset %}
 
-<div class="fd-has-background-color-neutral-2">
+{# //////////////////////// #}
+
+{% call layout.section() -%}
+{% call layout.section_header({ title: "<code>.fd-panel</code>"}) -%}
+{%- endcall %}
+{% call layout.container() -%}
+
+{{panel}}
+
+{%- endcall %}
+{%- endcall %}
+
+
+{# //////////////////////// #}
+
+
+
 {% call layout.section() -%}
 {% call layout.container() -%}
     {% call layout.col(6) -%}
@@ -45,7 +86,91 @@
 
 {%- endcall %}
 {%- endcall %}
-</div>
+
+
+
+{# //////////////////////// #}
+
+{% call layout.section() -%}
+{% call layout.section_header({ title: "<code>.fd-panel</code> with filters"}) -%}
+{%- endcall %}
+{% call layout.container() -%}
+
+{{panel_filters}}
+
+{%- endcall %}
+{%- endcall %}
+
+
+
+{# //////////////////////// #}
+
+{%- set tags %}
+{%- for i in range(0, 5) -%}
+{{  tag({label: "Bibendum"}) }}
+{% endfor %}
+{{  button({label: 'Clear All'},modifier={block: ['secondary','xs']}) }}
+{% endset %}
+
+
+{% set panel_filters_content %}
+{% call layout.panel() -%}
+    {% call layout.panel_header({ title: "Items (1180)" }) -%}
+        {% call layout.panel_actions() -%}
+
+        {{ dropdown(data.toolbar.properties.sort) }}
+
+        {{  button({label: 'Filter',icon: 'add-filter'},modifier={block: ['toolbar','s']}) }}
+
+        {{  button_group(
+          properties={
+            label: "Show as",
+            buttons: [
+              { "properties": { "icon": "grid" }, "modifier": { block: ["grouped","s" ] }, "aria": { "pressed": true } },
+              { "properties": { "icon": "list" }, "modifier": { block: ["grouped","s" ] } }
+            ]
+          })
+        }}
+
+
+        {%- endcall %}
+    {%- endcall %}
+    {% call layout.panel_filters(aria={ hidden: false }) -%}
+{% for item in data.toolbar.properties.filters.items %}
+{{ dropdown(item) }}
+{% endfor %}
+
+    {%- endcall %}
+    {% call layout.panel_filters(aria={ hidden: false }) -%}
+{{tags}}
+    {%- endcall %}
+    {% call layout.panel_body() -%}
+      .fd-panel__body
+    {%- endcall %}
+    {% call layout.panel_footer() -%}
+    {{  pagination(data.pagination.properties) }}
+
+    {%- endcall %}
+{%- endcall %}
+{% endset %}
+
+
+
+
+{% call layout.section() -%}
+{% call layout.section_header({ title: "Example <code>.fd-panel</code> with content"}) -%}
+{%- endcall %}
+{% call layout.container() -%}
+
+{{panel_filters_content}}
+
+{%- endcall %}
+{%- endcall %}
+
+{# //////////////////////// #}
+
+
+
 
 {% set badgetitle %}
 Vivamus sagittis <span class="fd-badge fd-badge--success">Active</span>
@@ -121,6 +246,9 @@ Vivamus sagittis <span class="fd-badge fd-badge--success">Active</span>
         {% call layout.panel_actions() -%}
 //buttons (optional)
         {%- endcall %}
+    {%- endcall %}
+    {% call layout.panel_filters() -%}
+//panel filters (optional)
     {%- endcall %}
     {% call layout.panel_body() -%}
 //panel body

--- a/test/templates/pagination/data.json
+++ b/test/templates/pagination/data.json
@@ -1,8 +1,8 @@
 {
   "type": "text",
   "properties": {
-    "totalItems": "",
-    "itemsPerPage": "",
-    "currentPage": ""
+    "totalItems": 1180,
+    "itemsPerPage": 20,
+    "currentPage": 25
   }
 }

--- a/test/templates/tag/component.njk
+++ b/test/templates/tag/component.njk
@@ -1,0 +1,10 @@
+<!--
+tag:
+    properties={},
+    modifier={ block: [] },
+    state={},
+    aria={}
+-->
+{% macro tag(properties={}, modifier={}, state={}, aria={}) -%}
+<span class="fd-tag{{ modifier.block | modifier('tag') }}{{ state | state }}"{{ aria | aria }} role="button">{{ properties.label }}</span>
+{%- endmacro %}

--- a/test/templates/tag/data.json
+++ b/test/templates/tag/data.json
@@ -1,0 +1,17 @@
+{
+    "id": "tag",
+    "name": "Tag",
+    "properties": {
+        "label": "Filter"
+    },
+    "modifier": {
+
+    },
+    "state": {
+
+    },
+    "aria": {
+
+    }
+
+}

--- a/test/templates/tag/index.njk
+++ b/test/templates/tag/index.njk
@@ -1,0 +1,47 @@
+{% extends "layout.njk" %}
+{% from "./../format.njk" import format %}
+{% from "../button/component.njk" import button %}
+{% from "./component.njk" import tag %}
+
+<!-- include add'tl css from src/styles/, e.g., ['helpers','components/button'] -->
+{% set css_deps = ['icons','helpers','components/button'] %}
+
+{% block content %}
+<style media="screen">
+  main {
+    background-color: white;
+  }
+</style>
+    <h1>tag</h1>
+    <p>Example shows the link for "Clear All" even though it is not part of the component.</p>
+
+    <!-- output the component example and the code snippet -->
+    {% set example %}
+{{  tag(
+        properties={
+            label: "Bibendum"
+        }
+    )
+}}
+{{  tag(
+        properties={
+            label: "Lorem"
+        }
+    )
+}}
+{{  tag(
+        properties={
+            label: "Dolor"
+        }
+    )
+}}
+{{  tag(
+        properties=data.properties
+    )
+}}
+<button type="button" name="button" class="fd-button--secondary fd-button--xs">Clear All</button>
+    {% endset %}
+    {{ format(example) }}
+
+
+{% endblock %}

--- a/test/templates/toolbar/index.njk
+++ b/test/templates/toolbar/index.njk
@@ -8,7 +8,7 @@
 {% from "./component.njk" import toolbar %}
 
 <!-- include add'tl css from src/styles/, e.g., ['helpers','components/button'] -->
-{% set css_deps = ['fonts','icons', 'components/button','components/dropdown','components/input-group', 'components/pagination','helpers'] %}
+{% set css_deps = ['components/alert', 'components/link','fonts','icons', 'components/button','components/dropdown','components/input-group', 'components/pagination','helpers'] %}
 
 {% block content %}
 
@@ -18,7 +18,12 @@
     }
 </style>
 
+<div class="fd-alert fd-alert--warning" role="alert">
+  The <code>.fd-toolbar</code> component has been deprecated in favor of using the <code>.fd-panel</code> header, filters, and footer containers.
+  <a href="pages/panel" class="fd-link">See the  <code>.fd-panel</code> example page. <span class="sap-icon--arrow-right sap-icon--s"></span></a>
+</div>
 
+<br>
 
     <h1>toolbar</h1>
 


### PR DESCRIPTION
#209 

## Updates
- Adds a new `tag` component for use with the filters. http://localhost:3030/tag
- Deprecates the `toolbar` component. http://localhost:3030/toolbar
- Adds new `__filters` container to the `panel` component so the filter functionality can be directly related to the collection. http://localhost:3030/pages/panel
- Pagination moves to the bottom.
- The filtering hiding and showing is not hooked up yet. We can circle back to demonstrate that. All the states are styled, just no JS yet. See #245

> NOTE: The dropdowns are bigger now but will adjust when #200 is complete.

<img width="957" alt="screen shot 2018-05-04 at 10 43 51 am" src="https://user-images.githubusercontent.com/424119/39637355-5dcd7336-4f88-11e8-805c-51027d58e8b6.png">
