### PR TITLE
#468 inital addition of issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,42 @@
+<!-- Feel free to remove sections that aren't relevant.
+
+## Title line template: [Title]: Brief description
+
+-->
+
+## Detailed description
+
+> Describe in detail the issue you're having.
+
+> Is this a feature request (new component, new icon), a bug, or a general issue?
+
+> Is this issue related to a specific component?
+
+> What did you expect to happen? What happened instead? What would you like to see changed?
+
+> What browser are you working in?
+
+> What version of the Fundamental UI are you using?
+
+> What offering/product do you work on? Any pressing ship or release dates we should be aware of?
+
+> What front-end framework are you implementing in, e.g., Angular, React, etc.?
+
+## If BUG, steps to reproduce the issue
+
+1. Step one
+2. Step two
+3. Step three
+4. etc.
+
+## If FEATURE REQUEST, describe the need
+
+* Component name
+* Use case
+* Expected behavior
+* Examples for reference
+
+## Additional information
+
+* Screenshots or code
+* Notes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+Closes sap/fundamental#
+
+{{short description}}
+
+#### Test
+
+* {{test thing}}
+
+#### Changelog
+
+**New**
+
+* {{new thing}}
+
+**Changed**
+
+* {{change thing}}
+
+**Removed**
+
+* {{removed thing}}

--- a/.npmignore
+++ b/.npmignore
@@ -7,6 +7,7 @@
 /test
 /bower_components
 /tmp
+/.github
 
 # Exclude Files
 .npmignore


### PR DESCRIPTION
Closes sap/fundamental#468

Adds simple issue and PR templates to collect better information from requestors and get better info for change logs, respectively.

#### Test

* After merge, create a new issue and a PR

#### Changelog

**New**

* Adds `ISSUE_TEMPLATE.md` and `PULL_REQUEST_TEMPLATE.md` to activate Github template functionality

**Changed**

* Nothing 

**Removed**

* Nothing
