### PR TITLE
Feature/880

### DIFF
--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -3,4 +3,5 @@
 @import "./mixins/forms";
 @import "./mixins/states";
 @import "./mixins/type";
+@import "./mixins/vars";
 @import "./mixins/breakpoints";

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -1,5 +1,6 @@
 //library namespace
 $fd-namespace: fd !default;
+$fd-support-css-var-fallback: true !default;
 
 //————————v FIORI FUNDAMENTALS FOUNDATION ————————v
 

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -1,6 +1,6 @@
 //library namespace
 $fd-namespace: fd !default;
-$fd-support-css-var-fallback: true !default;
+$fd-support-css-var-fallback: false !default;
 
 //————————v FIORI FUNDAMENTALS FOUNDATION ————————v
 

--- a/scss/components/button-group.scss
+++ b/scss/components/button-group.scss
@@ -21,7 +21,7 @@ $block-alt: #{$fd-namespace}-segmented-button;
       border-radius: 0;
     }
     &:not(:last-child) {
-      border-right: none;
+      border-right-width: 0;
     }
     &:first-child {
       border-top-right-radius: 0;
@@ -52,9 +52,8 @@ $block-alt: #{$fd-namespace}-segmented-button;
         border-bottom-left-radius: 0;
         border-top-right-radius: $fd-border-radius;
         border-bottom-right-radius: $fd-border-radius;
-        border-right: 1px var(--fd-button-border-color) solid;
+        border-right-width: 1px;
       }
-    } 
+    }
   }
 }
-

--- a/scss/components/button.scss
+++ b/scss/components/button.scss
@@ -9,13 +9,6 @@
 
 $block: #{$fd-namespace}-button;
 .#{$block} {
-
-  //SIZES — size: height "text size" "icon size"
-  $fd-button-sizes: (
-    "default": --fd-forms-height "0", //36px
-    "compact": --fd-forms-height-compact "0", //28px
-  ) !default;
-
   //spacing
   $fd-button-padding-x: fd-space("xs") !default;
   //anim
@@ -23,7 +16,6 @@ $block: #{$fd-namespace}-button;
 
   //BASE
   //set all reset and baseline block styles
-  $defaults: map-get($fd-button-sizes, "default");
   @at-root {
     .#{$block}, [class*="#{$block}--"] {
       $fd-button-color: fd-color("action", 1);
@@ -32,20 +24,17 @@ $block: #{$fd-namespace}-button;
       --fd-button-color: var(--fd-color-action-1);
       --fd-button-border-color: var(--fd-color-action-1);
       --fd-button-background-color: var(--fd-color-background-2);
-
       @include fd-button-reset;
       //set metrics
       @include fd-var-size("height", $fd-forms-height, --fd-forms-height);
       @include fd-var-size("max-height", $fd-forms-height, --fd-forms-height);
       @include fd-var-size("min-width", $fd-forms-height, --fd-forms-height);
-
       @include fd-type("0");
       @include fd-icon-size("m", "before");
       @include fd-icon-size("m", "after");
       line-height: 1;
       padding-left: $fd-button-padding-x;
       padding-right: $fd-button-padding-x;
-      min-width: var(nth($defaults, 1));
 
       //look
       border-style: solid;
@@ -62,6 +51,7 @@ $block: #{$fd-namespace}-button;
         margin-right: fd-space(2);
         vertical-align: text-bottom;
       }
