### PR TITLE
#499 change font size from fd-type(-2) to -3

### DIFF
--- a/scss/components/badge.scss
+++ b/scss/components/badge.scss
@@ -12,7 +12,7 @@ $block: #{$fd-namespace}-badge;
   $fd-badge-background-color--error: rgba($fd-color--error, 0.07) !default;
 
   @include fd-reset;
-  @include fd-type("-2");
+  @include fd-type("-3");
   @include fd-weight("bold");
   color: fd-color("text", 3);
   text-transform: uppercase;


### PR DESCRIPTION
#499 

changed font size to 10.99px which is what fd-type(-3) renders. it's not 11px shown in the design sheet, but close enough and adheres to the type system. 