### PR TITLE
#902 new issue templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,110 @@
+# Contributing
+
+FThank you for considering contributing to SAP Fiori Fundamentals. It's people like you that make this such a great tool.
+
+### 1. Where do I go from here?
+
+If you've noticed a bug or have a question, [search the issue tracker][] to see if
+someone else in the community has already created a ticket. If not, go ahead and
+[make one][]!
+
+### 2. Fork & create a branch
+
+If this is something you think you can fix, then [fork Fundamentals][] and
+create a branch with a descriptive name.
+
+A good branch name would be (where issue #325 is the ticket you're working on):
+
+```sh
+git checkout -b feature/325-japanese-translation
+```
+
+### 3. Did you find a bug?
+
+* **Ensure the bug was not already reported** by [searching all issues][].
+
+* If you're unable to find an open issue addressing the problem,
+  [open a new one][new issue]. Be sure to include a **title and clear
+  description**, as much relevant information as possible, and a **code sample**
+  or an **executable test case** demonstrating the expected behavior that is not
+  occurring.
+
+* If possible, use the relevant bug report templates to create the issue.
+
+### 4. Implement your fix or feature
+
+At this point, you're ready to make your changes! Feel free to ask for help;
+everyone is a beginner at first :smile_cat:
+
+
+### 5. Run the test framework
+Any markup or CSS changes should begin the test framework. The component test framework loads only `core.scss` and individual component `.scss` files. **The HTML created here will be used on the documentation site.**
+
+- Run `npm test`
+- Go to [localhost:3030](http://localhost:3030)
+
+### 6. Run the documentation
+If your update requires changes to the documentation. The docs CSS is compiled from the source SASS.
+
+- Run `gulp`
+- Go to [localhost:4000](http://localhost:4000)
+
+
+### 7. Make a Pull Request
+
+At this point, you should switch back to your master branch and make sure it's
+up to date with Fiori Fundamentals' master branch:
+
+```sh
+git remote add upstream git@github.com:sap/fundamental.git
+git checkout master
+git pull upstream master
+```
+
+Then update your feature branch from your local copy of master, and push it!
+
+```sh
+git checkout feature/325-japanese-translation
+git rebase master
+git push --set-upstream origin feature/325-japanese-translation
+```
+
+Finally, go to GitHub and [make a Pull Request][] :D
+
+
+### 8. Keeping your Pull Request updated
+
+If a maintainer asks you to "rebase" your PR, they're saying that a lot of code
+has changed, and that you need to update your branch so it's easier to merge.
+
+To learn more about rebasing in Git, there are a lot of [good][git rebasing]
+[resources][interactive rebase] but here's the suggested workflow:
+
+```sh
+git checkout feature/325-japanese-translation
+git pull --rebase upstream master
+git push --force-with-lease feature/325-japanese-translation
+```
+
+### 9. Merging a PR (maintainers only)
+
+A PR can only be merged into develop by a maintainer if:
+
+* It is passing CI.
+* It has been approved by at least two maintainers. If it was a maintainer who
+  opened the PR, only one extra approval is needed.
+* It has no requested changes.
+* It is up to date with current master.
+
+Any maintainer is allowed to merge a PR if all of these conditions are
+met.
+
+
+[make one]: https://github.com/SAP/fundamental/issues/new
+[search the issue tracker]: https://github.com/SAP/fundamental/issues?utf8=✓&q=is%3Aissue
+[new issue]: https://github.com/SAP/fundamental/issues/new
+[fork Fundamentals]: https://help.github.com/articles/fork-a-repo
+[searching all issues]: https://github.com/SAP/fundamental/issues?utf8=✓&q=is%3Aissue
+[make a pull request]: https://help.github.com/articles/creating-a-pull-request
+[git rebasing]: http://git-scm.com/book/en/Git-Branching-Rebasing
+[interactive rebase]: https://help.github.com/articles/interactive-rebase

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-FThank you for considering contributing to SAP Fiori Fundamentals. It's people like you that make this such a great tool.
+Thank you for considering contributing to SAP Fiori Fundamentals. It's people like you that make this such a great tool.
 
 ### 1. Where do I go from here?
 

--- a/.github/ISSUE_TEMPLATES/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATES/BUG_REPORT.md
@@ -1,0 +1,51 @@
+<!-- Feel free to remove sections that aren't relevant.
+
+Before opening:
+
+- [Search for duplicate or closed issues](https://github.com/SAP/fundamental/issues?utf8=✓&q=is%3Aissue)
+- Read the [contributing guidelines](https://github.com/SAP/fundamental/tree/develop/.github/CONTRIBUTING.md)
+
+Feature requests must include:
+- As much detail as possible for what we should add and why it's important
+- Relevant links to prior art, screenshots, or live demos whenever possible
+
+-->
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+> Is this issue related to a specific component?
+
+> What version of the Fiori Fundamentals are you using?
+
+> What offering/product do you work on? Any pressing ship or release dates we should be aware of?
+
+> What front-end framework are you implementing in, e.g., Angular, React, etc.?
+
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATES/COMPONENT_REQUEST.md
+++ b/.github/ISSUE_TEMPLATES/COMPONENT_REQUEST.md
@@ -1,0 +1,52 @@
+<!--
+Before opening:
+
+- [Search for duplicate or closed issues](https://github.com/SAP/fundamental/issues?utf8=✓&q=is%3Aissue)
+- Read the [contributing guidelines](https://github.com/SAP/fundamental/tree/develop/.github/CONTRIBUTING.md)
+
+Feature requests must include:
+- As much detail as possible for what we should add and why it's important
+- Relevant links to prior art, screenshots, or live demos whenever possible
+
+-->
+
+### Component name
+> Propose a new or variant name
+
+
+### Detailed description
+> Describe the request
+
+> What offering/product do you work on? Any pressing ship or release dates we should be aware of?
+
+> What front-end framework are you implementing in, e.g., Angular, React, etc.?
+
+
+### Use case
+> Describe when to use (and when not to use)
+
+
+### Visual style
+> Describe specific needs related to color, typography, iconography, borders, space, size, and other visual properties.
+
+> Describe how to arrange multiple instances and other alignment specifics.
+
+> How should this respond to common contexts, i.e., touch, RTL, small screens.
+
+> Describe interactive states, e.g., disabled, expanded, pressed.
+
+
+### Expected behavior
+> How should this handle events, outcomes, and transitions
+
+> What [states should be available](https://medium.com/swlh/the-nine-states-of-design-5bfe9b3d6d85), i.e., nothing, loading, none, one, some, too many, incorrect, correct, done.
+
+
+### Editorial
+> Advise on labels, tone, length, punctuation, truncation.
+
+
+## Additional information
+
+* Screenshots or code
+* Notes

--- a/.github/ISSUE_TEMPLATES/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATES/FEATURE_REQUEST.md
@@ -1,0 +1,36 @@
+<!-- Feel free to remove sections that aren't relevant.
+
+Before opening:
+- [Search for duplicate or closed issues](https://github.com/SAP/fundamental/issues?utf8=✓&q=is%3Aissue)
+- Read the [contributing guidelines](https://github.com/SAP/fundamental/tree/develop/.github/CONTRIBUTING.md)
+
+Feature requests must include:
+- As much detail as possible for what we should add and why it's important
+- Relevant links to prior art, screenshots, or live demos whenever possible
+
+-->
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+> Is this issue related to a specific component?
+
+> What browser are you working in?
+
+> What version of the Fiori Fundamentals are you using?
+
+> What offering/product do you work on? Any pressing ship or release dates we should be aware of?
+
+> What front-end framework are you implementing in, e.g., Angular, React, etc.?
+
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
### Please take a look at these new recommended issue templates and see if you have any suggestions. 

> The CONTRIBUTING file can be updated easily but the issue templates are only being committed so that the admin can apply them in the Settings once we agree they are OK.

sap/fundamental#902

Adds new issue templates. This alone will not close this. Once reviewed and merged, the Github admin will need to put these into action in Settings.

https://help.github.com/articles/creating-issue-templates-for-your-repository/

#### Test

* Once completed by the admin, when clicking on New Issue an interstitial page will appear with the three choices.

#### Changelog

**New**

* Adds New Component, Bug Report, and Feature Request templates.
