### PR TITLE
Update how to use scss guide - 1017

### DIFF
--- a/docs/pages/guides/how-to-use-scss.md
+++ b/docs/pages/guides/how-to-use-scss.md
@@ -61,17 +61,19 @@ Fiori Fundamentals installation is now complete
 
 1. Open `scss/app.scss` file
 2. Add the following line of code to define the icons path: <br><br> `$fd-icons-path: "~fiori-fundamentals/scss/icons/";`
-3. Add the following line of code to import SCSS source file: <br><br> `@import "~fiori-fundamentals/scss/all.scss";`
+3. Add the following line of code to define the fonts path: <br><br> `$fd-fonts-path: "~fiori-fundamentals/scss/fonts/";`
+4. Add the following line of code to import SCSS source file: <br><br> `@import "~fiori-fundamentals/scss/all.scss";`
 
 Importing Fiori Fundamentals SCSS is now complete
 
-> **Note:** In order to render the icons correctly, you need to define the `$fd-icons-path` variable.
+> **Note:** In order to render the icons and fonts correctly, you need to define the `$fd-icons-path` and `$fd-fonts-path` variables.
 
 At this point, the contents of your `scss/app.scss` should look like this:
 
 {% highlight css %}
 
 $fd-icons-path: "~fiori-fundamentals/scss/icons/";
+$fd-fonts-path: "~fiori-fundamentals/scss/fonts/";
 @import "~fiori-fundamentals/scss/all.scss";
 
 {% endhighlight %}


### PR DESCRIPTION
Closes sap/fundamental https://github.com/SAP/fundamental/issues/1017

Add in docs that $fd-fonts-path needs to be specified otherwise it causes a compilation error.

![screenshot 2018-12-07 at 13 29 36](https://user-images.githubusercontent.com/44162302/49650658-e73b7400-fa24-11e8-97be-3438f958abf1.png)
