### PR TITLE
Update doc side navigation for 3rd level menu item

### DIFF
--- a/docs/_includes/side-nav.html
+++ b/docs/_includes/side-nav.html
@@ -35,8 +35,11 @@
                     {% endif %}
                     {% for subfolders in folderitem.subfolders %}
                     {% if subfolders.output contains "web" %}
+                    {% assign subfolder-name = folderitem.title | downcase %}
+                    {% if page.url contains subfolder-name  %}
+
                     <li class="subfolders">
-                        <a href="#">{{ subfolders.title }}</a>
+                        <a class="side-nav__links-link-link" href="{{site.baseurl}}{{subfolders.url}}">{{ subfolders.title }}</a>
                         <ul>
                             {% for subfolderitem in subfolders.subfolderitems %}
                             {% if subfolderitem.output contains "web" %}
@@ -57,6 +60,7 @@
                             {% endfor %}
                         </ul>
                     </li>
+                    {% endif %}
                     {% endif %}
                     {% endfor %}
                     {% endif %}

--- a/docs/scss/_docs-side-nav.scss
+++ b/docs/scss/_docs-side-nav.scss
@@ -50,6 +50,17 @@ $side-nav-link-active-border: docs-color(action, 1);
                 text-decoration: none;
                 background-color: #e4eaf1;
             }
+            &-link{
+                color: $side-nav-links-color !important;
+                display: block;
+                padding: 8px 40px;
+                font-size: 12px;
+                &:hover{
+                    color: $side-nav-links-color;
+                    text-decoration: none;
+                    background-color: #e4eaf1;
+                }
+            }
         }
         &.active{
             a{


### PR DESCRIPTION
Closes sap/fundamental#

- Update side-nav css to show & indent 3rd level menu item properly.
- Update doc side menu rendering to apply right css and to show 3rd level only when respective header is selected.


#### Test

* Test with up coming Ariba-Theme 3rd-level menu items

#### Changelog

**New**

* None

**Changed**

* Side-Nav CSS update to indent & show correctly.
* Update Doc Side-Nav rendering to 3rd level item links and display children only when parent is selected.

**Removed**

* None