### PR TITLE
Update gulp packaging task for Ariba Theme

### DIFF
--- a/ops/gulp/docs-build.js
+++ b/ops/gulp/docs-build.js
@@ -5,7 +5,7 @@ let environment = require('../lib/environment');
 
 const task = (cb) => {
 
-    gulpSequence('build:dist', ['docs-resources', 'docs-icons', 'docs-css', 'docs-styleguide','docs-fonts'], cb);
+    gulpSequence('build:dist', ['docs-resources', 'docs-icons', 'docs-css', 'docs-icons-theme-ariba', 'docs-styleguide','docs-fonts'], cb);
 
 }
 

--- a/ops/gulp/docs-icons-theme-ariba.js
+++ b/ops/gulp/docs-icons-theme-ariba.js
@@ -1,0 +1,18 @@
+const gulp = require('gulp');
+
+let environment = require('../lib/environment');
+
+const paths = {
+	src: environment.production ? './dist' : './tmp',
+	dest: './docs/css'
+}
+
+var fundamentalIconCss = environment.production ? 'fundamental-ui-ariba-icons.min.css' : 'fundamental-ui-ariba-icons.css';
+
+const task = (cb) => {
+    return gulp.src([`${paths.src}/ariba/icons/*.woff`, `${paths.src}/ariba/icons/${fundamentalIconCss}`])
+		.pipe(gulp.dest(paths.dest));
+}
+
+gulp.task('docs-icons-theme-ariba', task);
+module.exports = task;

--- a/ops/gulp/pkg-build.js
+++ b/ops/gulp/pkg-build.js
@@ -4,7 +4,7 @@ const config = require('../config');
 let environment = require('../lib/environment');
 
 const task = (cb) => {
-    gulpSequence('pkg-clean', 'pkg-css', 'pkg-fonts', 'pkg-icons', cb)
+    gulpSequence('pkg-clean', 'pkg-css', 'pkg-fonts', 'pkg-icons', 'pkg-icons-ariba', 'pkg-css-ariba', cb)
 }
 
 gulp.task('build:dist', task);

