### PR TITLE
#846 Update tabs styles per new specs

### DIFF
--- a/docs/pages/components/tabs.md
+++ b/docs/pages/components/tabs.md
@@ -17,16 +17,24 @@ Tabs are based on a folder metaphor and used to separate content into different 
 {% capture default-tab %}
 <ul class="fd-tabs" role="tablist">
     <li class="fd-tabs__item">
-        <a class="fd-tabs__link" aria-controls="fuCwV550" href="#fuCwV550" role="tab">Link</a>
+        <a class="fd-tabs__link" aria-controls="fuCwV550" href="#fuCwV550" role="tab">
+            Link
+        </a>
     </li>
     <li class="fd-tabs__item">
-        <a class="fd-tabs__link" aria-controls="AiWfz165" aria-selected="true" href="#AiWfz165" role="tab">Selected</a>
+        <a class="fd-tabs__link" aria-controls="AiWfz165" aria-selected="true" href="#AiWfz165" role="tab">
+            Selected
+        </a>
     </li>
     <li class="fd-tabs__item">
-        <a class="fd-tabs__link" aria-controls="7ae0T849" href="#7ae0T849" role="tab">Link</a>
+        <a class="fd-tabs__link" aria-controls="7ae0T849" href="#7ae0T849" role="tab">
+            Link
+        </a>
     </li>
     <li class="fd-tabs__item">
-        <a class="fd-tabs__link" aria-controls="IR27Y941" aria-disabled="true" role="tab">Disabled</a>
+        <a class="fd-tabs__link" aria-controls="IR27Y941" aria-disabled="true" role="tab">
+            Disabled
+        </a>
     </li>
 </ul>
 <div class="fd-tabs__panel" aria-expanded="false" id="fuCwV550" role="tabpanel">
@@ -49,10 +57,26 @@ Tabs are based on a folder metaphor and used to separate content into different 
 ## Tabs with `nav` element
 {% capture modified-tab %}
 <nav class="fd-tabs" role="tablist">
-    <a class="fd-tabs__link" aria-controls="kf8369" href="#kf8369" role="tab">Link</a>
-    <a class="fd-tabs__link" aria-controls="9uQ282" aria-selected="true" href="#9uQ282" role="tab">Selected</a>
-    <a class="fd-tabs__link" aria-controls="DGl707" href="#DGl707" role="tab">Link</a>
-    <a class="fd-tabs__link" aria-controls="98q398" aria-disabled="true" role="tab">Disabled</a>
+    <span class="fd-tabs__item">
+        <a class="fd-tabs__link" aria-controls="kf8369" href="#kf8369" role="tab">
+            Link
+        </a>
+    </span>
+    <span class="fd-tabs__item">
+        <a class="fd-tabs__link" aria-controls="9uQ282" aria-selected="true" href="#9uQ282" role="tab">
+            Selected
+        </a>
+    </span>
+    <span class="fd-tabs__item">
+        <a class="fd-tabs__link" aria-controls="DGl707" href="#DGl707" role="tab">
+            Link
+        </a>
+    </span>
+    <span class="fd-tabs__item">
+        <a class="fd-tabs__link" aria-controls="98q398" aria-disabled="true" role="tab">
+            Disabled
+        </a>
+    </span>
 </nav>
 <div class="fd-tabs__panel" aria-expanded="false" id="kf8369" role="tabpanel">
     Lorem ipsum

--- a/docs/scss/_docs-display-component.scss
+++ b/docs/scss/_docs-display-component.scss
@@ -60,6 +60,12 @@
         margin-left: 0;
     }
 
