### PR TITLE
#1099 moves some helper classes to more logical sass files

### DIFF
--- a/scss/helpers.scss
+++ b/scss/helpers.scss
@@ -1,4 +1,3 @@
-@import "helpers/general";
 @import "helpers/type";
 @import "helpers/colors";
 @import "helpers/backgrounds";

--- a/scss/helpers/_display.scss
+++ b/scss/helpers/_display.scss
@@ -1,7 +1,18 @@
+
+$fd-display-types: none block inline-block grid inline-grid flex inline-flex table table-row table-cell !default;
+
+@each $type in $fd-display-types {
+  //general
+  .#{$fd-namespace}-has-display-#{$type} {
+      display: #{$type} !important;
+  }
+}
+//breakpoint-specific
 @each $breakpoint in map-keys($fd-breakpoints) {
   @include media-breakpoint-up($breakpoint) {
     $infix: breakpoint-infix($breakpoint, $fd-breakpoints);
 
+    //DEPRECATE in 1.6 IN FAVOR OF THE SET BELOW
     .#{$fd-namespace}-display#{$infix}-none         { display: none !important; }
     .#{$fd-namespace}-display#{$infix}-inline       { display: inline !important; }
     .#{$fd-namespace}-display#{$infix}-inline-block { display: inline-block !important; }
@@ -11,5 +22,11 @@
     .#{$fd-namespace}-display#{$infix}-table-cell   { display: table-cell !important; }
     .#{$fd-namespace}-display#{$infix}-flex         { display: flex !important; }
     .#{$fd-namespace}-display#{$infix}-inline-flex  { display: inline-flex !important; }
+
+    @each $type in $fd-display-types {
+      .#{$fd-namespace}-has-display-#{$type}-#{$infix} {
+          display: #{$type} !important;
+      }
+    }
   }
 }

--- a/scss/helpers/_flex.scss
+++ b/scss/helpers/_flex.scss
@@ -1,8 +1,11 @@
 @import "./../settings";
 @import "./../mixins";
-// .#{$fd-namespace}-has-clearfix {
-//     @include fd-clearfix;
-// }
-.#{$fd-namespace}-has-align-items-flex-end {
-    align-items: flex-end !important;
+
+@each $type in (flex-start flex-end center baseline stretch) {
+  .#{$fd-namespace}-has-align-items-#{$type} {
+      align-items: #{$type} !important;
+  }
+}
+.#{$fd-namespace}-has-flex-grow-1 {
+    flex-grow: 1 !important;
 }

--- a/scss/helpers/_general.scss
+++ b/scss/helpers/_general.scss
@@ -1,3 +1,4 @@
+//DEPRECATE 1.6
 @import "./../settings";
 .#{$fd-namespace}-has-text-transform-none {
     text-transform: none !important;

--- a/scss/helpers/_grid.scss
+++ b/scss/helpers/_grid.scss
@@ -1,11 +1,5 @@
 @import "./../settings";
 //set namespace using function to avoid hardcoding it
-.#{$fd-namespace}-has-display-grid {
-    display: grid !important;
-}
-.#{$fd-namespace}-has-display-inline-grid {
-    display: inline-grid !important;
-}
 @each $span in 2,3,4,5,6 {
     @each $direction in row,column {
       .#{$fd-namespace}-has-grid-#{$direction}-span-#{$span} {

--- a/scss/helpers/_layout.scss
+++ b/scss/helpers/_layout.scss
@@ -3,24 +3,9 @@
 .#{$fd-namespace}-has-clearfix {
     @include fd-clearfix;
 }
-.#{$fd-namespace}-has-display-flex {
-    display: flex !important;
+.#{$fd-namespace}-has-float-left {
+    float: left !important;
 }
-.#{$fd-namespace}-has-display-inline-flex {
-    display: inline-flex !important;
-}
-.#{$fd-namespace}-has-display-block {
-    display: block !important;
-}
-.#{$fd-namespace}-has-display-none {
-    display: none !important;
-}
-.#{$fd-namespace}-has-display-inline-block {
-    display: inline-block !important;
-}
-.#{$fd-namespace}-has-align-items-center {
-    align-items: center;
-}
-.#{$fd-namespace}-has-flex-grow-1 {
-    flex-grow: 1;
+.#{$fd-namespace}-has-float-right {
+    float: right !important;
 }

--- a/scss/helpers/_type.scss
+++ b/scss/helpers/_type.scss
@@ -16,15 +16,32 @@
             @include fd-type($key);
         }
     }
-
 }
 @each $key, $value in $fd-fonts {
     .#{$fd-namespace}-has-font-family-#{$key} {
-        font-family: $value;
+        font-family: $value !important;
     }
 }
 @each $key, $value in $fd-weights {
     .#{$fd-namespace}-has-font-weight-#{$key} {
-        font-weight: $value;
+        font-weight: $value !important;
     }
+}
+.#{$fd-namespace}-has-font-style-italic {
+    font-style: italic !important;
+}
+.#{$fd-namespace}-has-text-transform-none {
+    text-transform: none !important;
+}
+.#{$fd-namespace}-has-text-transform-uppercase {
+    text-transform: uppercase !important;
+}
+.#{$fd-namespace}-has-text-transform-lowercase {
+    text-transform: lowercase !important;
+}
+.#{$fd-namespace}-has-text-align-center {
+    text-align: center !important;
+}
+.#{$fd-namespace}-has-text-align-right {
+    text-align: right !important;
 }


### PR DESCRIPTION
Closes sap/fundamental#1099

Reorganizes some helper classes into more logical groupings, deprecates the `general` helper file in favor of more specific groups.

> NOTE: Anyone using individual `helpers` as imports may encounter issues. It is recommended you update your imports or use the entire `helpers.scss` file instead.

#### Test

* Distributed helpers file should include the full set of helpers as before

#### Changelog

**New**

* Breakpoint display classes use the format `fd-had-display-none--m` and follow a mobile-first approach meaning this class would show the element at `xs` and `s` screens but hide it starting at `m` and above.
* Expands `flex.scss` `align-items` helpers
* Expands `display.scss` helpers to include all display types for breakpoints

**Changed**

* Removes `general` SASS file from `helpers` index but the file will remain until v1.6
* All display classes, incl. grid and flex, are now in `display.scss`
* All type related helpers, e.g., text-transform, text-align, font-style, are now in `type.scss`

**Removed**

* N/A
