### PR TITLE
#838 fixing col stacking

### DIFF
--- a/scss/layout/col.scss
+++ b/scss/layout/col.scss
@@ -8,7 +8,7 @@
 $block: #{$fd-namespace}-col;
 .#{$block} {
   flex: 1;
-  @include fd-screen(s) {
+  @include fd-screen(m) {
     @for $i from 1 through 12 {
       &--#{$i} {
         @include fd-flow($i, 12);


### PR DESCRIPTION
Closes sap/fundamental#838

At some point the stacking behavior of the columns at small screens was reverted. 

#### Test

* http://localhost:3030/pages/grid

#### Changelog

**New**

* None

**Changed**

* The `col` containers go full width below the `m` breakpoint

**Removed**

* None