### PR TITLE
#706 set the z-index of toggle component to base

### DIFF
--- a/scss/components/toggle.scss
+++ b/scss/components/toggle.scss
@@ -30,6 +30,7 @@ $block: #{$fd-namespace}-toggle;
   $fd-toggle-switch-background-color--disabled: hsla(240, 2%, 93%, 1) !default;
   $fd-toggle-switch-on-background-color--disabled: hsla(209, 90%, 92%, 1) !default;
   $fd-toggle-switch-box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.15);
+  $fd-toggle-z-index: map-get($fd-z-index-levels, "base") !default;
 
   @include fd-reset;
   position: relative;
@@ -37,6 +38,7 @@ $block: #{$fd-namespace}-toggle;
   height: $fd-toggle-height;
   width: $fd-toggle-width;
   vertical-align: middle;
+  z-index: $fd-toggle-z-index;
 
   &__switch {
     height: $fd-toggle-switch-width;

--- a/test/templates/pages/form-elements.njk
+++ b/test/templates/pages/form-elements.njk
@@ -337,6 +337,14 @@
 {{combobox_input(size="compact")}}
 </div>
 
+{{  toggle(
+        properties=data.properties,
+        state=data.state,
+        aria=data.aria
+    )
+}}
+
+<br><br>
 
 <h3>.fd-date-picker</h3>
 <div class="fd-form__item">


### PR DESCRIPTION
Closes sap/fundamental#706

set the `z-index` of `fd-toggle` to `base`. 

#### Test

* http://localhost:3030/pages/form-elements

#### Changelog

before: 
<img width="651" alt="screen shot 2018-11-08 at 10 57 17 am" src="https://user-images.githubusercontent.com/15215400/48214269-39fe0f00-e345-11e8-943a-17790d4ce464.png">

after: 
<img width="645" alt="screen shot 2018-11-08 at 10 57 30 am" src="https://user-images.githubusercontent.com/15215400/48214285-42564a00-e345-11e8-9a91-d0cb618ac6fd.png">
