### PR TITLE
fix fonts problem in docs

### DIFF
--- a/ops/gulp/docs-build.js
+++ b/ops/gulp/docs-build.js
@@ -5,7 +5,7 @@ let environment = require('../lib/environment');
 
 const task = (cb) => {
 
-    gulpSequence('build:dist', ['docs-resources', 'docs-icons', 'docs-css', 'docs-styleguide'], cb);
+    gulpSequence('build:dist', ['docs-resources', 'docs-icons', 'docs-css', 'docs-styleguide','docs-fonts'], cb);
 
 }
 

--- a/ops/gulp/docs-fonts.js
+++ b/ops/gulp/docs-fonts.js
@@ -1,0 +1,21 @@
+const gulp = require('gulp');
+const config = require('../config');
+const pkg = require('../../package');
+
+let environment = require('../lib/environment');
+
+const paths = {
+	src: `${config.tasks.fonts}`,
+	dest: './docs/css'
+}
+
+const task = (cb) => {
+    return gulp.src([
+			`${config.root.css}/${config.tasks.fonts.src}/**/*`,
+			`!${config.root.css}/${config.tasks.fonts.src}/*.scss`,
+		])
+		.pipe(gulp.dest(`${paths.dest}/${config.tasks.fonts.dest}`));
+}
+
+gulp.task('docs-fonts', task);
+module.exports = task;


### PR DESCRIPTION
small fix.
404 for 42 fonts in docs.

![image](https://user-images.githubusercontent.com/780901/42888580-993ba4b2-8ab9-11e8-8845-cf9262568d50.png)

All Examples use font 'arial'

#### Test
Manual
It takes time to update (In my forks it took 1 hour). I think github page cache 404.

#### Changelog
**New**
gulp task for copy fonts.


