### PR TITLE
Adding support for gulp tasks with netlify

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -3,3 +3,4 @@ _site/
 .jekyll-metadata
 _pdf
 .DS_Store
+node_modules/

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -37,6 +37,7 @@ port: 4000
 exclude:
   - .idea/
   - .gitignore
+  - node_modules/
 
 feedback_subject_line: Fiori Fundamentals Documentation Feedback
 
@@ -113,7 +114,7 @@ defaults:
 sidebars:
 - left-navigation-sidebar
 
-exclude: [vendor]
+exclude: [vendor, node_modules]
 
 breadcrumbs:
   root:

--- a/docs/gulpfile.js
+++ b/docs/gulpfile.js
@@ -1,0 +1,22 @@
+const gulp = require('gulp');
+const sass = require('gulp-sass');
+const sourcemaps = require('gulp-sourcemaps');
+const rename = require("gulp-rename");
+
+const paths = {
+	src: './scss/**/*.scss',
+	dest: './css/'
+}
+
+const task = (cb) => {	
+    gulp.src(paths.src)
+	.pipe(sourcemaps.init())
+	.pipe(sass().on('error', sass.logError))
+	.pipe(rename("fui-site.css"))
+	.pipe(gulp.dest(paths.dest));
+	cb();
+
+}
+
+gulp.task('docs-site', task);
+module.exports = task;

--- a/docs/gulpfile.js
+++ b/docs/gulpfile.js
@@ -2,6 +2,7 @@ const gulp = require('gulp');
 const sass = require('gulp-sass');
 const sourcemaps = require('gulp-sourcemaps');
 const rename = require("gulp-rename");
+const path = require("path");
 
 const paths = {
 	src: './scss/**/*.scss',
@@ -11,7 +12,9 @@ const paths = {
 const task = (cb) => {	
     gulp.src(paths.src)
 	.pipe(sourcemaps.init())
-	.pipe(sass().on('error', sass.logError))
+	.pipe(sass({
+    includePaths: [ path.join(__dirname, '..')]
+  }).on('error', sass.logError))
 	.pipe(rename("fui-site.css"))
 	.pipe(gulp.dest(paths.dest));
 	cb();

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "fiori-fundamentals",
+  "description": "Fiori Fundamentals is a Design System and HTML/CSS Component Library used to build modern Product User Experiences with the SAP look and feel. Learn more about this project at - http://sap.github.io/fundamental/"
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,7 @@
 [build]
   base    = "docs/"
   publish = "docs/_site"
-  command = "bundle exec jekyll build"
+  command = "cp ../package.json . && npm i && gulp docs-site && ls css && bundle exec jekyll build"
 
 # Production context: All deploys to the main
 # repository branch will inherit these settings.


### PR DESCRIPTION
Closes sap/fundamental# https://github.com/SAP/fundamental/issues/946

Adds gulp tasks and node environment to Netlify build.  In order for the Netlify build to detect node, the base directory (docs) needs to have a package.json.  I've introduced a blank one to the docs directory, and install the correct root package.json at runtime. Similarly, the base directory needs a gulp file to run the associated gulp tasks.

The ideal scenario might be to look at hosting this (and the test site) with node rather than using Jekyll and remove this duplication.

#### Test

* Validate that the Netlify built site has the CSS applied.

#### Changelog

**New**

* Added gulp/NPM support into Netlify build