+    .fd-tabs__link:hover,
+    .fd-tabs__link:focus
+    {
+        text-decoration: none;
+    }
+
     &__app {
         height: 500px;
         color: #fff;

--- a/scss/components/tabs.scss
+++ b/scss/components/tabs.scss
@@ -13,6 +13,8 @@ $block: #{$fd-namespace}-tabs;
   $fd-tabs-margin-bottom: $fd-margin-bottom !default;
   $fd-tabs-border-width: 1px !default;
   $fd-tabs-border-color: fd-color("neutral", 3) !default;
+  $fd-tabs-background-color: fd-color("background", 2) !default;
+  $fd-tabs-link-color: fd-color("text", 2) !default;
   $fd-tabs-link-padding-y: fd-space("s") !default;
   $fd-tabs-link-padding-x: fd-space("s") !default;
   $fd-tabs-link-border-width: 3px !default;
@@ -20,21 +22,25 @@ $block: #{$fd-namespace}-tabs;
   $fd-tabs-link-transition-params: $fd-animation--speed ease-in !default;
 
   @include fd-reset;
+  background: $fd-tabs-background-color;
   display: flex;
   flex-wrap: wrap;
   padding-left: 0;
   margin-bottom: $fd-tabs-margin-bottom;
   list-style: none;
   border-bottom: solid $fd-tabs-border-width $fd-tabs-border-color;
+  &__item{
+      padding: 0 $fd-tabs-link-padding-x;
+  }
   &__link {
     display: block;
     position: relative;
-    padding: $fd-tabs-link-padding-y $fd-tabs-link-padding-x;
+    padding: $fd-tabs-link-padding-y 0;
     @include fd-type("0");
     @include action-cursor;
-    color: $fd-link-color;
+    color: $fd-tabs-link-color;
     &:link {
-      color: $fd-link-color;
+      color: $fd-tabs-link-color;
     }
     &::after {
       transition: all $fd-tabs-link-transition-params;
@@ -53,7 +59,7 @@ $block: #{$fd-namespace}-tabs;
     }
     &[aria-selected="true"],
     &.is-selected {
-      color: $fd-color;
+      color: $fd-link-color;
       &::after {
         background-color: $fd-tabs-link-border-color;
       }

--- a/test/templates/tabs/index.njk
+++ b/test/templates/tabs/index.njk
@@ -23,14 +23,22 @@
 
 <br><br><hr>
 <br>
-  <p>NOTE: The <code>.fd-tabs__item</code> container is optional. You can use <code>nav</code> and <code>a</code> elements to the same effect.</p>
+  <p>NOTE: You can use <code>nav</code>, <code>span</code> and <code>a</code> elements to the same effect.</p>
 
 {% set example %}
 <nav class="fd-tabs" role="tablist">
-    <a class="fd-tabs__link" aria-controls="kf8369" href="#kf8369" role="tab">Link</a>
-    <a class="fd-tabs__link" aria-controls="9uQ282" aria-selected="true" href="#9uQ282" role="tab">Selected</a>
-    <a class="fd-tabs__link" aria-controls="DGl707" href="#DGl707" role="tab">Link</a>
-    <a class="fd-tabs__link" aria-controls="98q398" aria-disabled="true" role="tab">Disabled</a>
+    <span class="fd-tabs__item">
+        <a class="fd-tabs__link" aria-controls="kf8369" href="#kf8369" role="tab">Link</a>
+    </span>
+    <span class="fd-tabs__item">
+        <a class="fd-tabs__link" aria-controls="9uQ282" aria-selected="true" href="#9uQ282" role="tab">Selected</a>
+    </span>
+    <span class="fd-tabs__item">
+        <a class="fd-tabs__link" aria-controls="DGl707" href="#DGl707" role="tab">Link</a>
+    </span>
+    <span class="fd-tabs__item">
+        <a class="fd-tabs__link" aria-controls="98q398" aria-disabled="true" role="tab">Disabled</a>
+    </span>
 </nav>
 <div class="fd-tabs__panel" aria-expanded="false" id="kf8369" role="tabpanel">
     Lorem ipsum


### PR DESCRIPTION
Closes sap/fundamental#846

Updated tabs style to match [new specs](https://github.com/SAP/fundamental/issues/846).

#### Test

* http://localhost:3030/tabs
* http://localhost:4000/components/tabs.html

**Changed**

* Tabs default state colors 
* Tabs Active state colors 
* active state border width 
* white background color by default 

before: 
<img width="901" alt="screen shot 2018-11-09 at 9 52 58 am" src="https://user-images.githubusercontent.com/15215400/48272899-52cdf980-e405-11e8-978d-281124b263d6.png">

after: 
<img width="837" alt="screen shot 2018-11-09 at 9 52 39 am" src="https://user-images.githubusercontent.com/15215400/48272898-52cdf980-e405-11e8-9b08-1aa7a5a82e27.png">
