### PR TITLE
#543 adds closing ul to menu

### DIFF
--- a/test/templates/menu/component.njk
+++ b/test/templates/menu/component.njk
@@ -8,21 +8,24 @@ menu:
 -->
 
 {%- macro menu(properties={}, modifier=[], classes=[], aria=[]) -%}
-    <nav class="fd-menu{{ modifier | modifier('menu') }}{{ classes | classes }}"{{ aria | aria }} id="{{ properties.id }}">
-        {%- for item in properties.items %}
-            {%- if item.items %}
-                {%- if not loop.first %}
-                    </ul>
-                {%- endif %}
-                    {{ optgroup(item)| indent(2) }}
-                {%- else %}
-                {%- if loop.first %}
-                    <ul class="fd-menu__list">
-                {%- endif %}
-                    {{ option(item) }}
-            {%- endif %}
-        {%- endfor %}
-    </nav>
+<nav class="fd-menu{{ modifier | modifier('menu') }}{{ classes | classes }}"{{ aria | aria }}{% if properties.id %} id="{{ properties.id }}"{% endif %}>
+{%- for item in properties.items %}
+  {%- if item.items %}
+    {%- if not loop.first %}
+    </ul>
+      {%- endif %}
+      {{ optgroup(item)| indent(2) }}
+    {%- else %}
+      {%- if loop.first %}
+    <ul class="fd-menu__list">
+      {%- endif %}
+      {{ option(item) }}
+      {%- if loop.last %}
+    </ul>
+      {%- endif %}
+    {%- endif %}
+{%- endfor %}
+</nav>
 {%- endmacro %}
 
 {%- macro option(properties={}) -%}
@@ -31,11 +34,11 @@ menu:
 
 {% macro optgroup(properties={}) -%}
     <div class="fd-menu__group">
-        <h1 class="fd-menu__title">{{ properties.label }}</h1>
-        <ul class="fd-menu__list">
-            {%- for item in properties.items %}
-                {{ option(item) }}
-            {%- endfor %}
-        </ul>
+      <h1 class="fd-menu__title">{{ properties.label }}</h1>
+      <ul class="fd-menu__list">
+          {%- for item in properties.items %}
+            {{ option(item) }}
+          {%- endfor %}
+      </ul>
     </div>
 {%- endmacro %}

--- a/test/templates/popover/component.njk
+++ b/test/templates/popover/component.njk
@@ -22,5 +22,7 @@ popover:
 {%- endmacro %}
 
 {%- macro popover_body(properties={}, modifier={}, state={}, aria={ hidden: true }) %}
-    <div class="fd-popover__body"{{ modifier.block | modifier('popover__body') }} {{ aria | aria }} id="{{ properties.id }}">{{properties.body}}</div>
+    <div class="fd-popover__body"{{ modifier.block | modifier('popover__body') }} {{ aria | aria }} id="{{ properties.id }}">
+      {{properties.body}}
+    </div>
 {%- endmacro %}


### PR DESCRIPTION
Closes sap/fundamental#543

Adds a closing `ul` to the `menu` component.

#### Test

* http://localhost:3030/contextual-menu
* http://localhost:3030/menu

Now has closing `ul`

```
<nav class="fd-menu">
    <ul class="fd-menu__list">
      <li><a href="#" class="fd-menu__item">Option 1</a></li>
      <li><a href="#" class="fd-menu__item">Option 2</a></li>
      <li><a href="#" class="fd-menu__item">Option 3</a></li>
      <li><a href="#" class="fd-menu__item">Option 4</a></li>
    </ul>
</nav>
```

#### Changelog

**Changed**

* Applies to test environment only. 
