### PR TITLE
#1042 updates breakpoints and UI padding

### DIFF
--- a/docs/pages/foundation/grid.html
+++ b/docs/pages/foundation/grid.html
@@ -28,50 +28,60 @@ summary: Fiori Fundamentals uses responsive grid system that achieves flexible 1
 
 -->
 
+When considering responsive views we follow a mobile-first approach where screens are built for small screens and adapted for larger screens. This means that <code>S</code> is always the default and we modify for <code>M</code> and above.
+
 <h2 class="docs-header-h2">Breakpoints</h2>
+
 
 <table class="fd-table docs-breakpoints-table">
     <thead>
         <tr>
             <th>Size</th>
+            <th class="docs-breakpoints-table_col-legend docs-breakpoints-table_col-legend--column">Target Devices</th>
+            <th class="docs-breakpoints-table_col-legend docs-breakpoints-table_col-legend--margin">Breakpoints</th>
             <th class="docs-breakpoints-table_col-legend docs-breakpoints-table_col-legend--column">Margin</th>
             <th class="docs-breakpoints-table_col-legend docs-breakpoints-table_col-legend--gutter">Gutter</th>
-            <th class="docs-breakpoints-table_col-legend docs-breakpoints-table_col-legend--margin">Breakpoints</th>
         </tr>
     </thead>
     <tbody>
         <tr>
-            <td>S (Phone)</td>
-            <td>8px</td>
-            <td>8px</td>
+            <td>S</td>
+            <td>Portrait Phone</td>
             <td>&lt;600px</td>
+            <td>8px</td>
+            <td>8px</td>
         </tr>
         <tr>
-            <td>M (Tablet)</td>
-            <td>16px</td>
-            <td>16px</td>
+            <td>M</td>
+            <td>Landscape Phone, Portrait Tablet</td>
             <td>601-1024px</td>
+            <td>16px</td>
+            <td>16px</td>
         </tr>
         <tr>
-            <td>L (Desktop)</td>
+            <td>L</td>
+            <td>Landscape Tablet, Small Laptops</td>
+            <td>1025-1440px</td>
             <td>32px</td>
             <td>16px</td>
-            <td>1025-1440px</td>
         </tr>
         <tr>
-            <td>XL (Desktop)</td>
+            <td>XL</td>
+            <td>Pro Laptops, Desktop</td>
+            <td>1441-1920px</td>
             <td>32px</td>
             <td>20px</td>
-            <td>1441-1920px</td>
         </tr>
         <tr>
-            <td>XXL (Desktop)</td>
+            <td>XXL</td>
+            <td>Pro Displays</td>
+            <td>1921px</td>
             <td>48px</td>
             <td>20px</td>
-            <td>1921px</td>
         </tr>
     </tbody>
 </table>
+
 
 <!-- Images currently out of date. Must update to reflect table above
 

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -5,23 +5,12 @@ $fd-support-css-var-fallback: false !default;
 //————————v FIORI FUNDAMENTALS FOUNDATION ————————v
 
 //breakpoints
-//
-//~ size ~~ target device ~~ viewport size
-//~ s       phone            <600px
-//~ m       tablet           600-1024px
-//~ l       desktop          1025-1439px
-//~ xl      desktop          1440-1919px
-//~ xxl     desktop          >=1920px
-//
-
-// replace xs references
-// find s references for LESS THAN? (max-width)
 $fd-breakpoints: (
-    s: 320px,
-    m: 600px,
-    l: 1025px,
-    xl: 1440px,
-    xxl: 1920px,
+    s: 320px,    //phone     <600
+    m: 600px,    //tablet    600-1023
+    l: 1024px,   //desktop   1024-1440
+    xl: 1441px,  //desktop   1441-1920
+    xxl: 1921px, //display   >1920
 ) !default;
 
 //spacing

--- a/scss/core/root.scss
+++ b/scss/core/root.scss
@@ -36,26 +36,14 @@
   @include fd-screen(m) {
     --fd-forms-height-compact: #{$fd-forms-height--compact};
   }
-
-
   //padding and gutter values used in page, section, and container
