### PR TITLE
Error handling of type functions

### DIFF
--- a/scss/functions/_type.scss
+++ b/scss/functions/_type.scss
@@ -1,6 +1,7 @@
 // get font-size from main map
 @function fd-font-size($size: "0") {
   $_map: $fd-type;
+  $_size: "0";
   $list: map-get($_map, "0");
   @if map-has-key($_map, $size) {
     $list: map-get($_map, $size);
@@ -13,6 +14,7 @@
 // get line-height from main map
 @function fd-line-height($size: "0") {
   $_map: $fd-type;
+  $_size: "0";
   $list: map-get($_map, "0");
   @if map-has-key($_map, $size) {
     $list: map-get($_map, $size);


### PR DESCRIPTION
Closes sap/fundamental https://github.com/SAP/fundamental/issues/802

The issue was that in @warn we were passing a variable that didn't exist.

#### Test

* http://localhost:3030

<img width="861" alt="screenshot 2018-11-06 at 15 12 56" src="https://user-images.githubusercontent.com/44162302/48073657-1e74f600-e1d7-11e8-890b-cb92789909e8.png">
