### PR TITLE
#366 css vars for padding and gutters

### DIFF
--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -113,13 +113,13 @@ $fd-colors-accent: map-get($fd-colors, "accent") !default;
 $fd-space-modify: normal !default; //normal, compact
 
 //ui
-$fd-padding--ui: $fd-spacing--base * 10 !default;
+$fd-padding--ui: $fd-spacing--base * 8 !default;
 
 //$fd-max-width--ui: map-get($fd-breakpoints,xl) !default;
 $fd-max-width--ui: 1290px !default;
 
 //global widths
-$fd-width--gutter: $fd-spacing--base * 6 !default;
+$fd-width--gutter: map-get($fd-spacing, m) !default;
 
 //type
 $fd-font-family: map-get($fd-fonts, "body") !default;

--- a/scss/core/root.scss
+++ b/scss/core/root.scss
@@ -1,4 +1,5 @@
 @import "./../settings";
+@import "./../mixins";
 
 :root {
   --color-action-1: #{map-get($fd-colors-action, 1)};
@@ -22,4 +23,19 @@
   --color-accent-7: #{map-get($fd-colors-accent, 7)};
   --color-accent-8: #{map-get($fd-colors-accent, 8)};
   --color-accent-9: #{map-get($fd-colors-accent, 9)};
+
+  //padding and gutter values used in page, section, and container
+  --fd-padding-ui: #{map-get($fd-spacing, xxs)};
+  --fd-width-gutter: #{map-get($fd-spacing, xxs)};
+  @include fd-screen(s) {
+    --fd-padding-ui: #{map-get($fd-spacing, xs)};
+  }
+  @include fd-screen(m) {
+    --fd-padding-ui: #{map-get($fd-spacing, s)};
+    --fd-width-gutter: #{map-get($fd-spacing, xs)};
+  }
+  @include fd-screen(l) {
+    --fd-padding-ui: #{$fd-padding--ui};
+    --fd-width-gutter: #{$fd-width--gutter};
+  }
 }

--- a/scss/layout/_mixins.scss
+++ b/scss/layout/_mixins.scss
@@ -78,16 +78,18 @@ $flow_width_of_gutter: $fd-width--gutter;
   float: left;
   //set margin for gutter
   margin-right: $flow_width_of_gutter;
+  margin-right: var(--fd-width-gutter);
+
+
   &:last-child {
     margin-right: 0;
   }
   //calc width without gutters
   $num_of_gutters: $cols - 1;
   $gutter_width_total: $num_of_gutters * $flow_width_of_gutter;
-  
+
   //calc spanned gutter width
   $gutter_width_spanned: $flow_width_of_gutter * ($span - 1);
-
 
   //the math
   //#1 subtract total gutter width from container width (e.g., 12 cols have 11 gutters * 20px)
@@ -101,6 +103,14 @@ $flow_width_of_gutter: $fd-width--gutter;
           / #{$cols}
       ) * #{$span}
     ) + #{$gutter_width_spanned}
