### PR TITLE
#270 hide cards, card-group and toolbar pages

### DIFF
--- a/docs/_data/components.yml
+++ b/docs/_data/components.yml
@@ -9,15 +9,6 @@
     - title: Button
       meta: button
 
-    - title: Button Group
-      meta: button-group
-
-    - title: Card
-      meta: card
-
-    - title: Card Group
-      meta: card-group
-
     - title: Dropdown
       meta: dropdown
 
@@ -59,9 +50,6 @@
 
     - title: Toggle
       meta: toggle
-
-    - title: Toolbar
-      meta: toolbar
 
     - title: Tree
       meta: tree

--- a/docs/_data/sidebars/left-navigation-sidebar.yml
+++ b/docs/_data/sidebars/left-navigation-sidebar.yml
@@ -86,17 +86,6 @@ entries:
     - title: Breadcrumb
       url: /components/breadcrumb.html
       output: web
-
-    - title: Card
-      url: /components/card.html
-      output: web
-
-    - title: Card Group
-      url: /components/card-group.html
-      output: web
-
-    - title: Contextual Menu
-      url: /components/contextual-menu.html
       output: web
 
     - title: Dropdown
@@ -165,10 +154,6 @@ entries:
 
     - title: Toggle
       url: /components/toggle.html
-      output: web
-
-    - title: Toolbar
-      url: /components/toolbar.html
       output: web
 
     - title: Tree

--- a/docs/_includes/search-box.html
+++ b/docs/_includes/search-box.html
@@ -10,7 +10,7 @@
         searchInput: document.getElementById('search-input'),
         resultsContainer: document.getElementById('results-container'),
         dataSource: '{{site.baseurl}}/js/search.json',
-        searchResultTemplate: '<li class="search-box__results-links"><a href="{url}" title="{{page.title | replace: "\'", "\"}}">{title}</a></li>',
+        searchResultTemplate: '<li class="search-box__results-links"><a href="{{site.baseurl}}{url}" title="{{page.title | replace: "\'", "\"}}">{title}</a></li>',
         noResultsText: '<li class="no-search-results">{{site.data.strings.search_no_results_text}}</li>',
         limit: 10,
         fuzzy: true,

--- a/docs/pages/components/card-group.md
+++ b/docs/pages/components/card-group.md
@@ -1,10 +1,11 @@
 ---
 title: Card Group
-keywords: card group
+keywords:
 sidebar: left-navigation-sidebar
 toc: false
 permalink: components/card-group.html
 folder: components
+exclude: true
 ---
 
 The Card Group is used to display a collection of Cards representing objects of the same type. For instance: A set of products, projects, organizations, etc. It should be used to display collections of objects where the user can find and identify the items visually, by glancing at the Card Groups. The Cards layouts doesn't allow too much comparison of the data inside the cards; but different state (active/inactive, etc) are easily identifiable.

--- a/docs/pages/components/card.md
+++ b/docs/pages/components/card.md
@@ -1,6 +1,6 @@
 ---
 title: Card
-keywords: card
+keywords: 
 sidebar: left-navigation-sidebar
 toc: false
 permalink: components/card.html

--- a/docs/pages/components/tool-bar.md
+++ b/docs/pages/components/tool-bar.md
@@ -1,6 +1,6 @@
 ---
 title: Toolbar
-keywords: toolbar
+keywords: 
 sidebar: left-navigation-sidebar
 toc: false
 permalink: components/toolbar.html


### PR DESCRIPTION
just need to verify that the card, card-group and toolbar pages are not visible on the site. 