### PR TITLE
Correct macOS and Xcode related spellings

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The project has the following prerequisites and works best with the noted versio
 * Python 2 (for Jekyll - documentation site)
 * Bundle (for documentation site)
 * Jekyll (for documentation site)
-* XCode (for some Mac OS user)
+* Xcode (for some macOS users)
 
 # Limitations
 


### PR DESCRIPTION
Closes sap/fundamental# N/A

Correct the spelling of Xcode and macOS in the readme.

#### Test

N/A

#### Changelog

N/A

**Changed**

Spelling in Readme.