+
       @at-root {
         [dir="rtl"] &,
         &[dir="rtl"] {
@@ -98,14 +88,20 @@ $block: #{$fd-namespace}-button;
       @include fd-hover {
           --fd-button-background-color: var(--fd-color-action-hover);
           --fd-button-color: var(--fd-color-action-2);
+          @include fd-var-color("color", fd-color("action",2));
+          @include fd-var-color("background-color", fd-color-state("hover","action"));
           @include fd-disabled {
             --fd-button-background-color: var(--fd-color-background-2);
             --fd-button-color: var(--fd-color-action-1);
+            @include fd-var-color("color", fd-color("action",1));
+            @include fd-var-color("background-color", fd-color("background",2));
           }
       }
       @include fd-selected {
-          --fd-button-background-color: var(--fd-color-action-selected);
-          --fd-button-color: var(--fd-color-action-2);
+        --fd-button-background-color: var(--fd-color-action-selected);
+        --fd-button-color: var(--fd-color-action-2);
+        @include fd-var-color("color", fd-color("action", 2));
+        @include fd-var-color("background-color", fd-color-state("selected","action"));
       }
       @include fd-disabled {
         opacity: 0.4;
@@ -135,6 +131,7 @@ $block: #{$fd-namespace}-button;
     }
   }
   //BUTTON emphasis variations
+  //.fd-button--emphasized
   &--emphasized {
     font-weight: fd-font-weight("bold");
     --fd-button-color: var(--fd-color-action-2);
@@ -150,6 +147,8 @@ $block: #{$fd-namespace}-button;
       @include fd-disabled {
         --fd-button-background-color: var(--fd-color-action-1);
         --fd-button-color: var(--fd-color-action-2);
+        @include fd-var-color("color", fd-color("action", 2));
+        @include fd-var-color("background-color", fd-color("action", 1));
       }
     }
     &.#{$block}--standard,
@@ -161,6 +160,7 @@ $block: #{$fd-namespace}-button;
       @include fd-hover {
         @include fd-disabled {
           --fd-button-color: var(--fd-color-action-2);
+          @include fd-var-color("color", fd-color("action", 2));
         }
       }
     }
@@ -172,6 +172,7 @@ $block: #{$fd-namespace}-button;
       @include fd-hover {
         @include fd-disabled {
           --fd-button-background-color: var(--fd-color-status-4);
+          @include fd-var-color("background-color", fd-color("status", 4));
         }
       }
     }
@@ -183,6 +184,7 @@ $block: #{$fd-namespace}-button;
       @include fd-hover {
         @include fd-disabled {
           --fd-button-background-color: var(--fd-color-status-3);
+          @include fd-var-color("background-color", fd-color("status", 3));
         }
       }
     }
@@ -194,6 +196,7 @@ $block: #{$fd-namespace}-button;
       @include fd-hover {
         @include fd-disabled {
           --fd-button-background-color: var(--fd-color-status-2);
+          @include fd-var-color("background-color", fd-color("status", 2));
         }
       }
     }
@@ -205,10 +208,12 @@ $block: #{$fd-namespace}-button;
       @include fd-hover {
         @include fd-disabled {
           --fd-button-background-color: var(--fd-color-status-1);
+          @include fd-var-color("background-color", fd-color("status", 1));
         }
       }
     }
   }
+  //.fd-button--light
   &--light {
     --fd-button-border-color: transparent;
     --fd-button-background-color: transparent;
@@ -217,14 +222,20 @@ $block: #{$fd-namespace}-button;
     @include fd-hover {
       --fd-button-background-color: var(--fd-color-neutral-1);
       --fd-button-color: var(--fd-color-action-1);
+      @include fd-var-color("color", fd-color("action", 1));
+      @include fd-var-color("background-color", fd-color("neutral", 1));
       @include fd-disabled {
         --fd-button-background-color: transparent;
         --fd-button-color: var(--fd-color-action-1);
+        @include fd-var-color("color", fd-color("action", 1));
+        @include fd-var-color("background-color", transparent);
       }
     }
     @include fd-selected {
       --fd-button-background-color: var(--fd-color-action-selected);
       --fd-button-color: var(--fd-color-action-2);
+      @include fd-var-color("color", fd-color("action", 2));
+      @include fd-var-color("background-color", fd-color-state("selected","action"));
     }
     &.#{$block}--standard,
     &.#{$block}--positive,
@@ -236,8 +247,10 @@ $block: #{$fd-namespace}-button;
       @include fd-var-color("background-color", transparent);
       @include fd-hover {
         --fd-button-background-color: var(--fd-color-neutral-1);
+        @include fd-var-color("background-color", fd-color("neutral", 1));
         @include fd-disabled {
           --fd-button-background-color: transparent;
+          @include fd-var-color("background-color", transparent);
         }
       }
     }
