### PR TITLE
#1032 adds fallback options for size CSS vars

### DIFF
--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -222,8 +222,9 @@ $fd-shell-header-height: 48px !default;
 $fd-shell-header-background-color: map-get($fd-colors-shell, 1) !default;
 $fd-padding--ui: $fd-spacing--base * 8 !default;
 
+//layout
 $fd-max-width--ui: 1290px !default;
-
+$fd-width--gutter: map-get($fd-spacing, s); //desktop default
 
 // menus and lists and navs
 $fd-menu-border-color: red !default;
@@ -244,7 +245,7 @@ $fd-menu-transition-params: $fd-animation--speed ease-in !default;
 // Form Configuration
 $fd-forms-height: $fd-spacing--base * 9 !default; //36px
 $fd-forms-height--compact: $fd-spacing--base * 7 !default; //28px
-$fd-forms-height--input-text: $fd-forms-height !default;
+$fd-forms-height--input-text: $fd-forms-height !default; //deprecate
 $fd-forms-height--input-check: $fd-spacing--base * 4 !default;
 $fd-forms-padding: $fd-spacing--base * 3 !default;
 

--- a/scss/components/input-group.scss
+++ b/scss/components/input-group.scss
@@ -24,7 +24,7 @@ $block: #{$fd-namespace}-input-group;
     }
 
     @include fd-rtl {
-        > * { 
+        > * {
             & input:read-only {
               border-right: none;
             }
@@ -44,7 +44,7 @@ $block: #{$fd-namespace}-input-group;
                   border-top-right-radius: $fd-border-radius;
                   border-bottom-right-radius: $fd-border-radius;
                   border-right: 1px $fd-forms-border-color solid;
-                }            
+                }
         }
     }
 
@@ -104,7 +104,7 @@ $block: #{$fd-namespace}-input-group;
         display: flex;
         flex-direction: column;
         border-radius: $fd-border-radius;
-        height: var(--fd-forms-height);
+        @include fd-var-size("height", $fd-forms-height, --fd-forms-height);
         &--readonly{
             border: none;
             border-top-color: transparent;
@@ -116,7 +116,7 @@ $block: #{$fd-namespace}-input-group;
         }
         @at-root {
           .#{$block}--compact & {
-            height: var(--fd-forms-height-compact);
+          @include fd-var-size("height", $fd-forms-height--compact, --fd-forms-height-compact);
             .#{$block}__button {
                 &--step-up:before,
                 &--step-down:before {

--- a/scss/components/modal.scss
+++ b/scss/components/modal.scss
@@ -13,27 +13,35 @@
       .fd-modal__button-secondary
 */
 $block: #{$fd-namespace}-modal;
+.#{$block} {
   $fd-modal-width: 460px !default;
   //these are used only to roughly calculate body overflow on compact screens - this can be improved with a flex or grid solution
   $fd-modal-header-height: 60px !default;
   $fd-modal-footer-height: 68px !default;
 
   $fd-modal-border-color: fd-color("neutral", 2) !default;
-  $fd-modal-padding-x: var(--fd-width-gutter) !default;
+  $fd-modal-padding-x: $fd-width--gutter !default;
+  --fd-modal-padding-x: var(--fd-width-gutter);
   $fd-modal-padding-y: fd-space(4) !default;
   $fd-modal-inner-content-background: fd-color("background", 2) !default;
 
-.#{$block} {
   @include fd-reset;
   max-width: $fd-modal-width;
   &__content{
     border-radius: $fd-border-radius;
     background-color: $fd-modal-inner-content-background;
   }
+  &__header,
+  &__body,
+  &__footer {
+    @include fd-var-size("padding-left", $fd-modal-padding-x, --fd-modal-padding-x);
+    @include fd-var-size("padding-right", $fd-modal-padding-x, --fd-modal-padding-x);
+    padding-top: $fd-modal-padding-y;
+    padding-bottom: $fd-modal-padding-y;
+  }
   &__header {
     position: relative;
     border-bottom: 1px solid $fd-modal-border-color;
-    padding: $fd-modal-padding-y $fd-modal-padding-x;
   }
   &__title{
     @include fd-type("1");
@@ -50,7 +58,6 @@ $block: #{$fd-namespace}-modal;
     @include fd-focus;
   }
   &__body{
-    padding: $fd-modal-padding-y $fd-modal-padding-x;
     max-height: calc(100vh - #{$fd-modal-header-height} - #{$fd-modal-footer-height});
     overflow-y: auto;
 
@@ -59,7 +66,6 @@ $block: #{$fd-namespace}-modal;
     }
   }
   &__footer {
-    padding: $fd-modal-padding-y $fd-modal-padding-x;
     text-align: right;
     border-top: 1px solid $fd-modal-border-color;
   }

--- a/scss/components/product-menu.scss
+++ b/scss/components/product-menu.scss
@@ -13,7 +13,7 @@ $block: #{$fd-namespace}-product-menu;
     color: inherit;
     position: relative;
     @include fd-button-reset();
-    height: var(--fd-forms-height);
+    @include fd-var-size("height", $fd-forms-height, --fd-forms-height);
     position: relative;
     padding-right: 20px;
     padding-left: 0;

--- a/scss/components/table.scss
+++ b/scss/components/table.scss
@@ -13,8 +13,6 @@ $block: #{$fd-namespace}-table;
     $fd-table-border-color: fd-color("neutral", 2) !default;
     $fd-table-border-width: 1px !default;
     $fd-table-link-color: fd-color(action, 1) !default;
-    $fd-table-cell-spacing: var(--fd-width-gutter) !default;
-    $fd-table-cell-padding: fd-space("xs") !default;
     $fd-table-background-color: fd-color("background", 2);
 
     $fd-table-header-color: fd-color("text", 3) !default;
@@ -23,7 +21,9 @@ $block: #{$fd-namespace}-table;
     fd-color-state("hover") !default;
     $fd-table-row-background-color--selected: fd-color-state("selected") !default;
 
-    $fd-table-cell-spacing: var(--fd-width-gutter) !default;
+    $fd-table-cell-spacing: $fd-width--gutter !default;
+    --fd-table-cell-spacing: var(--fd-width-gutter);
+
     $fd-table-cell-padding: fd-space("s") !default;
     $fd-table-transition-params: $fd-animation--speed ease-in !default;
     $fd-table-sort-icon-size: fd-space(3);
@@ -54,8 +54,7 @@ $block: #{$fd-namespace}-table;
                 background-color: fd-color-state("selected-hover")
             }
         }
