### PR TITLE
#1006 adds a spec object page

### DIFF
--- a/scss/components/form.scss
+++ b/scss/components/form.scss
@@ -20,7 +20,7 @@ $block: #{$fd-namespace}-form;
     $fd-form-message-font-size: -1 !default;
     $fd-form-message-color: fd-color(text, 2) !default;
     $fd-form-item-gutter: var(--fd-width-gutter) !default;
-    $fd-form-item-margin-bottom: fd-space(5) !default;
+    $fd-form-item-margin-bottom: fd-space("small") !default;
     $fd-form-item-focus-gutter: fd-space(1) !default;
 
     @include fd-reset;
@@ -34,6 +34,9 @@ $block: #{$fd-namespace}-form;
     }
     &__set {
         margin-bottom: $fd-form-item-margin-bottom;
+        &:last-child {
+          margin-bottom: 0
+        }
         .#{$block}__item {
             &--inline {
                 @include fd-screen(s) {
@@ -107,7 +110,7 @@ $block: #{$fd-namespace}-form;
         min-width: $fd-forms-height--input-check;
     }
     &__legend {
-        margin-bottom: fd-space(5);
+        margin-bottom: fd-space("tiny");
     }
     &__help {
         float: right;

--- a/scss/components/popover.scss
+++ b/scss/components/popover.scss
@@ -98,6 +98,7 @@ $block: #{$fd-namespace}-popover;
 
       &[aria-hidden="true"],
       &.is-hidden {
+          z-index: 1;
           opacity: 0;
           visibility: hidden;
           transform: translateY($fd-popover-transition-distance);

--- a/scss/components/tag.scss
+++ b/scss/components/tag.scss
@@ -37,7 +37,7 @@ $block: #{$fd-namespace}-tag;
     @include action-cursor;
 
     @include fd-icon("sys-cancel","s","after") {
-      color: fd-color("action",1);
+      color: inherit;
       margin-left: fd-space(base);
       vertical-align: bottom;
       line-height: fd-space(6);

--- a/scss/layout/col.scss
+++ b/scss/layout/col.scss
@@ -7,7 +7,6 @@
 */
 $block: #{$fd-namespace}-col;
 .#{$block} {
-  flex: 1;
   @include fd-screen(m) {
     @for $i from 1 through 12 {
       &--#{$i} {
@@ -22,6 +21,7 @@ $block: #{$fd-namespace}-col;
   }
   @at-root {
     [class^="#{$block}"] {
+      flex: 1;
       margin-bottom: $fd-margin-bottom;
       &:last-child {
         margin-bottom: 0;

--- a/scss/layout/page.scss
+++ b/scss/layout/page.scss
@@ -12,8 +12,7 @@ $block: #{$fd-namespace}-page;
   $fd-page-header-height: auto !default;
   $fd-page-header-border-color: fd-color("neutral", 3) !default;
   $fd-page-header-border-width: 0 !default;
-  $fd-page-header-background-color: fd-color("background", 2) !default;
-  $fd-page-intro-padding: fd-space(4) !default;
+  $fd-page-header-background-color: transparent !default;
 
   display: flex;
   flex-direction: column;

--- a/scss/layout/page.scss
+++ b/scss/layout/page.scss
@@ -12,7 +12,7 @@ $block: #{$fd-namespace}-page;
   $fd-page-header-height: auto !default;
   $fd-page-header-border-color: fd-color("neutral", 3) !default;
   $fd-page-header-border-width: 0 !default;
-  $fd-page-intro-background-color: fd-color("background", 2) !default;
+  $fd-page-header-background-color: fd-color("background", 2) !default;
   $fd-page-intro-padding: fd-space(4) !default;
 
   display: flex;
@@ -24,7 +24,7 @@ $block: #{$fd-namespace}-page;
     border-style: solid;
     border-width: $fd-page-header-border-width;
     border-color: $fd-page-header-border-color;
-    background-color: $fd-page-background-color;
+    background-color: $fd-page-header-background-color;
     min-height: $fd-page-header-height;
     padding: $fd-page-header-padding-y $fd-page-header-padding-x;
     padding: $fd-page-header-padding-y var(--fd-page-header-padding-x);

--- a/test/templates/pages/floorplans/object.njk
+++ b/test/templates/pages/floorplans/object.njk
@@ -18,6 +18,7 @@
 {% set page_intro = "Part Number NGX-FOO-1973" %}
 {% set is_landing_page = false %}
 {% set is_editable_page = true %}
+{% set is_object_page = true %}
 {% set show_toolbar = false %}
 {% set hide_app_sidebar = true %}
 

--- a/test/templates/pages/floorplans/object.njk
+++ b/test/templates/pages/floorplans/object.njk
@@ -158,7 +158,7 @@
     {% call form_set(properties={
             legend: "Label"
         }) %}
-{{ form_item("toggle", { label: "Off" }) }}
+{{ form_item("toggle", { label: "Inventory type" }) }}
     {% endcall %}
     {%- endcall %}
   {%- endcall %}
@@ -175,7 +175,7 @@
       {% call form_set(properties={
               legend: "Label"
           }) %}
-  {{ form_item("toggle", { label: "On" },state={ checked: true }) }}
+  {{ form_item("toggle", { label: "Inventory type" },state={ checked: true }) }}
       {% endcall %}
     {%- endcall %}
   {%- endcall %}

--- a/test/templates/pages/layouts/page.njk
+++ b/test/templates/pages/layouts/page.njk
@@ -20,7 +20,7 @@
     <article class="fd-page">
 
         {% if hide_page_header !== true %}
-            <header class="fd-page__header">
+            <header class="fd-page__header{{ ' fd-has-background-color-background-2' if is_details_page }}">
                 {% block page_header -%}
                 {%- endblock %}
             </header>

--- a/test/templates/pages/layouts/page.njk
+++ b/test/templates/pages/layouts/page.njk
@@ -20,7 +20,7 @@
     <article class="fd-page">
 
         {% if hide_page_header !== true %}
-            <header class="fd-page__header{{ ' fd-has-background-color-background-2' if is_details_page }}">
+            <header class="fd-page__header{{ ' fd-has-background-color-background-2' if is_object_page }}">
                 {% block page_header -%}
                 {%- endblock %}
             </header>


### PR DESCRIPTION
Closes sap/fundamental#1006

This adds a spec floorplan page for testing purposes.

#### Test

* localhost:3030/pages/floorplans/object

#### Changelog

**New**

* Test Object page

**Changed**

* Several small spacing updates were made to comply with Fiori 3.0 specs
* Adds `is_object_page` template var which enables a white background behind the `page__header` container

**Removed**

* N/A