@@ -245,6 +258,7 @@ $block: #{$fd-namespace}-button;
       --fd-button-color: var(--fd-color-status-4);
       @include fd-hover {
         --fd-button-color: var(--fd-color-status-4);
+        @include fd-var-color("color", fd-color("status", 4));
         @include fd-disabled {
           --fd-button-color: var(--fd-color-status-4);
         }
@@ -252,12 +266,15 @@ $block: #{$fd-namespace}-button;
       @include fd-selected {
         --fd-button-background-color: var(--fd-color-status-4);
         --fd-button-color: var(--fd-color-action-2);
+        @include fd-var-color("color", fd-color("action", 2));
+        @include fd-var-color("background-color", fd-color("status", 4));
       }
     }
     &.#{$block}--negative {
       --fd-button-color: var(--fd-color-status-3);
       @include fd-hover {
         --fd-button-color: var(--fd-color-status-3);
+        @include fd-var-color("color", fd-color("status", 3));
         @include fd-disabled {
           --fd-button-color: var(--fd-color-status-3);
         }
@@ -265,12 +282,15 @@ $block: #{$fd-namespace}-button;
       @include fd-selected {
         --fd-button-background-color: var(--fd-color-status-3);
         --fd-button-color: var(--fd-color-action-2);
+        @include fd-var-color("color", fd-color("action", 2));
+        @include fd-var-color("background-color", fd-color("status", 3));
       }
     }
     &.#{$block}--positive {
       --fd-button-color: var(--fd-color-status-1);
       @include fd-hover {
         --fd-button-color: var(--fd-color-status-1);
+        @include fd-var-color("color", fd-color("status", 1));
         @include fd-disabled {
           --fd-button-color: var(--fd-color-status-1);
         }
@@ -278,12 +298,15 @@ $block: #{$fd-namespace}-button;
       @include fd-selected {
         --fd-button-background-color: var(--fd-color-status-1);
         --fd-button-color: var(--fd-color-action-2);
+        @include fd-var-color("color", fd-color("action", 2));
+        @include fd-var-color("background-color", fd-color("status", 1));
       }
     }
     &.#{$block}--medium {
       --fd-button-color: var(--fd-color-status-2);
       @include fd-hover {
         --fd-button-color: var(--fd-color-status-2);
+        @include fd-var-color("color", fd-color("status", 2));
         @include fd-disabled {
           --fd-button-color: var(--fd-color-status-2);
         }
@@ -291,6 +314,8 @@ $block: #{$fd-namespace}-button;
       @include fd-selected {
         --fd-button-background-color: var(--fd-color-status-2);
         --fd-button-color: var(--fd-color-action-2);
+        @include fd-var-color("color", fd-color("action", 2));
+        @include fd-var-color("background-color", fd-color("status", 2));
       }
     }
   }
@@ -313,16 +338,21 @@ $block: #{$fd-namespace}-button;
     --fd-button-border-color: var(--fd-color-status-4);
     @include fd-var-color("color", fd-color("status", 4));
     @include fd-var-color("border-color", fd-color("status", 4));
