### PR TITLE
#843 update colors documentation page to reflect color palette

### DIFF
--- a/docs/_data/colors.yml
+++ b/docs/_data/colors.yml
@@ -10,10 +10,6 @@ group:
     colorhsl: hsl(210, 91%, 43%)
     textcolor: ffffff
     bordercolor: ffffff
-  - colorname: 2
-    colorvalue: d1e8ff
-    textcolor: 354A5F
-    bordercolor: ffffff
 
   - colorname: 2
     colorvalue: FFFFFF
@@ -89,12 +85,6 @@ group:
     textcolor: 000000
     bordercolor: cfdbe7
 
-  - colorname: 3
-    colorvalue: d1e8ff
-    textcolor: 000000
-    bordercolor: cfdbe7
-
-
 # Neutral
 - name: Neutral
   key: neutral
@@ -129,25 +119,25 @@ group:
   colors:
   - colorname: 1
     colorvalue: 107F3E
-    colorhsl:
+    colorhsl: hsl(145, 78%, 28%)
     textcolor: FFFFFF
-    bordercolor: 118843
+    bordercolor: 107F3E
 
   - colorname: 2
     colorvalue: E9730C
-    colorhsl:
+    colorhsl: hsl(28, 90%, 48%)
     textcolor: FFFFFF
-    bordercolor: F59518
+    bordercolor: E9730C
 
   - colorname: 3
     colorvalue: EE0000
-    colorhsl:
+    colorhsl: hsl(0, 100%, 47%)
     textcolor: FFFFFF
-    bordercolor: ee0000
+    bordercolor: EE0000
 
   - colorname: 4
-    colorvalue: 687173
-    colorhsl:
+    colorvalue: 6D7678
+    colorhsl: hsl(191, 5%, 45%)
     textcolor: FFFFFF
     bordercolor: 6D7678
 
@@ -242,3 +232,61 @@ group:
     colorhsl: hsl(213.3, 15%, 47.1%)
     textcolor: FFFFFF
     bordercolor: ffffff
+
+# State Action Colors
+- name: State Action
+  key: action
+  description:
+  colors:
+  - colorname: hover
+    colorvalue: 085CAF
+    colorhsl: hsla(210, 91%, 36%, 1)
+    textcolor: FFFFFF
+    bordercolor: ffffff
+
+  - colorname: selected
+    colorvalue: 0254A7
+    colorhsl: hsla(210, 98%, 33%, 1)
+    textcolor: FFFFFF
+    bordercolor: ffffff
+
+  - colorname: disabled
+    colorvalue: 0a6ed1
+    colorhsl: hsla(210, 91%, 43%, 0.4)
+    textcolor: FFFFFF
+    bordercolor: ffffff
+
+# State Background Colors
+- name: State Background
+  key: background
+  description:
+  colors:
+  - colorname: hover
+    colorvalue: FAFAFA
+    colorhsl: hsla(210, 3%, 98%, 1)
+    bordercolor: cfdbe7
+
+  - colorname: selected
+    colorvalue: 0A6ED1
+    colorhsl: hsla(210, 91%, 43%, 0.07)
+    bordercolor: cfdbe7
+
+  - colorname: selected-hover
+    colorvalue: 0A6ED1
+    colorhsl: hsla(210, 91%, 43%, 0.1)
+    bordercolor: cfdbe7
+
+  - colorname: positive
+    colorvalue: E4FCEE
+    colorhsl: hsla(144.7, 77.6%, 94%, 1)
+    bordercolor: cfdbe7
+
+  - colorname: alert
+    colorvalue: FFE9E9
+    colorhsl: hsla(144.7, 77.6%, 94%, 1)
+    bordercolor: cfdbe7
+
+  - colorname: negative
+    colorvalue: FFE9E9
+    colorhsl: hsla(0, 100%, 95.7%, 1)
+    bordercolor: cfdbe7

--- a/docs/_includes/colors.html
+++ b/docs/_includes/colors.html
@@ -1,17 +1,19 @@
 {% for group in site.data.colors.group %}
+    <h2 class="docs-header-h2">{{ group.name }}</h2>
+    <p>{{ group.description }}</p>
     <div class="docs-colors_container">
-        <h3>{{ group.name }}</h3>
-        <p>{{ group.description }}</p>
-
         <ul class="docs-colors_plaque">
         {% for colors in group.colors %}
-            <li style="background-color: #{{ colors.colorvalue }}; color: #{{colors.textcolor}}; border: 1px solid #{{colors.bordercolor}}{% if colors.colorname == 11 %}; clear: left;{% endif %}" class="docs-colors_plaque_color">
+            <li style="background-color: {{ colors.colorhsl }}; color: #{{colors.textcolor}}; border: 1px solid #{{colors.bordercolor}}{% if colors.colorname == 11 %}; clear: left;{% endif %}" class="docs-colors_plaque_color">
                <span class="docs-colors_plaque_color-name">
                 {{ colors.colorname }}
                </span>
 
-              <span class="docs-colors_plaque_color-value"> {{ colors.colorhsl }}<br> #{{ colors.colorvalue }} </span>
-  <code class="docs-colors_plaque_color-code"><small>fd-color("{{ group.key }}",{{ colors.colorname }})<br>var(--fd-color-{{ group.key }}-{{ colors.colorname }})</small>
+              <span class="docs-colors_plaque_color-value"> {{ colors.colorhsl }}<br> #{{ colors.colorvalue }}</span>
+  <code class="docs-colors_plaque_color-code">
+      <small>
+          var(--fd-color-{{group.key}}-{{colors.colorname}})
+      </small>
     </code>
             </li>
         {% endfor %}

--- a/test/templates/pages/styles.njk
+++ b/test/templates/pages/styles.njk
@@ -107,10 +107,11 @@
   <h1>State Colors</h1>
   <h2>{{ group }}</h2>
   {% for item in values %}
-    <span>{{ item[0] }} — {{ item[1] }}</span>
     {% set cssvar %}
     --fd-color-{{ group }}-{{ item[0] }}
     {% endset %}
+
+    <span>{{ item[0] }} — {{ item[1] }} / var({{cssvar}})</span>
 
     <br> <div style="padding: 20px; border: 1px solid #ccc; background-color: var({{cssvar}})">
         </div>


### PR DESCRIPTION
Closes sap/fundamental#843

Update colors documentation page to match design system colors 

#### Test

* http://localhost:4000/foundation/colors.html (updated page) 
* http://localhost:3030/pages/styles (reference for colors) 

#### Changelog

**New**

nothing 

**Changed**

* updated colors to match design system colors 

**Removed**

* Removed `fd-color` function documentation in favor of css vars 
