### PR TITLE
Fixing focus on input group RHS border.

### DIFF
--- a/scss/components/input-group.scss
+++ b/scss/components/input-group.scss
@@ -88,9 +88,6 @@ $block: #{$fd-namespace}-input-group;
           }
         }
 
-
-        z-index: map-get($fd-z-index-levels, "first"); // Brings focus state above input
-
         //ELEMENT MODIFIERS ************
         &:first-child {
             border-right-width: 0;


### PR DESCRIPTION
Closes sap/fundamental https://github.com/SAP/fundamental/issues/859

Removes z-index that was causing RHS border of input focus to not display.  Can't see why we need z-index on elements that are inline in the document?  Perhaps we should consider only having z-index on elements that overlay others (popovers, dialogs, modals etc).

#### Test

* http://localhost:3030/input-group

And focus an input element with a button addon

#### Changelog

Was:

![image](https://user-images.githubusercontent.com/15449680/47864113-c0b86680-ddf0-11e8-92d0-f9ffd2cfb069.png)

Now:

![image](https://user-images.githubusercontent.com/15449680/47864035-949ce580-ddf0-11e8-889b-c207f6b2baa7.png)


