### PR TITLE
#1072 removes links from Foundation page

### DIFF
--- a/docs/pages/foundation/index.md
+++ b/docs/pages/foundation/index.md
@@ -13,26 +13,6 @@ problems in a meaningful way and creates simple intuitive experience.
 </p>
 
 <div class="fd-tile-grid fd-tile-grid--2col docs-tiles">
-    <a class="fd-tile" role="button" href="getting-started-designers.html">
-        <div class="fd-tile__content">
-             <h2 class="fd-tile__header">
-                 Getting Started - Designers
-             </h2>
-            <p class="fd-tile__description">
-                Create a harmonious experience for users with Fiori Fundamentals design language.
-            </p>
-        </div>
-    </a>
-    <a class="fd-tile" role="button" href="getting-started-developers.html">
-        <div class="fd-tile__content">
-             <h2 class="fd-tile__header">
-                 Getting Started - Developers
-             </h2>
-             <p class="fd-tile__description">
-                 Fiori Fundamentals is a coherent Design System accompanied by a collection of HTML/CSS Components.
-             </p>
-        </div>
-    </a>
     <a class="fd-tile" role="button" href="colors.html">
         <div class="fd-tile__content">
              <h2 class="fd-tile__header">


### PR DESCRIPTION
Closes sap/fundamental#1072

Removes Designer and Developer Getting Started links from the [Foundation page](https://sap.github.io/fundamental/foundation/index.html). The dev link is broken and the design page is not useful.

#### Test

* http://localhost:4000/foundation/index.html

#### Changelog

**New**

* N/A

**Changed**

* N/A

**Removed**

* Removes links from Foundation page