### PR TITLE
Update Ariba-Theme Add SAP-Icon RTL support.

### DIFF
--- a/scss/theme/ariba/icons/icon.scss
+++ b/scss/theme/ariba/icons/icon.scss
@@ -43,6 +43,7 @@ $block: ariba-icon;
 }
 
 [dir='rtl']{
+  [class*="sap-icon"],
   [class*="#{$block}"] {
     &::before {
       -webkit-transform: scaleX(-1);


### PR DESCRIPTION
Closes sap/fundamental#

Add RTL support for SAP-Icons under Ariba-Theme

#### Test

* Documentation

#### Changelog

**New**

* None

**Changed**

* Ariba-theme "icons.scss", add class for SAP-Icon under RTL.

**Removed**

* None
