### PR TITLE
Fix vertical alignment in status label.

### DIFF
--- a/scss/components/status-label.scss
+++ b/scss/components/status-label.scss
@@ -25,7 +25,7 @@ $block: #{$fd-namespace}-status-label;
         line-height: 1;
         border-radius: 50%;
         position: absolute;
-        top: 1px;
+        top: 0;
         left: 0;
     }
 
@@ -62,7 +62,7 @@ $block: #{$fd-namespace}-status-label;
             @include fd-status-icon;
             width: 7px;
             height: 7px;
-            top: 5px;
+            top: 4px;
             left: 4px;
             background-image: url($fd-status-indicator-available);
         }
@@ -77,7 +77,7 @@ $block: #{$fd-namespace}-status-label;
             @include fd-status-icon;
             width: 6px;
             height: 6px;
-            top: 5px;
+            top: 4px;
             left: 6px;
             background-image: url($fd-status-indicator-away);
         }
@@ -92,7 +92,7 @@ $block: #{$fd-namespace}-status-label;
             @include fd-status-icon;
             width: 4px;
             height: 4px;
-            top: 7px;
+            top: 6px;
             left: 6px;
             background-image: url($fd-status-indicator-busy);
         }
@@ -107,7 +107,7 @@ $block: #{$fd-namespace}-status-label;
             @include fd-status-icon;
             width: 8px;
             height: 8px;
-            top: 5px;
+            top: 4px;
             left: 4px;
             background-image: url($fd-status-indicator-offline);
         }


### PR DESCRIPTION
Closes sap/fundamental# https://github.com/SAP/fundamental/issues/851

Moves the associated status label icon up to be better aligned with the status label text.

#### Test

* http://localhost:3030/status-label

#### Changelog

Before:

![image](https://user-images.githubusercontent.com/15449680/47917254-ca99a280-dea0-11e8-8596-73fa8c124c26.png)

Now:

![image](https://user-images.githubusercontent.com/15449680/47917263-d1c0b080-dea0-11e8-8532-86e935d304cd.png)
