### PR TITLE
Bugfix/text alignment in tree - #592

### DIFF
--- a/docs/scss/_docs-display-component.scss
+++ b/docs/scss/_docs-display-component.scss
@@ -30,6 +30,7 @@
         list-style: none;
         margin-left: 0;
         padding-left: 0;
+        text-align: left;
 
         a:hover {
             text-decoration: none;


### PR DESCRIPTION
Closes sap/fundamental https://github.com/SAP/fundamental/issues/592

I tested the tree, the menu and the popover and I think this was more a docs website bug because of some css rules from the parent. 

#### Test

* http://localhost:4000/components/tree.html

#### Changelog

Before:
<img width="1006" alt="screenshot 2018-11-14 at 13 16 53" src="https://user-images.githubusercontent.com/44162302/48485240-40422e80-e810-11e8-9ed0-583b64d80dd1.png">

After:
<img width="1008" alt="screenshot 2018-11-14 at 13 14 58" src="https://user-images.githubusercontent.com/44162302/48485227-37515d00-e810-11e8-81d7-cd3eaedd56dc.png">
