### PR TITLE
Bugfix/remove padding on breadcrumb #853

### DIFF
--- a/scss/components/breadcrumb.scss
+++ b/scss/components/breadcrumb.scss
@@ -17,7 +17,6 @@ $block: #{$fd-namespace}-breadcrumb;
     //LOCAL VARS *******************************************
     $fd-breadcrumb-background-color: fd-color(background, 2)!default;
     $fd-breadcrumb-border-bottom-color: fd-color(neutral, 3)!default;
-    $fd-breadcrumb-padding: fd-space(3) fd-space(4)!default;
 
     //BLOCK BASE *******************************************
     @include fd-reset;
@@ -27,7 +26,7 @@ $block: #{$fd-namespace}-breadcrumb;
     padding-left: 0;
     margin-bottom: -#{fd-space(3)};
     list-style: none;
-    padding: $fd-breadcrumb-padding 0 0;
+    padding-right: fd-space(4);
 
     //ELEMENTS *******************************************
     &__item {
@@ -48,7 +47,7 @@ $block: #{$fd-namespace}-breadcrumb;
 
 @include fd-rtl(#{$block}) {
     .#{$block}{
-        padding: fd-space(3) 0  0 fd-space(4);
+        padding: 0 0 0 fd-space(4);
 
         &__item {
             &::after{


### PR DESCRIPTION
Closes sap/fundamental https://github.com/SAP/fundamental/issues/853

Remove top padding from breadcrumb

#### Test

* http://localhost:3030/breadcrumb

<img width="344" alt="screenshot 2018-11-01 at 14 53 43" src="https://user-images.githubusercontent.com/44162302/47859387-2521f880-dde6-11e8-9dad-82d52adee423.png">
