### PR TITLE
#863 remove --compact modifier from time-input add-on

### DIFF
--- a/docs/pages/components/time-picker.md
+++ b/docs/pages/components/time-picker.md
@@ -22,7 +22,7 @@ A basic example of a time picker.
             <div class="fd-input-group fd-input-group--after">
                 <input type="time" class="fd-input " id="" placeholder="hh:mm am/pm">
                 <span class="fd-input-group__addon fd-input-group__addon--after fd-input-group__addon--button ">
-                                  <button class=" fd-button--light fd-button--compact sap-icon--fob-watch fd-popover__control" aria-controls="rthHR811" aria-expanded="false" aria-haspopup="true"></button>
+                                  <button class=" fd-button--light sap-icon--fob-watch fd-popover__control" aria-controls="rthHR811" aria-expanded="false" aria-haspopup="true"></button>
 
                       </span>
             </div>
@@ -35,7 +35,7 @@ A basic example of a time picker.
                 <div class="fd-time__item">
                     <div class="fd-time__control">
 
-                        <button class=" fd-button--standard fd-button--light fd-button--compact sap-icon--navigation-up-arrow" aria-label="Increase hours" aria-controls="BW7dC141"></button>
+                        <button class=" fd-button--standard fd-button--light sap-icon--navigation-up-arrow" aria-label="Increase hours" aria-controls="BW7dC141"></button>
                     </div>
                     <div class="fd-time__input">
                         <input class="fd-form__control" type="text" placeholder="hh" value="" id="BW7dC141" aria-label="Hours">

--- a/test/templates/time-picker/component.njk
+++ b/test/templates/time-picker/component.njk
@@ -45,7 +45,7 @@ time_picker:
     haspopup: true
   },
   state=state,
-  classes=["popover__control"],size="compact")
+  classes=["popover__control"])
 %}
 {{- input_group(
     type="time",


### PR DESCRIPTION
Closes sap/fundamental#863

removed `--compact` button modifier `time-picker` add-on 

#### Test

* http://localhost:3030/date-picker
* http://localhost:4000/components/time-picker.html

#### Changelog
before 
<img width="231" alt="screen shot 2018-11-08 at 11 16 09 am" src="https://user-images.githubusercontent.com/15215400/48215466-ea6d1280-e347-11e8-962e-1846d3a6f84c.png">

after 
<img width="231" alt="screen shot 2018-11-08 at 11 15 13 am" src="https://user-images.githubusercontent.com/15215400/48215464-ea6d1280-e347-11e8-8e36-3e4fa2d3a792.png">
