### PR TITLE
Fix broken test pages after menu/popover refactor

### DIFF
--- a/scss/components/global-nav.scss
+++ b/scss/components/global-nav.scss
@@ -122,15 +122,16 @@ $block: #{$fd-namespace}-global-nav;
     }
 
     &__context-menu {
-      //  height: $fd-global-nav-height - 2;
         border-left: 1px solid $fd-global-nav-border-color;
         border-right: 1px solid $fd-global-nav-border-color;
-        // display: inline-flex;
-        // align-items: center;
-margin-right: fd-space("xxs");
+        margin-right: fd-space("xxs");
         button{
             min-height: $fd-global-nav-height - 2;
             color: $fd-global-nav-color;
+            background: transparent;
+            border-color: transparent;
+            box-shadow: none;
+            border-radius: 0;
         }
 
     }

--- a/test/templates/global-nav/component.njk
+++ b/test/templates/global-nav/component.njk
@@ -1,5 +1,6 @@
 {% from "../button/component.njk" import button %}
 {% from "../icon/component.njk" import icon %}
+{% from "../menu/component.njk" import menu %}
 {% from "../dropdown/component.njk" import dropdown %}
 {% from "../form/component.njk" import form_control %}
 {% from "../mega-menu/component.njk" import mega_menu %}
@@ -13,6 +14,25 @@ global_nav:
     state={},
     aria={}
 -->
+
+
+{%- set contextmenu %}
+    {%- set _id = utils.id() %}
+
+    {{ dropdown(properties={
+      label: "Context Switcher",
+      body: menu(properties={
+        items: [
+            { "label": "Link 1" },
+            { "label": "Link 2" },
+            { "label": "Link 3" },
+            { "label": "Link 4" }
+          ]
+        })
+      })
+    }}
+
+{%- endset %}
 
 {% macro global_nav(properties={}, modifier={}, state={}, aria={}) -%}
 {%- set _id = utils.id() %}
@@ -59,7 +79,7 @@ global_nav:
 
         {%- if properties.context_menu -%}
         <div class="fd-global-nav__context-menu">
-            {{ dropdown(properties.context_menu, modifier={ button: "secondary", control: "no-border"}) | indent(12) }}
+            {{contextmenu}}
         </div>
         {%- endif -%}
 

--- a/test/templates/global-nav/index.njk
+++ b/test/templates/global-nav/index.njk
@@ -2,12 +2,13 @@
 {% import "./../utils.njk" as utils %}
 {% from "./../format.njk" import format %}
 {% from "../button/component.njk" import button %}
-{% from "../dropdown/component.njk" import dropdown, menu %}
+{% from "../menu/component.njk" import menu %}
+{% from "../dropdown/component.njk" import dropdown %}
 {% from "../nav/component.njk" import nav %}
 {% from "./component.njk" import global_nav %}
 
 <!-- include add'tl css from src/styles/, e.g., ['helpers','components/button'] -->
-{% set css_deps = ['icons', 'components/button', 'components/dropdown', 'components/nav', 'components/mega-menu', 'components/identifier', 'helpers'] %}
+{% set css_deps = ['icons', 'components/button', 'components/dropdown', 'components/nav', 'components/mega-menu', 'components/identifier', 'components/popover', 'components/menu', 'helpers'] %}
 
 {% block content %}
 

--- a/test/templates/pages/all.njk
+++ b/test/templates/pages/all.njk
@@ -3,7 +3,6 @@
 {% set page_intro = "" %}
 {% set is_landing_page = false %}
 {% set is_editable_page = true %}
-{% set show_toolbar = false %}
 
 {% import "../layout/component.njk" as layout %}
 {% from "../tabs/component.njk" import tabs %}
@@ -11,7 +10,6 @@
 {% from "../table/component.njk" import table %}
 {% from "../action-bar/component.njk" import action_bar %}
 {% from "../button/component.njk" import button %}