-        @include action-cursor;
-
+        cursor: pointer;
     }
 
     thead {
@@ -89,21 +88,21 @@ $block: #{$fd-namespace}-table;
     td,
     th {
         text-align: left;
-        padding: $fd-table-cell-padding calc(#{$fd-table-cell-spacing}/2);
-
+        --fd-table-cell-spacing: calc(var(--fd-width-gutter) / 2);
+        @include fd-var-size("padding-left", $fd-table-cell-spacing/2, --fd-table-cell-spacing);
+        @include fd-var-size("padding-right", $fd-table-cell-spacing/2, --fd-table-cell-spacing);
+        padding-top: $fd-table-cell-padding;
+        padding-bottom: $fd-table-cell-padding;
         &:first-child {
-            padding-left: $fd-table-cell-spacing;
+          @include fd-var-size("padding-left", $fd-width--gutter, --fd-width-gutter);
         }
-
         &:last-child {
-            padding-right: $fd-table-cell-spacing;
+          @include fd-var-size("padding-right", $fd-width--gutter, --fd-width-gutter);
         }
-
-        .fd-dropdown__menu{
+        .fd-dropdown__menu {
             min-width: auto;
             text-align: left;
         }
-
         > a {
             color: $fd-table-link-color;
             &:hover{
@@ -113,12 +112,10 @@ $block: #{$fd-namespace}-table;
     }
 
     &__sort-column {
-
         &:hover {
             background: $fd-table-sort-column-header-hover-color;
-            @include action-cursor;
+            cursor: pointer;
         }
-
         &::after {
             content: "";
             width: $fd-table-sort-icon-size;
@@ -149,8 +146,6 @@ $block: #{$fd-namespace}-table;
 
     &__context-menu-label {
         display: block;
-        padding: $fd-table-cell-padding calc(#{$fd-table-cell-spacing}/2);
-
         &::after {
             content: "";
             width: $fd-table-sort-icon-size;
@@ -163,11 +158,9 @@ $block: #{$fd-namespace}-table;
     }
 
     th.fd-table__context-menu {
-        padding: 0;
-
         &:hover {
             background: $fd-table-sort-column-header-hover-color;
-            @include action-cursor;
+            cursor: pointer;
         }
     }
 

--- a/scss/components/tree.scss
+++ b/scss/components/tree.scss
@@ -17,7 +17,8 @@ $block: #{$fd-namespace}-tree;
     $fd-tree-border-color: transparent !default;
     $fd-tree-border-width: 0 !default;
     $fd-tree-link-color: fd-color(action, 1) !default;
-    $fd-tree-cell-spacing: var(--fd-width-gutter) !default;
+    $fd-tree-cell-spacing: $fd-width--gutter !default;
+    --fd-tree-cell-spacing: var(--fd-width-gutter);
     $fd-tree-cell-padding: fd-space(3) !default;
 
     $fd-tree-header-background-color: fd-color("neutral", 2) !default;
@@ -64,7 +65,11 @@ $block: #{$fd-namespace}-tree;
         list-style: none;
     }
     &__row {
-        padding: 0 $fd-tree-cell-spacing;
+        @include fd-var-size("padding-left", $fd-tree-cell-spacing, --fd-tree-cell-spacing);
+        @include fd-var-size("padding-right", $fd-tree-cell-spacing, --fd-tree-cell-spacing);
+        padding-top: 0;
+        padding-bottom: 0;
+
         display: flex;
         align-items: center;
         position: relative;

--- a/scss/core/forms.scss
+++ b/scss/core/forms.scss
@@ -30,7 +30,7 @@ textarea,
 .#{$fd-namespace}-textarea {
     @include fd-form-text;
     width: 100%;
-    height: $fd-forms-height--input-text * 2;
+    height: $fd-forms-height * 2;
     padding-top: $fd-forms-padding;
 }
 
@@ -58,7 +58,7 @@ select,
         background-image: url(#{$fd-forms-select-background-image--disabled});
     }
     &[multiple] {
-        height: $fd-forms-height--input-text * 3;
+        height: $fd-forms-height * 3;
         background-image: none;
         padding-top: $fd-forms-padding;
     }
@@ -85,7 +85,7 @@ select,
     #{$fd-elements-inputs--radio},
     .#{$fd-namespace}-radio {
         -moz-appearance: radio;
-    }    
+    }
 }
 
 #{$fd-elements-inputs--check}, #{$fd-elements-inputs--radio},
@@ -135,12 +135,12 @@ input[type="checkbox"],
         }
     }
     &:indeterminate {
-        
+
             border: 3px solid $fd-forms-background-color;
             background-color: fd-color-darkest($fd-forms-color--active);
             box-shadow: 0 0 0 1px fd-color-darkest($fd-forms-color--active);
-        
-    }       
+
+    }
     @include fd-disabled {
         &::before {
             border-color: $fd-forms-background-color--check-disabled;

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -52,10 +52,10 @@
 
 @mixin fd-form-text() {
     @include fd-form-base;
-    height: var(--fd-forms-height);
+    @include fd-var-size("height", $fd-forms-height, --fd-forms-height);
     &.fd-input--compact,
     &.fd-select--compact {
-      height: var(--fd-forms-height-compact);
+      @include fd-var-size("height", $fd-forms-height--compact, --fd-forms-height-compact);
     }
     padding-left: $fd-forms-padding;
     padding-right: $fd-forms-padding;

--- a/scss/theme/fundamental.scss
+++ b/scss/theme/fundamental.scss
@@ -138,7 +138,7 @@ $fd-animation--speed: 0.125s;
 
 //FORMS
 //dimensions
-$fd-forms-height--input-text: $fd-spacing--base * 13;
+$fd-forms-height: $fd-spacing--base * 13;
 $fd-forms-height--input-check: $fd-spacing--base * 7;
 $fd-forms-padding: $fd-spacing--base * 4;
 //colors


### PR DESCRIPTION
Closes sap/fundamental#1032

Many of the CSS vars for spacing did not have fallback values so they displayed incorrectly on IE11.

> Note: The gutters in IE11 will not vary based on breakpoints. They will always display with the desktop default of 16px.

#### Test

Enable fallbacks by setting `$fd-support-css-var-fallback: true` before testing in IE11.

* http://localhost:3030/forms input and select heights
* http://localhost:3030/product-menu height
* http://localhost:3030/input-group height for default and compact
* http://localhost:3030/modal padding around modal containers
* http://localhost:3030/table cell padding
* http://localhost:3030/tree row and cell padding

#### Changelog

**New**

* Adds default for `$fd-width--gutter` 
* Deprecates `$fd-forms-height--input-text` in favor of the base `$fd-forms-height`

**Changed**

* See test list above



**Removed**

* N/A
