### PR TITLE
#552 scss updates to remove unnecessary scrolling on apps layout

### DIFF
--- a/scss/components/side-nav.scss
+++ b/scss/components/side-nav.scss
@@ -24,7 +24,7 @@ $block: #{$fd-namespace}-side-nav;
     $fd-side-nav-selected-background-color: rgba(fd-color("action", 1), .07);
     $fd-side-nav-hover-background-color: fd-color("neutral", 1);
     $fd-side-nav-link-color: fd-color("text", 2);
-    $fd-side-nav-max-width: 250px;
+    $fd-side-nav-max-width: 249px;
     $fd-side-nav-link-padding: fd-space(2.5) fd-space(5);
     $fd-side-nav-title-padding: fd-space(2) fd-space(5);
     $fd-side-nav-icon-right-padding: fd-space(2.5);

--- a/scss/layout/app.scss
+++ b/scss/layout/app.scss
@@ -14,6 +14,7 @@ $block: #{$fd-namespace}-app;
   $fd-app-sidebar-background-color: $fd-background-color--sidebar !default;
   $fd-app-sidebar-border-bottom: solid 1px fd-color("neutral",3) !default;
   width: 100%;
+  min-height: calc(100vh - 50px);
   @include fd-screen(s) {
     display: flex;
   }

--- a/scss/layout/app.scss
+++ b/scss/layout/app.scss
@@ -14,7 +14,6 @@ $block: #{$fd-namespace}-app;
   $fd-app-sidebar-background-color: $fd-background-color--sidebar !default;
   $fd-app-sidebar-border-bottom: solid 1px fd-color("neutral",3) !default;
   width: 100%;
-  min-height: 100vh;
   @include fd-screen(s) {
     display: flex;
   }
@@ -34,10 +33,10 @@ $block: #{$fd-namespace}-app;
         margin-right: 0;
       }
     }
-    overflow: scroll;
+    overflow: auto;
   }
   &__main {
     flex: 1;
-    overflow: scroll;
+    overflow: auto;
   }
 }

--- a/scss/layout/ui.scss
+++ b/scss/layout/ui.scss
@@ -27,7 +27,7 @@ $block: #{$fd-namespace}-ui;
     position: absolute;
     min-height: 100vh;
     width: 100vw;
-    max-width: 100vw;
+    max-width: 100%;
     background: $fd-ui-background;
     background-size: cover;
     background-attachment: fixed;


### PR DESCRIPTION
Closes #552, #553

scss updated in app.scss to remove unnecessary verticle and horizontal scrolling at app level. 

#### Test

* open http://localhost:3030/pages/app/sidebar - verify that there are no scrollbars. 

#### Changelog

**New**

* nothing

**Changed**

* Width of `side-nav` to 249px. this eliminates a horizontal scroll when side-nav is placed within `side-nav`
* Reduced 100vh on 100vh - 50px to account for the app header height 
* Changed scrolling from `scroll` to `auto` on `app__main` and `app__sidebar`

**Removed**

* nothing 
