### PR TITLE
#502 fixes primary action and changes close button

### DIFF
--- a/test/templates/modal/component.njk
+++ b/test/templates/modal/component.njk
@@ -10,7 +10,15 @@ modal:
   <div class="fd-modal__content" role="document">
       <header class="fd-modal__header">
           <h1 class="fd-modal__title">{{properties.header}}</h1>
-          <button class="fd-modal__close" aria-label="close"></button>
+          {{  button(
+                  {
+                      label: item.label
+                  },
+                  modifier={
+                      block: ['secondary']
+                  },
+                  classes=['modal__close'])
+          }}
       </header>
       <div class="fd-modal__body">
             <p>{{properties.body}}</p>

--- a/test/templates/modal/index.njk
+++ b/test/templates/modal/index.njk
@@ -21,7 +21,7 @@ NOTE: The <code>modal</code> itself does not provide the outer container. Use th
             body: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
             actions: [
               {type: 'secondary', label: 'Cancel'},
-              {type: '', label: 'Confirm'}
+              {type: 'primary', label: 'Confirm'}
             ]
           }
       )


### PR DESCRIPTION
Closes sap/fundamental#502

Updates the primary action button and the close button in the modal

#### Test

http://localhost:3030/modal
* The close button should now act like a `--secondary` button, blue with `hover` and `pressed` states
* The affirmative action in the footer should be a `--primary` button, outlined instead of filled.

#### Changelog

**New**

* Close button receives an additional class `fd-button--secondary`
```
<button class="fd-button--secondary fd-modal__close"></button>
```

**Changed**

* The affirmative action button changes to class `fd-button--primary`
```
<button class="fd-button--primary">Confirm</button>
```

**Removed**

* Nothing