-{% from "../toolbar/component.njk" import toolbar %}
 {% from "../tree/component.njk" import tree %}
 
 {# SET CONTENT #}
@@ -129,7 +127,7 @@
 {{ col_card }}
     {%- endcall %}
     {% call layout.panel_footer() -%}
-<a href="#" class="fd-button fd-button--link">See All</a>
+    <button href="#" class="fd-button--secondary" aria-role="button">See All</button>
     {%- endcall %}
 {%- endcall %}
 {% endset %}
@@ -174,56 +172,6 @@
 
 {%- endblock %}
 {% block page_content %}
-
-{{  toolbar(
-  {
-    "filters": {
-        "items": [
-            {
-                "label": "Color",
-                "items": [
-                    { "label": "Option 1" },
-                    { "label": "Option 2" },
-                    { "label": "Option 3" }
-                ]
-            },
-            {
-                "label": "Size",
-                "items": [
-                    { "label": "Option 1" },
-                    { "label": "Option 2" },
-                    { "label": "Option 3" }
-                ]
-            }
-
-        ]
-    },
-    "search": {
-        "placeholder": "Filter by Keyword"
-    },
-    "sort": {
-        "label": "Newest",
-        "icon": "sort",
-        "items": [
-            { "label": "Option 1" },
-            { "label": "Option 2" },
-            { "label": "Option 3" }
-        ]
-    },
-    "pagination": {
-        "total": 283,
-        "number": 20,
-        "page": 10
-    },
-    "view": {
-        "items": [
-            { "label": "View as grid", "icon": "grid" },
-            { "label": "View as list", "icon": "list" }
-        ]
-    }
-  }
-    )
-}}
 
 {%- call layout.section() %}
 {{  tabs(

--- a/test/templates/pages/panel.njk
+++ b/test/templates/pages/panel.njk
@@ -8,7 +8,8 @@
 {% from "../button/component.njk" import button %}
 {% from "../button-group/component.njk" import button_group %}
 {% from "../pagination/component.njk" import pagination %}
-{% from "../dropdown/component.njk" import dropdown, menu %}
+{% from "../dropdown/component.njk" import dropdown %}
+{% from "../menu/component.njk" import menu %}
 
 {% set hide_app_sidebar = false %}
 {% set hide_page_header = true %}
@@ -138,15 +139,21 @@
     {% call layout.panel_header({ title: "Items (1180)", description: "Lorem ipsum dolor sit amet" }) -%}
         {% call layout.panel_actions() -%}
 
-        {{ dropdown(
-          {            "label": "Newest",
-                      "icon": "sort",
-                      "items": [
-                          { "label": "Option 1" },
-                          { "label": "Option 2" },
-                          { "label": "Option 3" }
-                      ]},modifier={block: ['s']}
-          ) }}
+          {{ dropdown(
+              properties={
+                  label: "Newest",
+                  icon: "sort",
+                  body: menu(properties={
+                          items: [
+                              { "label": "Option 1" },
+                              { "label": "Option 2" },
+                              { "label": "Option 3" },
+                              { "label": "Option 4" }
+                          ]
+                        })
+               },
+               modifier={ block: 's' })
+          }}
 
         {{  button({label: 'Filter',icon: 'filter' }, modifier={block: ['toolbar','s']}, aria={ controls: _id, haspopup: true, expanded: false, label: "Filter" }) }}
 

--- a/test/templates/toolbar/component.njk
+++ b/test/templates/toolbar/component.njk
@@ -1,6 +1,7 @@
 {% from "../button/component.njk" import button %}
 {% from "../icon/component.njk" import icon %}
-{% from "../dropdown/component.njk" import dropdown, menu %}
+{% from "../dropdown/component.njk" import dropdown %}
+{% from "../menu/component.njk" import menu %}
 {% from "../form/component.njk" import form_control %}
 {% from "../input-group/component.njk" import input_group %}
 {% from "../pagination/component.njk" import pagination %}

--- a/test/templates/toolbar/index.njk
+++ b/test/templates/toolbar/index.njk
@@ -2,7 +2,8 @@
 {% import "./../utils.njk" as utils %}
 {% from "./../format.njk" import format %}
 {% from "../button/component.njk" import button %}
-{% from "../dropdown/component.njk" import dropdown, menu %}
+{% from "../dropdown/component.njk" import dropdown %}
+{% from "../menu/component.njk" import menu %}
 {% from "../form/component.njk" import form_control %}
 {% from "../input-group/component.njk" import input_group %}
 {% from "./component.njk" import toolbar %}


### PR DESCRIPTION
Closes sap/fundamental#526

Fixes broken test pages after dropdown/menu/popover refactor

#### Test

* http://localhost:3030/action-bar
* http://localhost:3030/global-nav
* http://localhost:3030/pages/panel
* http://localhost:3030/pages/all

#### Changelog

**New**

nothing

**Changed**

* http://localhost:3030/action-bar
* http://localhost:3030/global-nav
* http://localhost:3030/pages/panel
* http://localhost:3030/pages/all

**Removed**

nothing. 