-
-    @include fd-focus(--fd-color-status-4);
+    @include fd-focus(--fd-color-status-4, fd-color("status", 4));
     @include fd-hover {
+      --fd-button-color: var(--fd-color-action-2);
       --fd-button-background-color: var(--fd-color-status-4);
+      @include fd-var-color("color", fd-color("action", 2));
+      @include fd-var-color("background-color", fd-color("status", 4));
       @include fd-disabled {
         --fd-button-color: var(--fd-color-status-4);
+        @include fd-var-color("color", fd-color("status",4));
       }
     }
     @include fd-selected {
       --fd-button-background-color: var(--fd-color-status-4);
+      @include fd-var-color("background-color", fd-color("status", 4));
+      @include fd-var-color("color", fd-color("action", 2));
     }
   }
   &--positive {
@@ -330,15 +360,18 @@ $block: #{$fd-namespace}-button;
     --fd-button-border-color: var(--fd-color-status-1);
     @include fd-var-color("color", fd-color("status", 1));
     @include fd-var-color("border-color", fd-color("status", 1));
-    @include fd-focus(--fd-color-status-1);
+    @include fd-focus(--fd-color-status-1, fd-color("status", 1));
     @include fd-hover {
       --fd-button-background-color: var(--fd-color-status-1);
+      @include fd-var-color("background-color", fd-color("status", 1));
       @include fd-disabled {
         --fd-button-color: var(--fd-color-status-1);
+        @include fd-var-color("color", fd-color("status",1));
       }
     }
     @include fd-selected {
       --fd-button-background-color: var(--fd-color-status-1);
+      @include fd-var-color("background-color", fd-color("status", 1));
     }
   }
   &--medium {
@@ -346,15 +379,18 @@ $block: #{$fd-namespace}-button;
     --fd-button-border-color: var(--fd-color-status-2);
     @include fd-var-color("color", fd-color("status", 2));
     @include fd-var-color("border-color", fd-color("status", 2));
-    @include fd-focus(--fd-color-status-2);
+    @include fd-focus(--fd-color-status-2, fd-color("status", 2));
     @include fd-hover {
       --fd-button-background-color: var(--fd-color-status-2);
+      @include fd-var-color("background-color", fd-color("status", 2));
       @include fd-disabled {
         --fd-button-color: var(--fd-color-status-2);
+        @include fd-var-color("color", fd-color("status",2));
       }
     }
     @include fd-selected {
       --fd-button-background-color: var(--fd-color-status-2);
+      @include fd-var-color("background-color", fd-color("status", 2));
     }
   }
   &--negative {
@@ -362,17 +398,22 @@ $block: #{$fd-namespace}-button;
     --fd-button-border-color: var(--fd-color-status-3);
     @include fd-var-color("color", fd-color("status", 3));
     @include fd-var-color("border-color", fd-color("status", 3));
-    @include fd-focus(--fd-color-status-3);
+    @include fd-focus(--fd-color-status-3, fd-color("status", 3));
     @include fd-hover {
       --fd-button-background-color: var(--fd-color-status-3);
+      @include fd-var-color("background-color", fd-color("status", 3));
       @include fd-disabled {
         --fd-button-color: var(--fd-color-status-3);
+        @include fd-var-color("color", fd-color("status",3));
       }
     }
     @include fd-selected {
         --fd-button-background-color: var(--fd-color-status-3);
+        @include fd-var-color("background-color", fd-color("status", 3));
     }
   }
+
+
   &--shellheader {
     --fd-button-color: var(--fd-color-shell-2);
     --fd-button-border-color: transparent;

--- a/scss/components/button.scss
+++ b/scss/components/button.scss
@@ -26,15 +26,20 @@ $block: #{$fd-namespace}-button;
   $defaults: map-get($fd-button-sizes, "default");
   @at-root {
     .#{$block}, [class*="#{$block}--"] {
+      $fd-button-color: fd-color("action", 1);
+      $fd-button-border-color: fd-color("action", 1);
+      $fd-button-background-color: fd-color("background", 2);
       --fd-button-color: var(--fd-color-action-1);
       --fd-button-border-color: var(--fd-color-action-1);
       --fd-button-background-color: var(--fd-color-background-2);
 
       @include fd-button-reset;
       //set metrics
-      height: var(nth($defaults, 1));
-      max-height: var(nth($defaults, 1));
-      @include fd-type(nth($defaults, 2));
+      @include fd-var-size("height", $fd-forms-height, --fd-forms-height);
+      @include fd-var-size("max-height", $fd-forms-height, --fd-forms-height);
+      @include fd-var-size("min-width", $fd-forms-height, --fd-forms-height);
+
+      @include fd-type("0");
       @include fd-icon-size("m", "before");
       @include fd-icon-size("m", "after");
       line-height: 1;
@@ -45,9 +50,9 @@ $block: #{$fd-namespace}-button;
       //look
       border-style: solid;
       border-width: 1px;
-      border-color: var(--fd-button-border-color);
-      background-color: var(--fd-button-background-color);
-      color: var(--fd-button-color);
+      @include fd-var-color("color", $fd-button-color, --fd-button-color);
+      @include fd-var-color("border-color", $fd-button-color, --fd-button-border-color);
+      @include fd-var-color("background-color", $fd-button-background-color, --fd-button-background-color);
 
       //animation
       transition: all $fd-button-transition-params;
@@ -106,21 +111,27 @@ $block: #{$fd-namespace}-button;
         opacity: 0.4;
         cursor: not-allowed;
       }
-
-
     }
   }
   //compact sizes (see `core/root` for css vars rules)
