### PR TITLE
Feature/1011 modules

### DIFF
--- a/test/app.js
+++ b/test/app.js
@@ -6,6 +6,7 @@ const router = express.Router();
 const sass = require('node-sass');
 
 const TEMPLATE_DIRECTORY = path.join(__dirname, 'templates');
+const MODULES_DIRECTORY = path.join(__dirname, 'modules');
 const PUBLIC_DIRECTORY = path.join(__dirname, 'public');
 const SASS_DIRECTORY = path.join(__dirname, '..', 'scss');
 
@@ -16,7 +17,7 @@ const config = {
     id: "fundamentals"
 }
 // looks for html in templates folder, static resources in public
-const env = nunjucks.configure([TEMPLATE_DIRECTORY,PUBLIC_DIRECTORY], {
+var env = nunjucks.configure([TEMPLATE_DIRECTORY,PUBLIC_DIRECTORY,MODULES_DIRECTORY], {
     autoescape: false,
     cache: false,
     express: app,
@@ -130,6 +131,14 @@ env.addFilter('filter_array', (array={}, key="", value="") => {
    return result;
 });
 
+// merge_objs
+// returns obj
+// obj1 | merge_objs(obj2)
+env.addFilter('merge_objs', function(obj1={},obj2={}) {
+  var result = {...obj1, ...obj2 };
+  return result;
+});
+
 app.set('views', TEMPLATE_DIRECTORY);
 app.set('view engine', 'njk');
 
@@ -166,7 +175,8 @@ function getStarterData() {
         "breadcrumb": require(`./templates/breadcrumb/data.json`),
         "localization_editor": require(`./templates/localization-editor/data.json`),
         "image": require(`./templates/image/data.json`),
-        "product_switcher": require(`./templates/product-switcher/data.json`)
+        "product_switcher": require(`./templates/product-switcher/data.json`),
+        "test": require(`./data/test.json`)
     };
     return data;
 }

--- a/test/data/table.json
+++ b/test/data/table.json
@@ -1,0 +1,71 @@
+{
+  "id": "table",
+  "name": "Table",
+  "version": "1.0.0",
+  "properties": {
+  },
+  "modifiers": [
+  ],
+  "state": {
+  },
+  "aria": {
+  },
+  "elements": {
+    "headers": [
+      {
+        "properties": {
+          "id": "header-1",
+          "label": "Column Header"
+        },
+        "modifiers": [
+          "sorted"
+        ],
+        "state": {
+          "sorted": "asc"
+        },
+        "aria": {
+        }
+      },
+      {
+        "properties": {
+          "id": "header-2",
+          "label": "Column Header"
+        },
+        "modifiers": [
+          "sorted"
+        ],
+        "state": {
+          "sorted": "desc"
+        },
+        "aria": {
+        }
+      }
+    ],
+    "rows": [
+      ["Data 1.1", "Data 1.2", "Data 1.3", "Data 1.4", "Data 1.5"],
+      ["Data 2.1", "Data 2.2", "Data 2.3", "Data 2.4", "Data 2.5"]
+    ]
+
+
+
+  }
+
+}
+
+
+{
+    "label": "Test Header",
+    "sort": "asc"
+},
+{
+    "label": "Test Header",
+    "sort": "dsc"
+},
+{
+    "label": "Test Header",
+    "sort": ""
+},
+{
+    "label": "Test Header",
+    "sort": ""
+}

--- a/test/data/test.json
+++ b/test/data/test.json
@@ -1,0 +1,72 @@
+{
+  "donuts": [
+  	{
+  		"id": "0001",
+  		"type": "donut",
+  		"name": "Cake",
+  		"ppu": 0.55,
+  		"batters":
+  			{
+  				"batter":
+  					[
+  						{ "id": "1001", "type": "Regular" },
+  						{ "id": "1002", "type": "Chocolate" },
+  						{ "id": "1003", "type": "Blueberry" },
+  						{ "id": "1004", "type": "Devil's Food" }
+  					]
+  			},
+  		"topping":
+  			[
+  				{ "id": "5001", "type": "None" },
+  				{ "id": "5002", "type": "Glazed" },
+  				{ "id": "5005", "type": "Sugar" },
+  				{ "id": "5007", "type": "Powdered Sugar" },
+  				{ "id": "5006", "type": "Chocolate with Sprinkles" },
+  				{ "id": "5003", "type": "Chocolate" },
+  				{ "id": "5004", "type": "Maple" }
+  			]
+  	},
+  	{
+  		"id": "0002",
+  		"type": "donut",
+  		"name": "Raised",
+  		"ppu": 0.55,
+  		"batters":
+  			{
+  				"batter":
+  					[
+  						{ "id": "1001", "type": "Regular" }
+  					]
+  			},
+  		"topping":
+  			[
+  				{ "id": "5001", "type": "None" },
+  				{ "id": "5002", "type": "Glazed" },
+  				{ "id": "5005", "type": "Sugar" },
+  				{ "id": "5003", "type": "Chocolate" },
+  				{ "id": "5004", "type": "Maple" }
+  			]
+  	},
+  	{
+  		"id": "0003",
+  		"type": "donut",
+  		"name": "Old Fashioned",
+  		"ppu": 0.55,
+  		"batters":
+  			{
+  				"batter":
+  					[
+  						{ "id": "1001", "type": "Regular" },
+  						{ "id": "1002", "type": "Chocolate" }
+  					]
+  			},
+  		"topping":
+  			[
+  				{ "id": "5001", "type": "None" },
+  				{ "id": "5002", "type": "Glazed" },
+  				{ "id": "5003", "type": "Chocolate" },
+  				{ "id": "5004", "type": "Maple" }
+  			]
+  	}
+  ]
+}

--- a/test/modules/README.md
+++ b/test/modules/README.md
@@ -1,0 +1,3 @@
+## `modules`
+
+This is currently a POC workspace to create better Nunjucks macros that will enable easier construction of pages.

--- a/test/modules/button-group.njk
+++ b/test/modules/button-group.njk
@@ -1,0 +1,28 @@
+{% from "./button.njk" import icon_button %}
+{% import "./utils.njk" as utils %}
+{% set defaults = {
+    properties: {
+      label: "Sort by",
+      items: [
+        icon_button(size="compact",label="Survey",icon="survey"),
+        icon_button(size="compact",label="Chart",icon="pie-chart",aria={ selected: true }),
+        icon_button(size="compact",label="Pool",icon="pool")
+      ]
+    }
+  }
+%}
+
+{% macro button_group(label="", classes="", default=false) -%}
+{%- if default %}
+{%- set label = defaults.properties.label %}
+{%- endif %}
+<div class="fd-button-group{{ classes | classes }}" role="group" aria-label="{{label}}">
+  {%- if default %}
+    {%- for item in defaults.properties.items %}
+      {{item }}
+    {%- endfor %}
+  {%- else  %}
+  {{- caller() | indent -}}
+  {%- endif %}
+</div>
+{%- endmacro %}

--- a/test/modules/button.njk
+++ b/test/modules/button.njk
@@ -1,0 +1,45 @@
+{% from "../templates/icon/component.njk" import icon %}
+{% set defaults = {
+    properties:{
+      label: "Button",
+      icon: "pool"
+    }
+  }
+%}
+{%- macro button(
+    label=defaults.properties.label,
+    icon="",
+    size="",
+    type="",
+    color="",
+    state={},
+    aria={},
+    classes=""
+  ) -%}
+<button class="fd-button{{ ' fd-button--'+size if size }}{{ ' fd-button--'+type if type }}{{ ' fd-button--'+color if color }}{{ ' sap-icon--'+icon if icon }}{{ state | state }}{{ classes | classes }}"{{ aria | aria }}>
+  {%- if label %}{{label}}{%- endif %}</button>
+{%- endmacro %}
+
+{# AN ICON ONLY BUTTON #}
+{%- macro icon_button(
+    label=defaults.properties.label,
+    icon=defaults.properties.icon,
+    size="",
+    type="",
+    color="",
+    state={},
+    aria={},
+    classes=""
+  ) -%}
+{%- set aria_obj = { label: label } | merge_objs(aria) %}
+{{ button(
+  label="",
+  icon=icon,
+  size=size,
+  type=type,
+  color=color,
+  state=state,
+  aria=aria_obj,
+  classes=classes
+) }}
+{%- endmacro %}

--- a/test/modules/table.njk
+++ b/test/modules/table.njk
@@ -1,0 +1,90 @@
+{% from "../templates/icon/component.njk" import icon %}
+{% set defaults = {
+    properties:{
+      label: "Button",
+      icon: "pool"
+    },
+    elements: {
+      headers: [
+        {
+          id: "id",
+          label: "ID"
+        },
+        {
+          id: "type",
+          label: "Type"
+        }
+      ],
+      rows: [
+        {
+          id: "ID",
+          type: "Type"
+        },
+        {
+          id: "ID",
+          type: "Type"
+        }
+      ]
+    }
+  }
+%}
+
+
+
+{% macro default_table(headers=defaults.elements.headers, rows=defaults.elements.rows, modifiers={}, state={}, aria={}, classes=[]) -%}
+{% call table(headers=headers, rows=rows) -%}
+{% endcall -%}
+{%- endmacro %}
+
+
+{% macro table(headers={}, rows={}, modifiers={}, state={}, aria={}, classes=[]) -%}
+<table class="fd-table">
+  {%- if headers %}
+    {% call table_header(headers=headers) -%}{% endcall -%}
+  {%- endif %}
+  {%- if rows %}
+    {% call table_rows(rows=rows) -%}{% endcall -%}
+  {%- endif %}
+  {{ caller() }}
+</table>
+{%- endmacro %}
+
+{% macro table_header(headers={}, modifiers={}, state={}, aria={},classes=[]) -%}
+<thead>
+  <tr>
+    {%- if headers %}
+      {% for header in headers %}
+        {% call table_cell(type="header") -%}
+          {{ header.label }}
+        {% endcall -%}
+      {% endfor %}
+    {%- endif %}
+  {{ caller() }}
+  </tr>
+</thead>
+{%- endmacro %}
+
+{% macro table_rows(rows={}, modifiers=[], state={}, aria={},classes=[]) -%}
+  {% for row in rows %}
+  <tr>
+    {% for key, value in row %}
+      {% call table_cell() -%}
+        {{ value }}
+      {% endcall -%}
+    {% endfor %}
+  </tr>
+  {% endfor %}
+{{ caller() }}
+{%- endmacro %}
+
+{% macro table_row(rows={}, modifiers=[], state={}, aria={},classes=[]) -%}
+<tr>
+{{ caller() }}
+</tr>
+{%- endmacro %}
+
+{% macro table_cell(type="",properties={}, modifiers={}, state={}, aria={},classes=[]) -%}
+<{{ 'th ' if type == "header" else 'td' }}>
+{{ caller() }}
+</{{ 'th ' if type == "header" else 'td' }}>
+{%- endmacro %}

--- a/test/modules/token.njk
+++ b/test/modules/token.njk
@@ -1,0 +1,10 @@
+{% import "./utils.njk" as utils %}
+{% set defaults = {
+    properties:{
+      label: "Label"
+    }
+  }
+%}
+{% macro token(label=defaults.properties.label, classes="") -%}
+<span class="fd-token{{ classes | classes }}" role="button">{{ label }}</span>
+{%- endmacro %}

--- a/test/modules/utils.njk
+++ b/test/modules/utils.njk
@@ -1,0 +1,9 @@
+{%- macro id(prefix="") -%}
+{%- set num -%}
+    {%- if prefix === "" -%}
+    {{ 3 | random_string }}
+    {%- endif -%}
+    {{ 3 | random_number }}
+{%- endset -%}
+{{ prefix }}{{ num | trim }}
+{%- endmacro -%}

--- a/test/templates/date-picker/component.njk
+++ b/test/templates/date-picker/component.njk
@@ -12,7 +12,14 @@ date_picker:
     aria={}
 -->
 
-{%- macro date_picker_control(properties={}, modifier={}, state={}, aria={ hidden: true },size="") -%}
+{%- macro date_picker_control(properties={}, modifier={}, state={}, aria={ hidden: true },size="",id="") -%}
+{%- set value = "" %}
+{%- set placeholder = "" %}
+{%- if properties.month %}
+  {%- set value = properties.year+"/"+properties.month+"/"+properties.today %}
+{%- else %}
+  {%- set placeholder = "Pick a Date" %}
+{%- endif %}
 {%- set btn = button(
   { label: '',
     icon: 'calendar'
@@ -21,7 +28,7 @@ date_picker:
     block: ['light']
   },
   aria={
-    controls: properties.id,
+    controls: id,
     expanded: false,
     haspopup: true
   },
@@ -38,7 +45,8 @@ date_picker:
     properties={
         input: {
             properties: {
-                placeholder: "Pick a date"
+              placeholder: placeholder,
+              value: value
             }
         },
         after: btn
@@ -51,7 +59,7 @@ date_picker:
 <div class="fd-date-picker">
     {{  popover(properties={
             id: _id,
-            control: date_picker_control(properties={id: _id},size=size),
+            control: date_picker_control(properties=properties,size=size,id=_id),
             body: calendar({
                 "month": properties.month,
                 "year": properties.year,

--- a/test/templates/pages/floorplans/details.njk
+++ b/test/templates/pages/floorplans/details.njk
@@ -1,0 +1,257 @@
+{% extends "./../layouts/shell.njk" %}
+{% import "./../../layout/component.njk" as layout %}
+{% import "./../../button/component.njk" as button %}
+{% from "./../../tabs/component.njk" import tabs %}
+{% from "./../../table/component.njk" import table %}
+{% from "./../../date-picker/component.njk" import date_picker %}
+{% from "./../../button-group/component.njk" import button_group %}
+{% from "./../../toggle/component.njk" import toggle %}
+
+{% from "./../../time-picker/component.njk" import time_picker %}
+{% from "./../../form/component.njk" import form_control, form_item, form_set %}
+{% import "../../forms.njk" as forms %}
+{% set shellbar_product = {
+  title: "Supplier Portal"
+} %}
+
+{% set page_title = "Digital Components Ltd" %}
+{% set page_intro = "Part Number NGX-FOO-1973" %}
+{% set is_landing_page = false %}
+{% set is_editable_page = true %}
+{% set show_toolbar = false %}
+{% set hide_app_sidebar = true %}
+
+{% set is_details_page = true %}
+{% block page_header %}
+{# PAGE_HEADER ---------------------- #}
+<div class="fd-has-background-color-background-2">
+{{ super() }}
+</div>
+
+{# do columns #}
+{%- call layout.container(modifier=["fluid","flex"],classes="has-align-items-flex-end") -%}
+  {%- call layout.col(2) %}
+    {% call form_set({ }) %}
+      {{ form_item("select", { label: "View by", value: "Week ", options: [{
+          properties: { label: "Week", value: "1" }
+      },{
+          properties: { label: "Month", value: "2" }
+      }] }, modifier={ item: "" }) }}
+      {% endcall %}
+  {% endcall %}
+  {%- call layout.col(2) %}
+    {% call form_set({ }) %}
+      {{ form_item("select", { label: "Inventory type", options: [{
+        properties: { label: "Choose" }
+    }] }, modifier={ item: "" }) }}
+    {% endcall %}
+  {% endcall %}
+  {%- call layout.col(2) %}
+    {% call form_set({ }) %}
+    {{ form_item("select", { label: "Extra data for chart", options: [{
+      properties: { label: "None" }
+  }] }, modifier={ item: "" }) }}
+    {% endcall %}
+  {% endcall %}
+  {%- call layout.col(6) %}
+    {% call form_set({ legend: "" }) %}
+    <p class="fd-has-text-align-right">
+      <span class="fd-has-margin-right-small">
+        <span class="fd-has-color-text-3">
+          Starting from:
+        </span>
+        July 3, 2019
+      </span>
+      {{-  button(
+        { icon: 'slim-arrow-left' },
+          modifier={ block: [""] },
+          aria={ label: 'Previous' })
+      }}
+      {{-  button(
+        { icon: 'slim-arrow-right' },
+          modifier={ block: [""] },
+          aria={ label: 'Next' })
+      }}
+    </p>
+    {% endcall %}
+  {% endcall %}
+{%- endcall %}
+{{  tabs(
+        properties={
+          items: [
+            {
+                label: "Projected Stock",
+                selected: true
+            },
+            {
+                label: "Supply and Demand"
+            }
+          ]
+        },
+        classes="has-bottom-border-none"
+    )
+}}
+
+
+{# ---------------------- PAGE_HEADER #}
+{% endblock %}
+{% block page_content %}
+{# PAGE_CONTENT ---------------------- #}
+
+  {# FORM SECTION ---------------------- #}
+  {%- call layout.section() -%}
+
+
+  {% call layout.panel() -%}
+      {% call layout.panel_header({ title: "Form" }) -%}
+      {%- endcall %}
+      {% call layout.panel_body() -%}
+
+
+  {%- call layout.container() -%}
+    {%- call layout.col(5) -%}
+      {% call form_set({ }) %}
+        {{ form_item("text", { label: "ID" }) }}
+      {%- endcall %}
+    {%- endcall %}
+    {%- call layout.col(5) -%}
+      {% call form_set({ }) %}
+        {{ form_item("text", { label: "Store name" }) }}
+      {%- endcall %}
+    {%- endcall %}
+    {%- call layout.col(2) -%}
+      {% call form_set(properties={
+              legend: "Activate"
+          }) %}
+          {{  time_picker()
+          }}
+      {%- endcall %}
+    {%- endcall %}
+
+  {%- endcall %}
+  {%- call layout.container() -%}
+    {%- call layout.col(5) -%}
+      {% call form_set({ }) %}
+        {{ form_item("select", { label: "Default language", options: [{
+      properties: { label: "English" }
+  }] }, modifier={ item: "" }) }}
+      {%- endcall %}
+    {%- endcall %}
+    {%- call layout.col(5) -%}
+      {% call form_set({ }) %}
+        {{ form_item("select", { label: "Default currency", options: [{
+        properties: { label: "US - Dollar" }
+    }] }, modifier={ item: "" }) }}
+      {%- endcall %}
+    {%- endcall %}
+  {%- endcall %}
+  {%- call layout.container() -%}
+    {%- call layout.col(5) -%}
+    {% call form_set(properties={
+            legend: "Net"
+        }) %}
+    {{ form_item("radio", { label: "Yes", name: "foo" }, modifier={ item: "inline" }) }}
+    {{ form_item("radio", { label: "No", name: "foo" }, modifier={ item: "inline" }, state={ checked: true}) }}
+    {% endcall %}
+    {%- endcall %}
+    {%- call layout.col(5) -%}
+    {% call form_set(properties={
+            legend: "Label"
+        }) %}
+{{ form_item("toggle", { label: "Inventory type" }) }}
+    {% endcall %}
+    {%- endcall %}
+  {%- endcall %}
+  {%- call layout.container() -%}
+    {%- call layout.col(5) -%}
+    {% call form_set(properties={
+            legend: "Net"
+        }) %}
+    {{ form_item("radio", { label: "Yes", name: "bar" }, modifier={ item: "inline" }, state={ checked: true}) }}
+    {{ form_item("radio", { label: "No", name: "bar" }, modifier={ item: "inline" }) }}
+    {% endcall %}
+    {%- endcall %}
+    {%- call layout.col(5) -%}
+      {% call form_set(properties={
+              legend: "Label"
+          }) %}
+  {{ form_item("toggle", { label: "Inventory type" },state={ checked: true }) }}
+      {% endcall %}
+    {%- endcall %}
+  {%- endcall %}
+
+      {%- endcall %}
+    {%- endcall %}
+  {%- endcall %}
+  {# ---------------------- FORM SECTION #}
+
+
+
+
+
+  {# TABLE SECTION ---------------------- #}
+  {%- call layout.section() -%}
+  {%- set btnedit %}
+  {{button({ icon: "edit" },size="compact",modifier={block: ["light"]},aria={ label: "Edit" })}}
+  {%- endset %}
+  {%- set btndelete %}
+  {{button({ icon: "delete" },size="compact",modifier={block: ["light","negative"]},aria={ label: "Edit" })}}
+  {%- endset %}
+
+  {% set headers = [ {
+    label: '<input type="checkbox">'
+  },
+          { label: "Name" },
+          { label: "Version" },
+          { label: "TA Type" },
+          { label: "Description" },
+          { label: "Region" },
+          { label: "Status" },
+          { label: "Last Update" },
+          { label: "" }
+      ] %}
+  {% set picker = date_picker(properties={
+            month: 08,
+            year: 2018,
+            today: 21,
+            dates: {
+              daysOffset: 3,
+              block: [25,29],
+              selected: 15,
+              disablePast: true
+            }
+        },size="compact")
+  %}
+  {% set checkbox_row = ['<input type="checkbox">', '<strong>Name of Technical Asset</strong>', '1.3', 'API Packages', 'Lorem ipsum dolor sit amet', 'US Midwest/Chicago', '<span class="fd-has-color-status-1">Deployed</span>', '2018/03/21', [btnedit,btndelete].join('') ] %}
+  {% set checkbox_row_selected = ['<input type="checkbox" checked>', '<strong>Name of Technical Asset</strong>', '1.3', 'API Packages', 'Lorem ipsum dolor sit amet', 'US Midwest/Chicago', '<span class="fd-has-color-status-3">Failed</span>', picker, btndelete] %}
+  {% call layout.panel() -%}
+      {% call layout.panel_header({ title: "Technical Assets (12)" }) -%}
+          {% call layout.panel_actions() -%}
+            {% call button_group() -%}
+              {{button({ icon: "table-chart" },size="compact",modifier={block: []},aria={ label: "Table Chart" })}}
+              {{button({ icon: "bar-chart" },size="compact",modifier={block: []},aria={ label: "Bar Chart", "pressed": true })}}
+            {%- endcall %}
+            <span class="fd-has-margin-left-tiny">
+              {{button({ icon: "sort" },size="compact",modifier={block: ["light"]},aria={ label: "Sort"})}}
+              {{button({ icon: "group-2" },size="compact",modifier={block: ["light"]},aria={ label: "Group"})}}
+              {{button({ icon: "action-settings" },size="compact",modifier={block: ["light"]},aria={label: "Settings" })}}
+            </span>
+          {%- endcall %}
+      {%- endcall %}
+      {% call layout.panel_body(modifier=["bleed"]) -%}
+      {{  table({
+              headers: headers,
+              rows: [checkbox_row, checkbox_row, checkbox_row, checkbox_row_selected, checkbox_row, checkbox_row, checkbox_row, checkbox_row, checkbox_row, checkbox_row, checkbox_row, checkbox_row],
+              selectedRow: 4
+          },
+          classes="has-last-child-text-align-right")
+      }}
+      {%- endcall %}
+    {%- endcall %}
+  {%- endcall %}
+  {# ---------------------- TABLE SECTION #}
+
+
+
+{# ---------------------- PAGE_CONTENT #}
+{% endblock %}

--- a/test/templates/pages/floorplans/test.njk
+++ b/test/templates/pages/floorplans/test.njk
@@ -32,8 +32,8 @@
       {% call layout.panel_header({ title: "Technical Assets (12)" }) -%}
           {% call layout.panel_actions() -%}
 
-          {{ button(default=true) }}
-          {{ icon_button(default=true) }}
+          {{ button() }}
+          {{ icon_button() }}
        <br>
 
 {{ button_group(default=true) }}

--- a/test/templates/pages/floorplans/test.njk
+++ b/test/templates/pages/floorplans/test.njk
@@ -1,0 +1,213 @@
+{% extends "./../layouts/module.njk" %}
+{% import "./../../layout/component.njk" as layout %}
+{% from "./../../table/component.njk" import table %}
+
+{% from "./../../form/component.njk" import form_control, form_item, form_set %}
+{% import "../../forms.njk" as forms %}
+
+{% from "./../../../modules/table.njk" import default_table, table, table_row, table_header, table_cell %}
+{% from "./../../../modules/button-group.njk" import button_group %}
+{% from "./../../../modules/button.njk" import icon_button, button %}
+
+{% set shellbar_product = {
+  title: "Supplier Portal"
+} %}
+
+{% set page_title = "Digital Components Ltd" %}
+{% set page_intro = "Part Number NGX-FOO-1973" %}
+{% set is_landing_page = false %}
+{% set is_editable_page = true %}
+{% set show_toolbar = false %}
+{% set hide_page_header = true %}
+{% set hide_app_sidebar = true %}
+
+{% block page_content %}
+{# PAGE_CONTENT ---------------------- #}
+
+
+
+  {# TABLE SECTION ---------------------- #}
+  {%- call layout.section() -%}
+  {% call layout.panel() -%}
+      {% call layout.panel_header({ title: "Technical Assets (12)" }) -%}
+          {% call layout.panel_actions() -%}
+
+          {{ button(default=true) }}
+          {{ icon_button(default=true) }}
+       <br>
+
+{{ button_group(default=true) }}
+
+{% call button_group() -%}
+  {{ icon_button(size="compact",label="Survey",icon="survey") }}
+  {{ icon_button(size="compact",label="Chart",icon="pie-chart",aria={ selected: true }) }}
+{%- endcall %}
+
+
+
+
+
+          {%- endcall %}
+      {%- endcall %}
+      {% call layout.panel_body(modifier=["bleed"]) -%}
+
+{# VARS #}
+
+
+
+
+<h1>DEAFULT</h1>
+{% call default_table() -%}
+{% endcall -%}
+
+
+
+
+{% set headers = [
+  {
+
+      id: "header-1",
+      label: "Custom Header"
+
+  },
+  {
+
+      id: "header-1",
+      label: "Custom Header"
+
+  }
+] %}
+{% set rows = [
+    {
+      id: "Foo",
+      type: "Bar"
+    },
+    {
+      id: "Baz",
+      type: "Boo"
+    }
+  ]
+  %}
+<h1>TABLE</h1>
+{% call table(headers=headers, rows=rows) -%}
+
+{% endcall -%}
+
+
+<h1>DONUTS</h1>
+
+
+{% set donuts = data.test.donuts %}
+
+{% call table() -%}
+    {% call table_header() -%}
+        {% for header in ["ID", "Type", "Name", "PPU", "Batters", "Toppings"] %}
+          {% call table_cell() -%}
+       {{header}}
+          {% endcall -%}
+        {% endfor %}
+
+    {% endcall -%}
+      {% for donut in donuts %}
+        {% call table_row() -%}
+
+        {% for key, value in donut %}
+          {% call table_cell() -%}
+            {{ value |dump }}
+          {% endcall -%}
+        {% endfor %}
+
+        {% endcall -%}
+      {% endfor %}
+    {% endcall -%}
+
+
+      <pre>
+      {{ donuts | dump(2) }}
+      </pre>
+
+
+      {%- endcall %}
+    {%- endcall %}
+  {%- endcall %}
+  {# ---------------------- TABLE SECTION #}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  {# FORM SECTION ---------------------- #}
+  {%- call layout.section() -%}
+
+
+  {% call layout.panel() -%}
+      {% call layout.panel_header({ title: "Form" }) -%}
+      {%- endcall %}
+      {% call layout.panel_body() -%}
+
+
+  {%- call layout.container() -%}
+    {%- call layout.col(5) -%}
+
+    {%- endcall %}
+    {%- call layout.col(5) -%}
+
+    {%- endcall %}
+    {%- call layout.col(2) -%}
+
+    {%- endcall %}
+
+  {%- endcall %}
+  {%- call layout.container() -%}
+    {%- call layout.col(5) -%}
+
+    {%- endcall %}
+    {%- call layout.col(5) -%}
+
+    {%- endcall %}
+  {%- endcall %}
+  {%- call layout.container() -%}
+    {%- call layout.col(5) -%}
+
+    {%- endcall %}
+    {%- call layout.col(5) -%}
+
+    {%- endcall %}
+  {%- endcall %}
+  {%- call layout.container() -%}
+    {%- call layout.col(5) -%}
+
+    {%- endcall %}
+    {%- call layout.col(5) -%}
+
+
+    {%- endcall %}
+  {%- endcall %}
+
+      {%- endcall %}
+    {%- endcall %}
+  {%- endcall %}
+  {# ---------------------- FORM SECTION #}
+
+
+
+
+
+
+
+
+{# ---------------------- PAGE_CONTENT #}
+{% endblock %}

--- a/test/templates/pages/layouts/module.njk
+++ b/test/templates/pages/layouts/module.njk
@@ -1,6 +1,6 @@
-{% extends "./ui.njk" %}
+{% extends "./master.njk" %}
 {% from "../../action-bar/component.njk" import action_bar %}
-{% from "../../button/component.njk" import button %}
+{% from "../../button/component.njk" import button as btn %}
 
 {# ui-level vars #}
 {%- set hide_ui_header = true %}
@@ -31,15 +31,15 @@
         {% set actions_props = {
             properties: {
                 items: [
-button({ label: 'Add New Item', icon: 'add' })
+btn({ label: 'Add New Item', icon: 'add' })
                  ]
             }
         } %}
         {%- endif %}
             {%- if is_editable_page %}
-            {%- set actionbtn = button({ label: 'Cancel', icon: 'close' },modifier={ block: ['text','action-bar'] })
+            {%- set actionbtn = btn({ label: 'Cancel', icon: 'close' },modifier={ block: ['text','action-bar'] })
             %}
-            {%- set primarybtn = button({ label: 'Save', icon: 'checked' },modifier={ block: ['action-bar'] })
+            {%- set primarybtn = btn({ label: 'Save', icon: 'checked' },modifier={ block: ['action-bar'] })
             %}
             {% set actions_props = {
                 properties: {

--- a/test/templates/table/component.njk
+++ b/test/templates/table/component.njk
@@ -35,7 +35,7 @@ table:
 {%- endmacro %}
 
 
-{% macro table(properties={}, modifier={}, state={}, aria={}) -%}
+{% macro table(properties={}, modifier={}, state={}, aria={}, classes=[]) -%}
 {%- if properties.fixed_col_table %}
 <div class="fd-table--fixed-wrapper">
 <div class="fd-table--fixed">


### PR DESCRIPTION
Closes sap/fundamental#1011

This implements a POC area of the test framework to build out improved, consistent Nunjucks templates.

The goal is two fold ...
1. Set defaults for the modules so we can quickly composite UIs without having to pass specific data objects to output a simple component.
2. Update the macros to accept properties as params instead of inside an object.

For example, compare the following ...
```
{{ button(label="Survey", size="compact", icon="survey") }}
vs.
{{ button(properties={ label:"Survey", icon:"survey" }, modifier={ block: ["compact"]}) }}
```

#### Test

* http://localhost:3030/pages/floorplans/test

#### Changelog

**New**

* `modules` directory added to hold new macros
* `data` directory added to hold assorted data objects useful for testing

**Changed**

* No existing functionality is affected

**Removed**

* N/A