--- a/ops/gulp/pkg-css-theme-ariba.js
+++ b/ops/gulp/pkg-css-theme-ariba.js
@@ -1,0 +1,116 @@
+const gulp = require('gulp');
+const sass = require('gulp-sass');
+const rename = require("gulp-rename");
+const gulpif = require('gulp-if');
+const sourcemaps = require('gulp-sourcemaps');
+const cleanCSS = require('gulp-clean-css');
+const autoprefixer = require('gulp-autoprefixer');
+const debug = require('gulp-debug');
+const gulpSequence = require('gulp-sequence');
+const replace = require('gulp-replace');
+const header = require('gulp-header');
+const config = require('../config');
+const pkg = require('../../package');
+
+let environment = require('../lib/environment');
+
+const paths = {
+	src: config.root.css + '/theme/ariba',
+	dest: (environment.production ? config.root.dest : config.root.tmp) + '/ariba'
+}
+
+var d = new Date();
+var y = d.getFullYear();
+var banner = `/*!
+* Fundamental-UI-Theme-Ariba v${pkg.version}
+* Copyright (c) ${y} SAP SE or an SAP affiliate company.
+* Licensed under Apache License 2.0 (https://github.com/SAP/Fundamental/blob/master/LICENSE)
+*/\n`;
+
+// //compile top-level files
+// var sassTask = (cb) => {
+//     let prefix = config.tasks.css.prefix + '-ariba';
+//     let files = environment.production ?  `${paths.src}/*.${config.tasks.css.extensions}` : `!${paths.src}/all.scss`;
+//
+//     var isAllCss = function (file) {
+//       return file.path.includes('all') ;
+//     }
+//     return gulp.src(files)
+//         .pipe(gulpif(environment.development, sourcemaps.init()))
+//         .pipe(sass().on('error', sass.logError))
+//         .pipe(autoprefixer(config.tasks.css.autoprefixer))
+//         .pipe(gulpif(environment.production, cleanCSS(config.tasks.css.cleanCSS)))
+//         // .pipe(rename({
+//         //     prefix: `${prefix}-`
+//         // }))
+//         .pipe(gulpif(isAllCss, rename({
+//             basename: prefix
+//         })))
+//         .pipe(gulpif(environment.development, sourcemaps.write()))
+//         .pipe(gulp.dest(paths.dest))
+// }
+// gulp.task('pkg-sass-ariba', sassTask);
+
+// //compile individual component files
+// var componentsTask = (cb) => {
+//     var files = [
+//         `${paths.src}/components/*.${config.tasks.css.extensions}`,
+//         `!${paths.src}/components/_*.${config.tasks.css.extensions}`
+//     ];
+//     return gulp.src(files)
+//         .pipe(sass().on('error', sass.logError))
+//         .pipe(autoprefixer(config.tasks.css.autoprefixer))
+//         .pipe(gulpif(environment.production, cleanCSS(config.tasks.css.cleanCSS)))
+//         .pipe(gulp.dest(`${paths.dest}/components`))
+// }
+// gulp.task('pkg-css-components-ariba', componentsTask);
+
+//compile individual font-icon files
+var fontIconTask = (cb) => {
+    var files = [`${paths.src}/icons/icon.scss`];
+    var prefix = config.tasks.css.prefix + '-ariba-icons';
+    return gulp.src(files)
+        .pipe(sass().on('error', sass.logError))
+        //.pipe(autoprefixer(config.tasks.css.autoprefixer))
+        .pipe(gulpif(environment.production, cleanCSS(config.tasks.css.cleanCSS)))
+        .pipe(rename({basename: prefix}))
+        .pipe(gulp.dest(`${paths.dest}/icons`))
+}
+gulp.task('pkg-css-font-icon-ariba', fontIconTask);
+
+//create minify versions
+var minifyTask = (cb) => {
+    return gulp.src([`${paths.dest}/**/*.css`])
+        .pipe(cleanCSS({
+            level: {
+                1: {
+                    specialComments: false
+                }
+            }
+        }))
+        .pipe(rename({
+            suffix: `.min`
+        }))
+        .pipe(gulp.dest(paths.dest))
+}
+gulp.task('pkg-css-minify-ariba', minifyTask);
+
+//add banner
+var bannerTask = (cb) => {
+    return gulp.src([`${paths.dest}/**/*.css`])
+        .pipe(header(banner))
+        .pipe(gulp.dest(paths.dest))
+}
+gulp.task('pkg-css-banner-ariba', bannerTask);
+
+//main css task
+module.exports = cssTask = (cb) => {
+    gulpSequence(
+        //'pkg-sass-ariba',
+        //'pkg-css-components-ariba',
+        'pkg-css-font-icon-ariba',
+        'pkg-css-minify-ariba',
+        'pkg-css-banner-ariba',
+        cb)
+}
+gulp.task('pkg-css-ariba', cssTask);

--- a/ops/gulp/pkg-icons-ariba.js
+++ b/ops/gulp/pkg-icons-ariba.js
@@ -1,0 +1,17 @@
+const gulp = require('gulp');
+const config = require('../config');
+
+let environment = require('../lib/environment');
+
+const paths = {
+	src: `${config.root.css}/theme/ariba/icons`,
+	dest: (environment.production ? config.root.dest : config.root.tmp ) + '/ariba/icons'
+}
+
+const task = (cb) => {
+	return gulp.src([`${paths.src}/*.woff`, `!${paths.src}/icon.scss`])
+		.pipe(gulp.dest(paths.dest));
+}
+
+gulp.task('pkg-icons-ariba', task);
+module.exports = task;


### PR DESCRIPTION
Closes sap/fundamental#

- Add new icon & css task for Ariba-Theme
- Update create task to run Ariba-Theme gulp task

#### Test

* Included in standard gulp job to produce new Ariba-Theme artifacts.

#### Changelog

**New**

* Add Gulp task to generate Ariba Theme Font Icon and CSS files

**Changed**

* Update Gulp task to run Ariba Theme related jobs

**Removed**

* None