-  --fd-padding-ui: #{map-get($fd-spacing, xxs)}; // 8px ~ Margin (A)
-  --fd-width-gutter: #{map-get($fd-spacing, xxs)}; // 8px ~ Gutter (B)
-
+  --fd-padding-ui: #{fd-space("tiny")}; //8px
+  --fd-width-gutter: #{fd-space("tiny")}; //8px
   @include fd-screen(m) {
-    --fd-padding-ui: #{map-get($fd-spacing, s)}; // 16px
-    --fd-width-gutter: #{map-get($fd-spacing, s)}; // 16px
-  }
-  @include fd-screen(l) {
-    --fd-padding-ui: #{map-get($fd-spacing, m)}; // 32px
-    --fd-width-gutter: #{map-get($fd-spacing, s)}; // 16px
+    --fd-padding-ui: #{fd-space("medium")}; //32px
+    --fd-width-gutter: #{fd-space("small")}; //16px
   }
   @include fd-screen(xl) {
-    --fd-padding-ui: #{map-get($fd-spacing, m)}; // 32px
-    --fd-width-gutter: #{map-get($fd-spacing, reg) - map-get($fd-spacing, base)}; // 20px
-  }
-  @include fd-screen(xxl) {
-    --fd-padding-ui: #{map-get($fd-spacing, xxl)}; // 48px
-    --fd-width-gutter: #{map-get($fd-spacing, reg) - map-get($fd-spacing, base)}; // 20px
+    --fd-padding-ui: #{fd-space("large")}; //48px
   }
 }

--- a/test/templates/pages/grid.njk
+++ b/test/templates/pages/grid.njk
@@ -12,6 +12,40 @@
 {% from "../button/component.njk" import button %}
 {% from "../tree/component.njk" import tree %}
 
+
+
+{% block page_header %}
+
+
+
+{% set breakpoints = {
+  "s": [320,"320-599"],
+  "m": [600,"600-1023"],
+  "l": [1024,"1024-1440"],
+  "xl": [1441,"1441-1920"],
+  "xxl": [1921,">1920"]
+} %}
+<style>
+.fd-shell__header::before {
+  content: "default: <320px";
+  font-size: 2em;
+  background-color: white;
+}
+{% for size,width in breakpoints %}
+
+@media screen and (min-width: {{width[0]}}px) {
+  .fd-shell__header::before {
+    content: "{{size}}: {{width[1]}}px";
+  }
+}
+{% endfor %}
+</style>
+
+
+{% endblock %}
+
+
+
 {# SET CONTENT #}
 
 {% set div %}
@@ -154,6 +188,8 @@
 
 
 
+
+
 {% block page_content %}
 
 
@@ -191,6 +227,3 @@
 
 
 {% endblock %}
-{% block page_header -%}
-.page__header
-{%- endblock %}

--- a/test/templates/pages/styles.njk
+++ b/test/templates/pages/styles.njk
@@ -3,19 +3,23 @@
 
 
 {% set breakpoints = {
-  "xs": 320,
-  "s": 800,
-  "m": 1024,
-  "l": 1440,
-  "xl": 1580
+  "s": [320,"320-599"],
+  "m": [600,"600-1023"],
+  "l": [1024,"1024-1440"],
+  "xl": [1441,"1441-1920"],
+  "xxl": [1921,">1920"]
 } %}
 <style>
+.fd-ui__header::before {
+  content: "default: <320px";
+  font-size: 2em;
+  background-color: white;
+}
 {% for size,width in breakpoints %}
-@media screen and (min-width: {{width}}px) {
+
+@media screen and (min-width: {{width[0]}}px) {
   .fd-ui__header::before {
-    content: "{{size}}: {{width}}px";
-    font-size: 2em;
-    background-color: white;
+    content: "{{size}}: {{width[1]}}px";
   }
 }
 {% endfor %}


### PR DESCRIPTION
Closes sap/fundamental#1042

Updates breakpoints and UI side padding slightly to conform with approve specs. **This only changes side padding and gutters, inner content padding and bottom margins will be addressed later.**

> Note: The `s` breakpoint of `320` is retained since it can be useful but it is not a specific breakpoint in terms of the design system and is not documented.

#### Test

* http://localhost:3030/pages/grid
* localhost:4000/foundation/grid.html

#### Changelog

**New**

* N/A

**Changed**

* Breakpoint `l` now starts at `1024px`, `xl` now starts `1441`, and `xxl` now `>1920`
* Side padding for high level containers like `shellbar` and `section`s now use 32px starting at `l`
* Gutters are now 16px for `xl` and `xxl` sizes

**Removed**

* N/A