### PR TITLE
Feature/528

### DIFF
--- a/scss/components/time-picker.scss
+++ b/scss/components/time-picker.scss
@@ -13,7 +13,7 @@ $block: #{$fd-namespace}-time-picker;
     .#{$fd-namespace}-popover {
         &__body {
             padding: fd-space(s);
-            min-width: 230px;
+            min-width: 0;
         }
     }
 }

--- a/scss/components/time.scss
+++ b/scss/components/time.scss
@@ -4,13 +4,16 @@
 
 $block: #{$fd-namespace}-time;
 .#{$block} {
-    display: inline-block;
-    max-width: fd-space(10);
-    text-align: center;
-    margin-right: fd-space(1);
-    &:last-child {
-      margin-right: 0;
+    &__item {
+      display: inline-block;
+      max-width: fd-space(10);
+      text-align: center;
+      margin-right: fd-space(1);
+      &:last-child {
+        margin-right: 0;
+      }  
     }
+
     &__input {
         margin: fd-space(2) 0;
         input {

--- a/scss/components/time.scss
+++ b/scss/components/time.scss
@@ -4,18 +4,19 @@
 
 $block: #{$fd-namespace}-time;
 .#{$block} {
-    display: flex;
-    justify-content: space-between;
-
-    &__item {
-        text-align: center;
-        padding: 0 5px;
-        max-width: 75px;
+    display: inline-block;
+    max-width: fd-space(10);
+    text-align: center;
+    margin-right: fd-space(1);
+    &:last-child {
+      margin-right: 0;
     }
     &__input {
-        margin: 5px 0;
-        input{
-            text-align: center;
+        margin: fd-space(2) 0;
+        input {
+          padding-left: fd-space(2);
+          padding-right: fd-space(2);
+          text-align: center;
         }
     }
 }

--- a/test/templates/time-picker/component.njk
+++ b/test/templates/time-picker/component.njk
@@ -10,21 +10,23 @@ time_picker:
     aria={}
 -->
 {%- set _time_items %}
-{{ time(properties={
-  "placeholder": "hh",
-  "label": "hours"
-}) }}
-{{ time(properties={
-  "placeholder": "mm",
-  "label": "minutes"
-}) }}
-{{ time(properties={
-  "placeholder": "ss",
-  "label": "seconds"
-}) }}
-{{ time(properties={
-  "placeholder": "am",
-  "label": "period"
+{{ time(properties={ items: [
+  {
+    "placeholder": "hh",
+    "label": "hours"
+  },
+  {
+    "placeholder": "mm",
+    "label": "minutes"
+  },
+  {
+    "placeholder": "ss",
+    "label": "seconds"
+  },
+  {
+    "placeholder": "am",
+    "label": "period"
+  }]
 }) }}
 {%- endset %}
 {%- macro time_picker_control(properties={}, modifier={}, state={}, aria={ hidden: true }) %}

--- a/test/templates/time-picker/component.njk
+++ b/test/templates/time-picker/component.njk
@@ -9,25 +9,40 @@ time_picker:
     state={},
     aria={}
 -->
-
-{%- set _id = utils.id() %}
+{%- set _time_items %}
+{{ time(properties={
+  "placeholder": "hh",
+  "label": "hours"
+}) }}
+{{ time(properties={
+  "placeholder": "mm",
+  "label": "minutes"
+}) }}
+{{ time(properties={
+  "placeholder": "ss",
+  "label": "seconds"
+}) }}
+{{ time(properties={
+  "placeholder": "am",
+  "label": "period"
+}) }}
+{%- endset %}
 {%- macro time_picker_control(properties={}, modifier={}, state={}, aria={ hidden: true }) %}
 <div class="fd-input-group fd-input-group--after">
-  <input type="text" class="" id="" placeholder="hh:mm am/pm">
+  <input type="text" id="" placeholder="hh:mm am/pm">
     <span class="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button">
-        <button class="fd-popover__control fd-button--icon fd-button--secondary sap-icon--fob-watch" aria-controls="{{ _id }}" aria-expanded="false" aria-haspopup="true"{{ " disabled" if state.disabled }}{{ aria | aria }}></button>
+        <button class="fd-popover__control fd-button--icon fd-button--secondary sap-icon--fob-watch" aria-controls="{{ properties.id }}" aria-expanded="false" aria-haspopup="true"{{ " disabled" if state.disabled }}{{ aria | aria }}></button>
     </span>
 </div>
 {%- endmacro %}
 
 {%- macro time_picker(properties={}, modifier={}, state={}, aria={ hidden: true }) -%}
+{%- set _id = utils.id() %}
 <div class="fd-time-picker">
     {{  popover(properties={
             id: _id,
             control: time_picker_control(properties={id: _id}),
-            body: time({
-                id: _id
-            })
+            body: _time_items
         })
     }}
 </div>

--- a/test/templates/time-picker/component.njk
+++ b/test/templates/time-picker/component.njk
@@ -11,9 +11,9 @@ time_picker:
 -->
 
 {%- set _id = utils.id() %}
-
-{%- macro time_picker_control(properties={}, modifier={}, state={}, aria={ hidden: true }) -%}
+{%- macro time_picker_control(properties={}, modifier={}, state={}, aria={ hidden: true }) %}
 <div class="fd-input-group fd-input-group--after">
+  <input type="text" class="" id="" placeholder="hh:mm am/pm">
     <span class="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button">
         <button class="fd-popover__control fd-button--icon fd-button--secondary sap-icon--fob-watch" aria-controls="{{ _id }}" aria-expanded="false" aria-haspopup="true"{{ " disabled" if state.disabled }}{{ aria | aria }}></button>
     </span>

--- a/test/templates/time-picker/index.njk
+++ b/test/templates/time-picker/index.njk
@@ -3,7 +3,7 @@
 {% from "./../format.njk" import format %}
 {% from "./../time-picker/component.njk" import time_picker %}
 
-{% set css_deps = ['fonts','components/button','icons','components/time', 'components/popover', 'components/time-picker'] %}
+{% set css_deps = ['fonts','components/button','icons','components/time', 'components/popover', 'components/time-picker','components/input-group'] %}
 
 {% block content %}
   <h2>timepicker</h2>

--- a/test/templates/time/component.njk
+++ b/test/templates/time/component.njk
@@ -9,66 +9,32 @@ menu:
     aria={}
 -->
 
-{%- set _id = utils.id() %}
 
-{%- macro time(properties={}, modifier=[], classes=[], aria=[]) -%}
-    <div class="fd-time{{ modifier | modifier('menu') }}{{ classes | classes }}"{{ aria | aria }} id="{{ _id }}">
-        <div class="fd-time__item">
-            <div class="fd-time__button">
-                {{  button({
-                        icon: 'navigation-up-arrow' },
-                        modifier={ block: ['secondary','xs'] },
-                        aria={ label: 'Increase Hours' })
-                }}
-            </div>
-            <div class="fd-time__input">
-                <input class="fd-form__control" type="text" placeholder="6" />
-            </div>
-            <div class="fd-time__button">
-                {{  button({
-                        icon: 'navigation-down-arrow' },
-                        modifier={ block: ['secondary','xs'] },
-                        aria={ label: 'Decrease Hours' })
-                }}
-            </div>
-        </div>
-        <div class="fd-time__item">
-            <div class="fd-time__button">
-                {{  button({
-                        icon: 'navigation-up-arrow' },
-                        modifier={ block: ['secondary','xs'] },
-                        aria={ label: 'Increase Minutes' })
-                }}
-            </div>
-            <div class="fd-time__input">
-                <input class="fd-form__control" type="text" placeholder="45" />
-            </div>
-            <div class="fd-time__button">
-                {{  button({
-                        icon: 'navigation-down-arrow' },
-                        modifier={ block: ['secondary','xs'] },
-                        aria={ label: 'Decrease Minutes' })
-                }}
-            </div>
-        </div>
-        <div class="fd-time__item">
-            <div class="fd-time__button">
-                {{  button({
-                        icon: 'navigation-up-arrow' },
-                        modifier={ block: ['secondary','xs'] },
-                        aria={ label: 'Increase Clock' })
-                }}
-            </div>
-            <div class="fd-time__input">
-                <input class="fd-form__control" type="text" placeholder="PM" />
-            </div>
-            <div class="fd-time__button">
-                {{  button({
-                        icon: 'navigation-down-arrow' },
-                        modifier={ block: ['secondary','xs'] },
-                        aria={ label: 'Decrease Clock' })
-                }}
-            </div>
-        </div>
+{%- macro time(properties={}, state={}, modifier=[], classes=[], aria=[]) -%}
+{%- set _id = utils.id() %}
+<div class="fd-time{{ modifier | modifier('menu') }}{{ classes | classes }}"{{ aria | aria }}>
+    <div class="fd-time__control">
+        {{  button({
+                icon: 'navigation-up-arrow' },
+                modifier={ block: ['secondary','xs'] },
+                aria={ label: 'Increase ' + properties.label, controls: _id },
+                state={
+                  disabled: properties.lastValue
+                })
+        }}
     </div>
+    <div class="fd-time__input">
+        <input class="fd-form__control" type="text" placeholder="{{properties.placeholder}}" value="{{properties.value}}" id="{{ _id }}" aria-label="{{properties.label | capitalize }}"/>
+    </div>
+    <div class="fd-time__control">
+        {{  button({
+                icon: 'navigation-down-arrow' },
+                modifier={ block: ['secondary','xs'] },
+                aria={ label: 'Decrease ' + properties.label, controls: _id },
+                state={
+                  disabled: properties.firstValue
+                })
+        }}
+    </div>
+</div>
 {%- endmacro %}

--- a/test/templates/time/component.njk
+++ b/test/templates/time/component.njk
@@ -11,30 +11,38 @@ menu:
 
 
 {%- macro time(properties={}, state={}, modifier=[], classes=[], aria=[]) -%}
-{%- set _id = utils.id() %}
-<div class="fd-time{{ modifier | modifier('menu') }}{{ classes | classes }}"{{ aria | aria }}>
-    <div class="fd-time__control">
-        {{  button({
-                icon: 'navigation-up-arrow' },
-                modifier={ block: ['secondary','xs'] },
-                aria={ label: 'Increase ' + properties.label, controls: _id },
-                state={
-                  disabled: properties.lastValue
-                })
-        }}
-    </div>
-    <div class="fd-time__input">
-        <input class="fd-form__control" type="text" placeholder="{{properties.placeholder}}" value="{{properties.value}}" id="{{ _id }}" aria-label="{{properties.label | capitalize }}"/>
-    </div>
-    <div class="fd-time__control">
-        {{  button({
-                icon: 'navigation-down-arrow' },
-                modifier={ block: ['secondary','xs'] },
-                aria={ label: 'Decrease ' + properties.label, controls: _id },
-                state={
-                  disabled: properties.firstValue
-                })
-        }}
-    </div>
+<div class="fd-time{{ modifier | modifier('time') }}{{ classes | classes }}"{{ aria | aria }}>
+  {%- for item in properties.items %}
+    {{ time_item(item) }}
+  {%- endfor %}
 </div>
+{%- endmacro %}
+
+{%- macro time_item(properties={}, state={}, modifier=[], classes=[], aria=[]) -%}
+{%- set _id = utils.id() %}
+  <div class="fd-time__item">
+      <div class="fd-time__control">
+          {{  button({
+                  icon: 'navigation-up-arrow' },
+                  modifier={ block: ['secondary','xs'] },
+                  aria={ label: 'Increase ' + properties.label, controls: _id },
+                  state={
+                    disabled: properties.lastValue
+                  })
+          }}
+      </div>
+      <div class="fd-time__input">
+          <input class="fd-form__control" type="text" placeholder="{{properties.placeholder}}" value="{{properties.value}}" id="{{ _id }}" aria-label="{{properties.label | capitalize }}"/>
+      </div>
+      <div class="fd-time__control">
+          {{  button({
+                  icon: 'navigation-down-arrow' },
+                  modifier={ block: ['secondary','xs'] },
+                  aria={ label: 'Decrease ' + properties.label, controls: _id },
+                  state={
+                    disabled: properties.firstValue
+                  })
+          }}
+      </div>
+  </div>
 {%- endmacro %}

--- a/test/templates/time/data.json
+++ b/test/templates/time/data.json
@@ -3,6 +3,11 @@
     "name": "Time",
     "properties": {
         "id": "",
+        "value": "06",
+        "placeholder": "hh",
+        "label": "hours",
+        "firstValue": false,
+        "lastValue": false
     },
     "modifier": {
         "block": ""

--- a/test/templates/time/data.json
+++ b/test/templates/time/data.json
@@ -3,11 +3,37 @@
     "name": "Time",
     "properties": {
         "id": "",
-        "value": "06",
-        "placeholder": "hh",
-        "label": "hours",
-        "firstValue": false,
-        "lastValue": false
+        "items": [
+          {
+            "value": "02",
+            "placeholder": "hh",
+            "label": "hours",
+            "firstValue": false,
+            "lastValue": false
+          },
+          {
+            "value": "34",
+            "placeholder": "mm",
+            "label": "minutes",
+            "firstValue": false,
+            "lastValue": false
+          },
+          {
+            "value": "56",
+            "placeholder": "ss",
+            "label": "seconds",
+            "firstValue": false,
+            "lastValue": false
+          },
+          {
+            "value": "pm",
+            "placeholder": "am",
+            "label": "period",
+            "firstValue": false,
+            "lastValue": false
+          }
+        ]
+
     },
     "modifier": {
         "block": ""

--- a/test/templates/time/index.njk
+++ b/test/templates/time/index.njk
@@ -7,13 +7,87 @@
 {% block content %}
 
   <h1>time</h1>
+  <p>The <code>fd-time</code> component is used for a single time value. Multiple components can be used in the
+<a href="time-picker"><code>fd-time-picker</code></a>
+     to assemble a clock time. A max of four will account for hours, minutes, seconds and period of the day.</p>
 
+</p>
+
+  <p>
+<strong>It will be rare to see this component used outside of the <code>fd-time-picker</code>.
+</strong>
+
+  </p>
+
+
+  <h2>with values</h2>
   {% set example %}
-    <div style="max-width: 210px;">
-      {{ time(properties=data.properties) }}
-    </div>
+{{ time(properties=data.properties) }}
+{{ time(properties={
+  "value": "34",
+  "placeholder": "mm",
+  "label": "minutes"
+}) }}
+{{ time(properties={
+  "value": "58",
+  "placeholder": "00",
+  "label": "seconds"
+}) }}
+{{ time(properties={
+  "value": "pm",
+  "placeholder": "am",
+  "label": "period"
+}) }}
   {% endset %}
 
   {{ format(example) }}
+<br><br>
+
+  <h2>with placeholder</h2>
+  {% set example %}
+  {{ time(properties={
+    "placeholder": "hh",
+    "label": "hours"
+  }) }}
+  {{ time(properties={
+    "placeholder": "mm",
+    "label": "minutes"
+  }) }}
+  {{ time(properties={
+    "placeholder": "ss",
+    "label": "seconds"
+  }) }}
+  {{ time(properties={
+    "placeholder": "am",
+    "label": "period"
+  }) }}
+  {% endset %}
+
+  {{ format(example) }}
+
+<br><br>
+<h2>with button state</h2>
+
+<p>Since the controls and inputs are standard components, they can take all states available to buttons and forms respectively, e.g., <code>disabled, .is-invalid</code>
+</p>
+
+
+  {% set example %}
+  {{ time(properties={
+    "value": "00",
+    "placeholder": "hh",
+    "label": "hours",
+    "firstValue": true
+  }) }}
+  {{ time(properties={
+    "value": "59",
+    "placeholder": "mm",
+    "label": "minutes",
+    "lastValue": true
+  }) }}
+  {% endset %}
+
+  {{ format(example) }}
+
 
 {% endblock %}

--- a/test/templates/time/index.njk
+++ b/test/templates/time/index.njk
@@ -23,21 +23,6 @@
   <h2>with values</h2>
   {% set example %}
 {{ time(properties=data.properties) }}
-{{ time(properties={
-  "value": "34",
-  "placeholder": "mm",
-  "label": "minutes"
-}) }}
-{{ time(properties={
-  "value": "58",
-  "placeholder": "00",
-  "label": "seconds"
-}) }}
-{{ time(properties={
-  "value": "pm",
-  "placeholder": "am",
-  "label": "period"
-}) }}
   {% endset %}
 
   {{ format(example) }}
@@ -45,22 +30,24 @@
 
   <h2>with placeholder</h2>
   {% set example %}
-  {{ time(properties={
+{{ time(properties={ items: [
+  {
     "placeholder": "hh",
     "label": "hours"
-  }) }}
-  {{ time(properties={
+  },
+  {
     "placeholder": "mm",
     "label": "minutes"
-  }) }}
-  {{ time(properties={
+  },
+  {
     "placeholder": "ss",
     "label": "seconds"
-  }) }}
-  {{ time(properties={
+  },
+  {
     "placeholder": "am",
     "label": "period"
-  }) }}
+  }]
+}) }}
   {% endset %}
 
   {{ format(example) }}
@@ -73,17 +60,20 @@
 
 
   {% set example %}
-  {{ time(properties={
-    "value": "00",
-    "placeholder": "hh",
-    "label": "hours",
-    "firstValue": true
-  }) }}
-  {{ time(properties={
-    "value": "59",
-    "placeholder": "mm",
-    "label": "minutes",
-    "lastValue": true
+  {{ time(properties={ items: [
+    {
+      "value": "00",
+      "placeholder": "hh",
+      "label": "hours",
+      "firstValue": true
+    },
+    {
+      "value": "59",
+      "placeholder": "mm",
+      "label": "minutes",
+      "lastValue": true
+    }
+]
   }) }}
   {% endset %}
 

--- a/test/templates/time/index.njk
+++ b/test/templates/time/index.njk
@@ -68,7 +68,7 @@
 <br><br>
 <h2>with button state</h2>
 
-<p>Since the controls and inputs are standard components, they can take all states available to buttons and forms respectively, e.g., <code>disabled, .is-invalid</code>
+<p>Since the controls and inputs are standard components, they can take all states available to buttons and forms respectively, e.g., <code>disabled, .is-invalid</code>. In this case, the buttons are disabled when the first or last values are reached.
 </p>
 
 


### PR DESCRIPTION
Closes sap/fundamental#528

- Improves the logic of the test component to accept an array of items with first and last values.
- Adds a text input with placeholder to the `time-picker` instead of a button only.

#### Test

Refactor should have no impact on the design ...
https://zpl.io/V4JGAG8 and https://zpl.io/a7ypZpp

* http://localhost:3030/time 
* http://localhost:3030/time-picker 

#### Changelog

**New**

* None

**Changed**

* The `time__button` element is now `time__control` to better match vocabulary used in other components.
* Time items now display inline instead of flex to ensure a consistent width in the popover container.
* The `time-picker` popover container no longer forces a width.
* Time picker adds an input field.

**Removed**

* Nothing