+  );
+  width: calc(
+    (
+      (
+        (100% - (#{$num_of_gutters} * var(--fd-width-gutter)))
+          / #{$cols}
+      ) * #{$span}
+    ) + (var(--fd-width-gutter) * (#{$span} - 1))
   );
 }
 
@@ -121,5 +131,13 @@ $flow_width_of_gutter: $fd-width--gutter;
           / #{$cols}
       ) * #{$span}
     ) + #{$gutter_width_spanned}
+  );
+  margin-left: calc(
+    (
+      (
+        (100% - (#{$num_of_gutters} * var(--fd-width-gutter)))
+          / #{$cols}
+      ) * #{$span}
+    ) + (var(--fd-width-gutter) * (#{$span}))
   );
 }

--- a/scss/layout/container.scss
+++ b/scss/layout/container.scss
@@ -5,7 +5,6 @@
 $block: #{$fd-namespace}-container;
 .#{$block} {
   @include fd-clearfix;
-  //padding: 0 $fd-padding--ui;
   margin-bottom: $fd-margin-bottom;
   max-width: $fd-max-width--ui;
   &:last-child {

--- a/scss/layout/page.scss
+++ b/scss/layout/page.scss
@@ -7,12 +7,14 @@ $block: #{$fd-namespace}-page;
   $fd-page-background-color: $fd-background-color !default;
   $fd-page-header-padding-x: $fd-padding--ui !default;
   $fd-page-header-padding-y: 0 !default;
+  --fd-page-header-padding-x: var(--fd-padding-ui);
 
   $fd-page-header-height: auto !default;
   $fd-page-header-border-color: fd-color("neutral", 3) !default;
   $fd-page-header-border-width: 0 !default;
   $fd-page-intro-background-color: fd-color("background", 2) !default;
   $fd-page-intro-padding: fd-space(4) !default;
+
   display: flex;
   flex-direction: column;
   min-height: 100%;
@@ -25,14 +27,7 @@ $block: #{$fd-namespace}-page;
     background-color: $fd-page-background-color;
     min-height: $fd-page-header-height;
     padding: $fd-page-header-padding-y $fd-page-header-padding-x;
-  }
-  &__intro {
-    @include fd-type("-1");
-    padding: $fd-page-intro-padding $fd-padding--ui;
-    background-color: $fd-page-intro-background-color;
-    text-align: center;
-    border-bottom: solid 1px fd-color("neutral", 3);
-    margin-bottom: -1px;
+    padding: $fd-page-header-padding-y var(--fd-page-header-padding-x);
   }
   &__content {
     flex-grow: 1;

--- a/scss/layout/section.scss
+++ b/scss/layout/section.scss
@@ -12,6 +12,8 @@ $block: #{$fd-namespace}-section;
 .#{$block} {
     $fd-section-border-color: fd-color("neutral", 3) !default;
     $fd-section-padding: $fd-padding--ui !default;
+    --fd-section-padding-x: var(--fd-padding-ui);
+
     $fd-section-padding--top: fd-space(s) !default;
     $fd-section-padding--bottom: fd-space(reg) !default;
     $fd-section-header-margin--bottom: fd-space(reg) !default;
@@ -19,6 +21,7 @@ $block: #{$fd-namespace}-section;
 
     @include fd-clearfix;
     padding: $fd-section-padding--top $fd-section-padding $fd-section-padding--bottom;
+    padding: $fd-section-padding--top var(--fd-section-padding-x) $fd-section-padding--bottom;
     border-bottom: none;
     &:last-child,
     &--no-border {
@@ -30,7 +33,9 @@ $block: #{$fd-namespace}-section;
         padding-left: 0;
         .#{$block}__header, .#{$block}__footer {
             margin-left: $fd-section-padding;
+            margin-left: var(--fd-section-padding-x);
             margin-right: $fd-section-padding;
+            margin-right: var(--fd-section-padding-x);
         }
     }
     &__header {

--- a/test/templates/index.njk
+++ b/test/templates/index.njk
@@ -92,4 +92,5 @@ li {
 <ul>
     <li><a href="pages/styles">Styles</a></li>
     <li><a href="pages/all">Sections and Panels</a></li>
+    <li><a href="pages/grid">Grid</a></li>
 </ul>

--- a/test/templates/pages/grid.njk
+++ b/test/templates/pages/grid.njk
@@ -1,0 +1,196 @@
+{% extends "./layouts/page.njk" %}
+{% set page_title = "Details 2" %}
+{% set page_intro = "" %}
+{% set hide_app_sidebar = true %}
+{% set is_editable_page = false %}
+
+{% import "../layout/component.njk" as layout %}
+{% from "../tabs/component.njk" import tabs %}
+{% from "../form/component.njk" import form_item %}
+{% from "../table/component.njk" import table %}
+{% from "../action-bar/component.njk" import action_bar %}
+{% from "../button/component.njk" import button %}
+{% from "../tree/component.njk" import tree %}
+
+{# SET CONTENT #}
+
+{% set div %}
+<div class="fd-has-background-color-accent-2" style="height: 50px;"></div>
+{%- endset %}
+{% set div_2 %}
+<div class="fd-has-background-color-accent-7" style="height: 50px;"></div>
+{%- endset %}
+
+
+{% set cols %}
+
+  {%- call layout.container() -%}
+      {%- for i in range(1,13) %}
+          {%- call layout.col(1) %}
+          {{div}}
+          {% endcall %}
+      {%- endfor %}
+  {%- endcall %}
+  {%- call layout.container() -%}
+      {%- for i in range(1,7) %}
+          {%- call layout.col(2) %}
+          {{div}}
+          {% endcall %}
+      {%- endfor %}
+  {%- endcall %}
+
+  {%- call layout.container() -%}
+      {%- for i in range(1,5) %}
+          {%- call layout.col(3) %}
+          {{div}}
+          {% endcall %}
+      {%- endfor %}
+  {%- endcall %}
+
+    {%- call layout.container() -%}
+        {%- for i in range(1,4) %}
+            {%- call layout.col(4) %}
+            {{div}}
+            {% endcall %}
+        {%- endfor %}
+    {%- endcall %}
+
+    {%- call layout.container() -%}
+        {%- for i in range(1,3) %}
+            {%- call layout.col(6) %}
+            {{div}}
+            {% endcall %}
+        {%- endfor %}
+    {%- endcall %}
+
+    {%- call layout.container() -%}
+        {%- for i in range(1,13) %}
+            {%- call layout.col(1) %}
+            {{div}}
+            {% endcall %}
+        {%- endfor %}
+    {%- endcall %}
+
+    {%- call layout.container() -%}
+            {%- call layout.col(11, classes="col--shift-1") %}
+            {{div}}
+            {% endcall %}
+    {%- endcall %}
+    {%- call layout.container() -%}
+            {%- call layout.col(6, classes="col--shift-3") %}
+            {{div}}
+            {% endcall %}
+            {%- call layout.col(1, classes="col--shift-1") %}
+            {{div}}
+            {% endcall %}
+    {%- endcall %}
+
+{%- endset %}
+
+{% set cols_fluid %}
+
+  {%- call layout.container(modifier="fluid") -%}
+      {%- for i in range(1,13) %}
+          {%- call layout.col(1) %}
+          {{div_2}}
+          {% endcall %}
+      {%- endfor %}
+  {%- endcall %}
+  {%- call layout.container(modifier="fluid") -%}
+      {%- for i in range(1,7) %}
+          {%- call layout.col(2) %}
+          {{div_2}}
+          {% endcall %}
+      {%- endfor %}
+  {%- endcall %}
+
+  {%- call layout.container(modifier="fluid") -%}
+      {%- for i in range(1,5) %}
+          {%- call layout.col(3) %}
+          {{div_2}}
+          {% endcall %}
+      {%- endfor %}
+  {%- endcall %}
+
+    {%- call layout.container(modifier="fluid") -%}
+        {%- for i in range(1,4) %}
+            {%- call layout.col(4) %}
+            {{div_2}}
+            {% endcall %}
+        {%- endfor %}
+    {%- endcall %}
+
+    {%- call layout.container(modifier="fluid") -%}
+        {%- for i in range(1,3) %}
+            {%- call layout.col(6) %}
+            {{div_2}}
+            {% endcall %}
+        {%- endfor %}
+    {%- endcall %}
+
+    {%- call layout.container(modifier="fluid") -%}
+        {%- for i in range(1,13) %}
+            {%- call layout.col(1) %}
+            {{div_2}}
+            {% endcall %}
+        {%- endfor %}
+    {%- endcall %}
+
+    {%- call layout.container(modifier="fluid") -%}
+            {%- call layout.col(11, classes="col--shift-1") %}
+            {{div_2}}
+            {% endcall %}
+    {%- endcall %}
+    {%- call layout.container(modifier="fluid") -%}
+            {%- call layout.col(6, classes="col--shift-3") %}
+            {{div_2}}
+            {% endcall %}
+            {%- call layout.col(1, classes="col--shift-1") %}
+            {{div_2}}
+            {% endcall %}
+    {%- endcall %}
+
+{%- endset %}
+
+
+
+{% block page_content %}
+
+
+{%- call layout.section() %}
+{{cols}}
+{%- endcall %}
+
+
+
+{%- call layout.section() %}
+  <div class="fd-panel">
+    <div class="fd-panel__body">
+      {{cols_fluid}}
+    </div>
+  </div>
+{%- endcall %}
+
+
+{%- call layout.section() %}
+{% call layout.container() -%}
+<div class="fd-panel">
+  <div class="fd-panel__body">
+      {{cols}}
+  </div>
+</div>
+{%- endcall %}
+{%- endcall %}
+
+
+
+{%- call layout.section() %}
+{{cols_fluid}}
+{%- endcall %}
+
+
+
+{% endblock %}
+{% block page_header -%}
+.page__header
+{%- endblock %}

--- a/test/templates/pages/layouts/page.njk
+++ b/test/templates/pages/layouts/page.njk
@@ -20,11 +20,6 @@
         {%- endblock %}
     </header>
     {% endif %}
-    {# {% if page_intro %}
-    <div class="fd-page__intro">
-        <p><em>{{ page_intro }}</em></p>
-    </div>
-    {% endif %} #}
     <div class="fd-page__content">
     {% block page_content -%}
     {%- endblock %}


### PR DESCRIPTION
Closes sap/fundamental#366

Implements variable `section` padding and `col` gutters based on screen size

|breakpoint|ui padding|gutter|
|--|--|--|
| default | 8px | 8px |
| xs (320) |  | |
| s (800) | 12px | 8px |
| m (1024)  | 16px | 12px |
| l (1440)  | 32px | 16px |
| xl (1580) | | |


#### Test

* http://localhost:3030/pages/grid
* http://localhost:3030/layout

> NOTE: IE 11 will always use the `l` SASS value. All other modern browsers will use the CSS var values.

#### Changelog

**New**

* Padding and gutter values added to `root` scss
* Page and section containers updated to use CSS vars with fallback
* Flow mixin updated to use CSS vars with fallback


**Changed**

* Default `$fd-padding--ui` and `$fd-width--gutter` updated to new values

**Removed**

* Deleted CSS for deprecated `.fd-page__intro` container