### PR TITLE
#202 style updates to inline help popup

### DIFF
--- a/scss/components/inline-help.scss
+++ b/scss/components/inline-help.scss
@@ -1,31 +1,31 @@
 @import "./../settings";
-@import "./../mixins";
 @import "./../functions";
+@import "./../mixins";
 /*!
 .fd-tooltip
     .fd-tooltip__content+(left, right, bottom-left, bottom-right)
 */
 $block: #{$fd-namespace}-inline-help;
 .#{$block} {
-    //LOCAL VARS (set all themeable properties, always include !default)
-    $fd-tooltip-content-background-color: fd-color(text, 3) !default;
-    $fd-tooltip-content-color: fd-color(text-inverse, 1) !default;
-    $fd-tooltip-padding: fd-space(s) !default;
-    $fd-tooltip-arrow-offset: (fd-space(s)) - 2 !default ;
+    //LOCAL VARS
+    $fd-tooltip-content-background-color: fd-color(background, 2) !default;
+    $fd-tooltip-content-color: fd-color(text, 2) !default;
+    $fd-tooltip-padding: fd-space(xs) !default;
+    $fd-tooltip-arrow-offset: fd-space(2) !default ;
     $fd-tooltip-arrow-width: $fd-tooltip-arrow-offset !default;
     $fd-tooltip-icon-size: 18px;
     $fd-tooltip-transition-params: $fd-animation--speed ease-in !default;
-    $fd-tooltip-min-width: 350px;
+    $fd-tooltip-min-width: 350px !default;
+    $fd-tooltip-box-shadow: drop-shadow(rgba(0,0,0,0.1) 0 2px 10px) !default;
 
     //BLOCK BASE *******************************************
     @include fd-reset;
-    @include fd-type("-1");
     position: relative;
-    //margin-left: fd-space(xs);
     display: inline-block;
     width: $fd-tooltip-icon-size;
     height: $fd-tooltip-icon-size;
     top: 3px;
+
 
     &::before {
         content: "?";
@@ -42,7 +42,7 @@ $block: #{$fd-namespace}-inline-help;
 
     //ELEMENTS *******************************************
     &__content {
-        @include fd-type("-2")
+        @include fd-type("-2");
         background: $fd-tooltip-content-background-color;
         padding: $fd-tooltip-padding;
         display: block;
@@ -51,28 +51,27 @@ $block: #{$fd-namespace}-inline-help;
         top: $fd-tooltip-padding * 2.5;
         right: -$fd-tooltip-padding;
         min-width: $fd-tooltip-min-width;
-        visibility: hidden;
-        opacity: 0;
         transition: opacity $fd-tooltip-transition-params;
         text-align: left;
         z-index: 1;
+        border-radius: 5px;
+        visibility: hidden;
+        opacity: 0;
+
+        filter: $fd-tooltip-box-shadow;
         &::before {
-            width: 0;
-            height: 0;
-            border-style: solid;
-            border-width: 0 $fd-tooltip-arrow-width $fd-tooltip-arrow-width $fd-tooltip-arrow-width;
-            border-color: transparent transparent $fd-tooltip-content-background-color transparent;
-            position: absolute;
+            @include triangle(13px 8px, white, up);
             content: "";
+            position: absolute;
             top: -($fd-tooltip-arrow-offset);
-            right: $fd-tooltip-arrow-offset;
+            right: $fd-tooltip-arrow-offset * 1.75;
         }
         &--left{
             top: -$fd-tooltip-padding;
             left: $fd-tooltip-padding * 2.5;
             &::before{
-                top: $fd-tooltip-arrow-offset + 5;
-                left: -($fd-tooltip-arrow-offset + 5);
+                top: $fd-tooltip-arrow-offset + 8;
+                left: -($fd-tooltip-arrow-offset + 2);
                 transform: rotate(-90deg);
             }
         }
@@ -80,16 +79,16 @@ $block: #{$fd-namespace}-inline-help;
             top: -$fd-tooltip-padding;
             right: $fd-tooltip-padding * 2.5;
             &::before{
-                top: $fd-tooltip-arrow-offset + 5;
-                right: -($fd-tooltip-arrow-offset + 5);
+                top: $fd-tooltip-arrow-offset + 8;
+                right: -($fd-tooltip-arrow-offset + 2);
                 transform: rotate(90deg);
             }
         }
         &--bottom-left{
             left: -$fd-tooltip-arrow-offset;
             &::before{
-                top: -($fd-tooltip-arrow-offset);
-                left: $fd-tooltip-arrow-offset;
+                top: -($fd-tooltip-arrow-offset) ;
+                left: $fd-tooltip-arrow-offset * 1.5;
             }
         }
     }

--- a/scss/components/tree.scss
+++ b/scss/components/tree.scss
@@ -83,7 +83,7 @@ $block: #{$fd-namespace}-tree;
         }
         &.is-selected,
         &[aria-selected="true"] {
-            background-color: lighten(fd-color("action", 3), 0);
+            background-color: lighten(fd-color("action", 1), 0);
         }
     }
     $_row_padding: $fd-tree-control-width + $fd-tree-control-margin-right + 4;


### PR DESCRIPTION
#202 

Updated component - http://localhost:3030/inline-help

Design specs - https://zpl.io/agnkooZ

The design for the popover was applied. A slight variation on the box-shadow effect. Since we have to account for a triangle with the popover, box-shadow cannot be used. The filter(drop-shadow( ... )) is used instead and it does not support multiple layers like box-shadow, but it's close enough to the design. 