-  @each $key, $list in $fd-button-sizes {
-    @if $key != "default" {
-      &--#{$key} {
-        //set metrics
-        height: var(nth($list, 1));
-        max-height: var(nth($list, 1));
-        min-width: var(nth($list, 1));
-        @include fd-type(nth($list, 2));
-        line-height: 1;
+  &--compact {
+    //set metrics
+    @include fd-var-size("height", $fd-forms-height, --fd-forms-height-compact);
+    @include fd-var-size("max-height", $fd-forms-height, --fd-forms-height-compact);
+    @include fd-var-size("min-width", $fd-forms-height, --fd-forms-height-compact);
+    @at-root {
+      .fd-for-touch & {
+        @include fd-var-size("height", $fd-forms-height);
+        @include fd-var-size("min-width", $fd-forms-height);
       }
+      .fd-for-compact & {
+        @include fd-var-size("height", $fd-forms-height--compact);
+        @include fd-var-size("min-width", $fd-forms-height--compact);
+      }
+    }
+    @include fd-screen(m) {
+      @include fd-var-size("height", $fd-forms-height--compact);
+      @include fd-var-size("min-width", $fd-forms-height--compact, --fd-forms-height);
     }
   }
   //BUTTON emphasis variations
@@ -129,6 +140,10 @@ $block: #{$fd-namespace}-button;
     --fd-button-color: var(--fd-color-action-2);
     --fd-button-border-color: var(--fd-color-action-1);
     --fd-button-background-color: var(--fd-color-action-1);
+    @include fd-var-color("color", fd-color("action", 2));
+    @include fd-var-color("border-color", fd-color("action", 1));
+    @include fd-var-color("background-color", fd-color("action", 1));
+
     @include fd-hover {
       --fd-button-background-color: var(--fd-color-action-hover);
       --fd-button-color: var(--fd-color-action-2);
@@ -142,6 +157,7 @@ $block: #{$fd-namespace}-button;
     &.#{$block}--negative,
     &.#{$block}--medium {
       --fd-button-color: var(--fd-color-action-2);
+      @include fd-var-color("color", fd-color("action", 2));
       @include fd-hover {
         @include fd-disabled {
           --fd-button-color: var(--fd-color-action-2);
@@ -151,6 +167,8 @@ $block: #{$fd-namespace}-button;
     &.#{$block}--standard {
       --fd-button-border-color: var(--fd-color-status-4);
       --fd-button-background-color: var(--fd-color-status-4);
+      @include fd-var-color("border-color", fd-color("status", 4));
+      @include fd-var-color("background-color", fd-color("status", 4));
       @include fd-hover {
         @include fd-disabled {
           --fd-button-background-color: var(--fd-color-status-4);
@@ -160,6 +178,8 @@ $block: #{$fd-namespace}-button;
     &.#{$block}--negative {
       --fd-button-border-color: var(--fd-color-status-3);
       --fd-button-background-color: var(--fd-color-status-3);
+      @include fd-var-color("border-color", fd-color("status", 3));
+      @include fd-var-color("background-color", fd-color("status", 3));
       @include fd-hover {
         @include fd-disabled {
           --fd-button-background-color: var(--fd-color-status-3);
@@ -169,6 +189,8 @@ $block: #{$fd-namespace}-button;
     &.#{$block}--medium {
       --fd-button-border-color: var(--fd-color-status-2);
       --fd-button-background-color: var(--fd-color-status-2);
+      @include fd-var-color("border-color", fd-color("status", 2));
+      @include fd-var-color("background-color", fd-color("status", 2));
       @include fd-hover {
         @include fd-disabled {
           --fd-button-background-color: var(--fd-color-status-2);
@@ -178,6 +200,8 @@ $block: #{$fd-namespace}-button;
     &.#{$block}--positive {
       --fd-button-border-color: var(--fd-color-status-1);
       --fd-button-background-color: var(--fd-color-status-1);
+      @include fd-var-color("border-color", fd-color("status", 1));
+      @include fd-var-color("background-color", fd-color("status", 1));
       @include fd-hover {
         @include fd-disabled {
           --fd-button-background-color: var(--fd-color-status-1);
@@ -188,6 +212,8 @@ $block: #{$fd-namespace}-button;
   &--light {
     --fd-button-border-color: transparent;
     --fd-button-background-color: transparent;
+    @include fd-var-color("border-color", transparent);
+    @include fd-var-color("background-color", transparent);
     @include fd-hover {
       --fd-button-background-color: var(--fd-color-neutral-1);
       --fd-button-color: var(--fd-color-action-1);
@@ -206,6 +232,8 @@ $block: #{$fd-namespace}-button;
     &.#{$block}--medium {
       --fd-button-border-color: transparent;
       --fd-button-background-color: transparent;
+      @include fd-var-color("border-color", transparent);
+      @include fd-var-color("background-color", transparent);
       @include fd-hover {
         --fd-button-background-color: var(--fd-color-neutral-1);
         @include fd-disabled {
@@ -223,6 +251,7 @@ $block: #{$fd-namespace}-button;
       }
       @include fd-selected {
         --fd-button-background-color: var(--fd-color-status-4);
+        --fd-button-color: var(--fd-color-action-2);
       }
     }
     &.#{$block}--negative {
@@ -235,6 +264,7 @@ $block: #{$fd-namespace}-button;
       }
       @include fd-selected {
         --fd-button-background-color: var(--fd-color-status-3);
+        --fd-button-color: var(--fd-color-action-2);
       }
     }
     &.#{$block}--positive {
@@ -247,6 +277,7 @@ $block: #{$fd-namespace}-button;
       }
       @include fd-selected {
         --fd-button-background-color: var(--fd-color-status-1);
+        --fd-button-color: var(--fd-color-action-2);
       }
     }
     &.#{$block}--medium {
@@ -259,6 +290,7 @@ $block: #{$fd-namespace}-button;
       }
       @include fd-selected {
         --fd-button-background-color: var(--fd-color-status-2);
+        --fd-button-color: var(--fd-color-action-2);
       }
     }
   }
@@ -279,6 +311,9 @@ $block: #{$fd-namespace}-button;
   &--standard {
     --fd-button-color: var(--fd-color-status-4);
     --fd-button-border-color: var(--fd-color-status-4);
+    @include fd-var-color("color", fd-color("status", 4));
+    @include fd-var-color("border-color", fd-color("status", 4));
+
     @include fd-focus(--fd-color-status-4);
     @include fd-hover {
       --fd-button-background-color: var(--fd-color-status-4);
@@ -293,6 +328,8 @@ $block: #{$fd-namespace}-button;
   &--positive {
     --fd-button-color: var(--fd-color-status-1);
     --fd-button-border-color: var(--fd-color-status-1);
+    @include fd-var-color("color", fd-color("status", 1));
+    @include fd-var-color("border-color", fd-color("status", 1));
     @include fd-focus(--fd-color-status-1);
     @include fd-hover {
       --fd-button-background-color: var(--fd-color-status-1);
@@ -307,6 +344,8 @@ $block: #{$fd-namespace}-button;
   &--medium {
     --fd-button-color: var(--fd-color-status-2);
     --fd-button-border-color: var(--fd-color-status-2);
+    @include fd-var-color("color", fd-color("status", 2));
+    @include fd-var-color("border-color", fd-color("status", 2));
     @include fd-focus(--fd-color-status-2);
     @include fd-hover {
       --fd-button-background-color: var(--fd-color-status-2);
@@ -321,6 +360,8 @@ $block: #{$fd-namespace}-button;
   &--negative {
     --fd-button-color: var(--fd-color-status-3);
     --fd-button-border-color: var(--fd-color-status-3);
+    @include fd-var-color("color", fd-color("status", 3));
+    @include fd-var-color("border-color", fd-color("status", 3));
     @include fd-focus(--fd-color-status-3);
     @include fd-hover {
       --fd-button-background-color: var(--fd-color-status-3);

--- a/scss/core/elements.scss
+++ b/scss/core/elements.scss
@@ -81,15 +81,17 @@ a {
     display: inline-block;
     transition: all $fd-animation--speed ease-in;
     color: $fd-color--action;
-    &:focus{
-        outline: 1px dotted var(--fd-color-action-focus);
-    }
     @include fd-hover {
       color: fd-color-state("hover", "action");
     }
     @include fd-selected {
         color: fd-color-state("selected", "action");
         outline: none;
+    }
+    &:focus{
+      outline-style: dotted;
+      outline-width: 1px;
+      @include fd-var-color("outline-color", fd-color-state("hover","action"), --fd-color-action-focus)
     }
     @include fd-disabled {
         color: $fd-link-color--disabled;

--- a/scss/mixins/_mixins.scss
+++ b/scss/mixins/_mixins.scss
@@ -136,8 +136,8 @@
 }
 
 @mixin fd-rtl($class){
-  [dir=rtl],
-  .#{$class}[dir=rtl] {
+  [dir="rtl"],
+  .#{$class}[dir="rtl"] {
     @content;
   }
 }

--- a/scss/mixins/_states.scss
+++ b/scss/mixins/_states.scss
@@ -1,7 +1,11 @@
-@mixin fd-focus($shadow: --fd-color-action-focus) {
+@import "./../functions/color";
+@mixin fd-focus($shadow-var: --fd-color-action-focus, $shadow-value: fd-color-state("hover","action")) {
   &:focus,
   &.is-focus {
-    box-shadow: 0 0 0 1px var(#{$shadow});
+    @if $fd-support-css-var-fallback {
+      box-shadow: 0 0 0 1px $shadow-value;
+    }
+    box-shadow: 0 0 0 1px var(#{$shadow-var});
     @content;
   }
 }

--- a/scss/mixins/_vars.scss
+++ b/scss/mixins/_vars.scss
@@ -1,0 +1,20 @@
+@import "./../settings";
+@import "./../functions";
+@mixin fd-var-color($property, $value, $var:null) {
+  @if $fd-support-css-var-fallback {
+    #{$property}: #{$value};
+  } @else {
+    @if $var {
+      #{$property}: var(#{$var});
+    }
+  }
+}
+@mixin fd-var-size($property, $value, $var:null) {
+  @if $fd-support-css-var-fallback {
+    #{$property}: #{$value};
+  } @else {
+    @if $var {
+      #{$property}: var(#{$var});
+    }
+  }
+}

--- a/scss/mixins/_vars.scss
+++ b/scss/mixins/_vars.scss
@@ -3,18 +3,16 @@
 @mixin fd-var-color($property, $value, $var:null) {
   @if $fd-support-css-var-fallback {
     #{$property}: #{$value};
-  } @else {
-    @if $var {
-      #{$property}: var(#{$var});
-    }
+  }
+  @if $var {
+    #{$property}: var(#{$var});
   }
 }
 @mixin fd-var-size($property, $value, $var:null) {
   @if $fd-support-css-var-fallback {
     #{$property}: #{$value};
-  } @else {
-    @if $var {
-      #{$property}: var(#{$var});
-    }
+  }
+  @if $var {
+    #{$property}: var(#{$var});
   }
 }

--- a/test/templates/layout.njk
+++ b/test/templates/layout.njk
@@ -30,19 +30,26 @@
         textarea.test-textarea { font-family: monospace; height: 200px; width: 100%; padding: 10px; font-size: 0.9rem; border: solid 1px rgba(0,0,0,0.1); }
     </style>
 </head>
-<body>
+<body class="">
     <header style="border-bottom: solid 6px lightgray; padding-bottom: 10px; margin-bottom: 10px;">
         <form action="#" method="get">
 
         <fieldset style="font-family: monospace;font-size: 14px;">
-            <label class="test-label fd-has-float-right"><input type="checkbox"  value="" id="toggleBg"> Toggle BG</label>
-            <label class="test-label fd-has-float-right"><input type="checkbox"  value="" id="toggleDir"> Toggle RTL</label>
-            <label class="test-label"><input type="checkbox" name="lib" value="b3" {{'checked' if libs.b3 }}> bootstrap/3.3.7</label>
+            <label class="test-label"><input type="checkbox"  value="" id="toggleBg"> Toggle BG</label>
+            <span class="fd-has-float-right">
+            Contexts:
+
+            <label class="test-label"><input type="checkbox"  value="" id="toggleDir"> RTL</label>
+            <label class="test-label" title="Enables touch metrics"><input type="checkbox"  value="" id="toggleTouch"> Touch</label>
+            <label class="test-label" title="Forces compact metrics"><input  type="checkbox"  value="" id="toggleCompact"> Compact</label>
+
+          </span>
+            {# <label class="test-label"><input type="checkbox" name="lib" value="b3" {{'checked' if libs.b3 }}> bootstrap/3.3.7</label>
             <label class="test-label"><input type="checkbox" name="lib" value="b4" {{'checked' if libs.b4 }}> bootstrap/4.0.0-beta</label>
             <label class="test-label"><input type="checkbox" name="lib" value="md" {{'checked' if libs.md }}>
 angular_material/1.1.4</label>
             <label class="test-label"><input type="checkbox" name="lib" value="tn" {{'checked' if libs.tn }}> techne/1.5.7</label>
-            <button type="submit" class="fd-button--small">Submit</button>
+            <button type="submit" class="fd-button--small">Submit</button> #}
 
         </fieldset>
 
@@ -107,6 +114,39 @@ angular_material/1.1.4</label>
                   localStorage.setItem("toggleDirState", false);
                 }
             });
+
+            var toggleTouch = document.getElementById("toggleTouch"),
+                toggleTouchState = localStorage.getItem('toggleTouch');
+            if(toggleTouchState ==  "true") {
+                toggle.checked = true;
+                document.body.classList.add("fd-for-touch");
+            }
+            toggleTouch.addEventListener( 'change', function() {
+                if(this.checked) {
+                    document.body.classList.add("fd-for-touch");
+                    localStorage.setItem("toggleTouchState", true);
+                } else {
+                  document.body.classList.remove("fd-for-touch");
+                  localStorage.setItem("toggleTouchState", false);
+                }
+            });
+
+            var toggleCompact = document.getElementById("toggleCompact"),
+                toggleCompactState = localStorage.getItem('toggleCompact');
+            if(toggleCompactState ==  "true") {
+                toggle.checked = true;
+                document.body.classList.add("fd-for-compact");
+            }
+            toggleCompact.addEventListener( 'change', function() {
+                if(this.checked) {
+                    document.body.classList.add("fd-for-compact");
+                    localStorage.setItem("toggleCompactState", true);
+                } else {
+                  document.body.classList.remove("fd-for-compact");
+                  localStorage.setItem("toggleCompactState", false);
+                }
+            });
+
 
 
 


### PR DESCRIPTION
Closes sap/fundamental#880

Implements color fallbacks for SS variables esp. those used for buttons. A SCSS var is used to trigger the fallback support. 

> The default is **OFF** since a great deal more CSS is output when the fallback is used.
```
$fd-support-css-var-fallback: false !default;
```
The CSS has the hex value first and then the CSS var value which is ignored if the browser does not support CSS vars.

```
  color: #0a6ed1;
  color: var(--fd-button-color);
  border-color: #0a6ed1;
  border-color: var(--fd-button-border-color);
  background-color: white;
  background-color: var(--fd-button-background-color);
```
### Enabling the fallback is ideal for apps that must support IE 11. 
Teams should enable it in their own SASS pipeline.


#### Test

Enable the SASS flag `$fd-support-css-var-fallback: true` and test in IE 11 and a modern browser. Each should display the same.

* http://localhost:3030/button
* http://localhost:3030/button-group

#### Changelog

**New**

* A `fd-var-color($property, $value, $var:null)` mixin has been added. The property must be passed along with the hex value and optional CSS var.

```
@mixin fd-var-color($property, $value, $var:null) {}
```

To output both values ...

```
@include fd-var-color("color", $fd-button-color, --fd-button-color);
//outputs
color: #0a6ed1;
color: var(--fd-button-color);
```

To output only the hex value, leave off the var param. This will be used when the CSS var is reset.

```
.foo {
  --fd-color: red;
  @include fd-var-color("color", red, --fd-color);
  &--bar {
     --fd-color: yellow;
     @include fd-var-color("color", yellow);
  }
}
//outputs
.foo {
  --fd-color: red;
  color: red;
  color: var(--fd-color); }
  .foo--bar {
    --fd-color: yellow;
    color: yellow; }
```

In the above, however, the CSS var in the `.foo--bar` class will be overridden by the property. When the fallback flag is false the output makes more sense.

```
.foo {
  --fd-color: red;
  color: var(--fd-color); }
  .foo--bar {
    --fd-color: yellow; }
```

* A `fd-var-size($property, $value, $var:null)` mixin has been added. This works exactly as above except should be used for metrics.





**Changed**

* The `fd-focus` mixin was modified to accept a value and a CSS var.

**Removed**

* N/A
