### PR TITLE
#873 update table demo page to use fd-token instead of fd-tag

### DIFF
--- a/docs/_includes/demo-page-components/table-page-content.html
+++ b/docs/_includes/demo-page-components/table-page-content.html
@@ -51,11 +51,11 @@
                         </nav>
                     </div>
                 </div>
-                <div class="fd-panel__filters" aria-hidden="false"><span class="fd-tag" role="button">Bibendum</span>
-                    <span class="fd-tag" role="button">Bibendum</span>
-                    <span class="fd-tag" role="button">Bibendum</span>
-                    <span class="fd-tag" role="button">Bibendum</span>
-                    <span class="fd-tag" role="button">Bibendum</span>
+                <div class="fd-panel__filters" aria-hidden="false"><span class="fd-token" role="button">Bibendum</span>
+                    <span class="fd-token" role="button">Bibendum</span>
+                    <span class="fd-token" role="button">Bibendum</span>
+                    <span class="fd-token" role="button">Bibendum</span>
+                    <span class="fd-token" role="button">Bibendum</span>
                     <button class="fd-button--light fd-button--compact">Clear All</button>
                 </div>
                 <div class="fd-panel__body fd-panel__body--bleed">


### PR DESCRIPTION
Closes sap/fundamental#873

# NOTE: This PR is against master and needs to be merged back into develop before deleting the branch 

#### Test

* http://localhost:4000/demo-pages/table-demo-page.html 
ensure `fd-token` is being used in the table header 

#### Changelog

**New**

nothing 

**Changed**

* tables demo page updated to use `fd-token` instead of `fd-tag`

**Removed**

* `fd-tag` references on table demo page 
