### PR TITLE
Feature/1034 textarea

### DIFF
--- a/docs/pages/components/form.md
+++ b/docs/pages/components/form.md
@@ -188,6 +188,12 @@ Do not use the text area if
         <textarea class="fd-form__control" id="textarea-1">Pellentesque metus lacus commodo eget justo ut rutrum varius nunc.</textarea>
     </div>
 </div>
+<div class="fd-form__set">
+    <div class="fd-form__item">
+        <label class="fd-form__label" for="textarea-2">Compact text area:</label>
+        <textarea class="fd-form__control fd-textarea--compact" id="textarea-2">Pellentesque metus lacus commodo eget justo ut rutrum varius nunc.</textarea>
+    </div>
+</div>
 {% endcapture %}
 
 {% include display-component.html component=inputs %}
@@ -397,7 +403,7 @@ Do not use the checkbox control if:
                 Field label
             </label>
         </div>
-        
+
     </div>
 </fieldset>{% endcapture %}
 

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -249,7 +249,7 @@ $fd-forms-border-color--disabled: map-get($fd-colors-neutral, 2) !default;
 
 
 
-$fd-elements-inputs--text: "input[type=text]", "input[type=password]", "input[type=email]", "input[type=url]", "input[type=search]", "input[type=tel]", "input[type=number]", "input[type=date]", "input[type=time]", "textarea";
+$fd-elements-inputs--text: "input[type=text]", "input[type=password]", "input[type=email]", "input[type=url]", "input[type=search]", "input[type=tel]", "input[type=number]", "input[type=date]", "input[type=time]";
 $fd-elements-inputs--check: "input[type=checkbox]";
 $fd-elements-inputs--radio: "input[type=radio]";
 

--- a/scss/core/forms.scss
+++ b/scss/core/forms.scss
@@ -1,6 +1,75 @@
 @import "./../settings";
 @import "./../functions";
-@import "./../mixins/forms";
+
+// Form Mixins
+@mixin fd-form-base {
+    @include fd-reset;
+    @include fd-type("0");
+    appearance: none;
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    font-size: inherit;
+    box-sizing: border-box;
+    outline: none;
+    border-style: solid;
+    border-width: 1px;
+    @include fd-var-color("color", $fd-forms-color, --fd-forms-color);
+    @include fd-var-color("border-color", $fd-forms-border-color, --fd-forms-border-color);
+    @include fd-var-color("background-color", $fd-forms-background-color, --fd-forms-background-color);
+    border-radius: $fd-border-radius;
+    transition: border-color $fd-animation--speed;
+    //states
+    @include fd-hover {
+      @include fd-var-color("border-color", fd-color-state("hover", "action"));
+      --fd-forms-border-color: var(--fd-color-action-hover);
+    }
+    @include fd-focus {
+      --fd-forms-border-color: var(--fd-color-action-focus);
+      @include fd-var-color("border-color", fd-color-state("hover", "action"));
+    }
+    &.is-invalid {
+      --fd-forms-border-color: var(--fd-color-negative);
+      @include fd-var-color("border-color", $fd-color--negative);
+      border-width: 2px;
+    }
+    &.is-valid {
+      --fd-forms-border-color: var(--fd-color-positive);
+      @include fd-var-color("border-color", $fd-color--positive);
+      border-width: 2px;
+    }
+    &.is-warning,
+    &.is-alert {
+      --fd-forms-border-color: var(--fd-color-alert);
+      @include fd-var-color("border-color", $fd-color--alert);
+      border-width: 2px;
+    }
+    @include fd-disabled {
+        cursor: not-allowed;
+        --fd-forms-color: var(--fd-color-text-3);
+        --fd-forms-border-color: var(--fd-color-neutral-2);
+        --fd-forms-background-color: var(--fd-color-neutral-1);
+        @include fd-var-color("color", $fd-forms-color--disabled);
+        @include fd-var-color("border-color", $fd-forms-border-color--disabled);
+        @include fd-var-color("background-color", $fd-forms-background-color--disabled);
+    }
+    &[readonly],
+    &.is-readonly {
+        --fd-forms-color: var(--fd-forms-color);
+        --fd-forms-border-color: var(--fd-color-neutral-2);
+        @include fd-var-color("color", $fd-forms-color);
+        @include fd-var-color("border-color", $fd-forms-border-color--disabled);
+        border-width: 0 0 1px;
+        border-radius: 0;
+    }
+    @content;
+}
+
+@mixin fd-form-text() {
+    @include fd-form-base;
+    padding-left: $fd-forms-padding;
+    padding-right: $fd-forms-padding;
+    @content;
+}
 
 // Form Base
 %form-field-base {
@@ -17,23 +86,31 @@ fieldset {
   padding: 0;
   margin: 0;
 }
-
-#{$fd-elements-inputs--text}, .#{$fd-namespace}-input {
+#{$fd-elements-inputs--text},
+.#{$fd-namespace}-input {
     @include fd-form-text();
+    @include fd-var-size("height", $fd-forms-height, --fd-forms-height);
     width: 100%;
     &::placeholder {
       color: $fd-forms-color--placeholder;
     }
 }
-
+input.#{$fd-namespace}-input--compact {
+    @include fd-var-size("height", $fd-forms-height--compact, --fd-forms-height-compact);
+}
 textarea,
 .#{$fd-namespace}-textarea {
     @include fd-form-text;
     width: 100%;
-    height: $fd-forms-height * 2;
+    @include fd-var-size("height", $fd-forms-height * 2);
+    height: calc(var(--fd-forms-height) * 2);
     padding-top: $fd-forms-padding;
 }
-
+.#{$fd-namespace}-textarea--compact {
+    @include fd-var-size("height", $fd-forms-height--compact);
+    height: calc(var(--fd-forms-height-compact) * 2);
+    padding-top: $fd-forms-padding;
+}
 select,
 .#{$fd-namespace}-select {
     @include fd-form-text;
@@ -44,6 +121,7 @@ select,
     background-position: calc(100%) center;
     padding-right: ($fd-forms-padding * 3) + $fd-forms-select-width--background-image;
     width: 100%;
+    @include fd-var-size("height", $fd-forms-height, --fd-forms-height);
     &:focus,
     &:hover {
         background-image: url(#{$fd-forms-select-background-image});
@@ -52,15 +130,8 @@ select,
     &.is-expanded {
         background-image: url(#{$fd-forms-select-background-image});
     }
-    &[disabled],
-    &[aria-disabled="true"],
-    &.is-disabled {
-        background-image: url(#{$fd-forms-select-background-image--disabled});
-    }
-    &[multiple] {
-        height: $fd-forms-height * 3;
-        background-image: none;
-        padding-top: $fd-forms-padding;
+    @include fd-disabled {
+      background-image: url(#{$fd-forms-select-background-image--disabled});
     }
     &::after {
         content: "";
@@ -75,8 +146,20 @@ select,
         top: calc(50% - 4px);
         left: calc(50% - 10px/2);
     }
+    &[multiple] {
+        @include fd-var-size("height", $fd-forms-height * 3)
+        height: calc(var(--fd-forms-height) * 3);
+        background-image: none;
+        padding-top: $fd-forms-padding;
+    }
 }
-
+.#{$fd-namespace}-select--compact {
+    @include fd-var-size("height", $fd-forms-height--compact, --fd-forms-height-compact);
+}
+[multiple].#{$fd-namespace}-select--compact {
+    @include fd-var-size("height", $fd-forms-height--compact * 3);
+    height: calc(var(--fd-forms-height-compact) * 3);
+}
 @-moz-document url-prefix() {
     #{$fd-elements-inputs--check},
     .#{$fd-namespace}-checkbox {
@@ -87,7 +170,6 @@ select,
         -moz-appearance: radio;
     }
 }
-
 #{$fd-elements-inputs--check}, #{$fd-elements-inputs--radio},
 .#{$fd-namespace}-checkbox,
 .#{$fd-namespace}-radio {
@@ -98,22 +180,60 @@ select,
     vertical-align: middle;
     position: relative;
     @include action-cursor;
-    border-color: fd-color(neutral, 4);
-    &:hover{
-        border-width: 2px;
+    @include fd-hover {
+      border-width: 2px;
+      @include fd-disabled {
+        border-width: 1px;
+      }
     }
     &:checked {
-        border-color: fd-color-darkest($fd-forms-color--active);
-        background-color: fd-color-darkest($fd-forms-color--active);
-    }
-    &[disabled],
-    &[aria-disabled="true"],
-    &.is-disabled {
-        border-color: $fd-forms-border-color--disabled;
-        background-color: $fd-forms-background-color--disabled;
+      --fd-forms-border-color: var(--fd-color-action-selected);
+      --fd-forms-background-color: var(--fd-color-action-selected);
+      @include fd-var-color("border-color", fd-color-state("selected", "action"));
+      @include fd-var-color("background-color", fd-color-state("selected", "action"));
+      @include fd-disabled {
+        --fd-forms-border-color: var(--fd-color-action-disabled);
+        --fd-forms-background-color: var(--fd-color-action-disabled);
+        @include fd-var-color("border-color", fd-color-state("disabled", "action"));
+        @include fd-var-color("background-color", fd-color-state("disabled", "action"));
+      }
+      @include fd-hover {
+        border-width: 1px;
+      }
     }
 }
-
+input[type="radio"],
+.#{$fd-namespace}-radio {
+    border-radius: 50%;
+    &::after {
+        $check-size_: fd-space(2);
+        content: "";
+        border-radius: 50%;
+        width: $check-size_;
+        height: $check-size_;
+        position: absolute;
+        top: calc(50% - (#{$check-size_}/2));
+        left: calc(50% - (#{$check-size_}/2));
+        transition: background-color $fd-forms-transition-params;
+        background-color: transparent;
+    }
+    &:checked {
+        --fd-forms-background-color: var(--fd-forms-background-color);
+        @include fd-var-color("background-color", $fd-forms-background-color);
+        &::after {
+            --fd-forms-background-color: var(--fd-color-action-selected);
+            @include fd-var-color("background-color", fd-color-state("selected", "action"), --fd-forms-background-color);
+        }
+        @include fd-disabled {
+          --fd-forms-background-color: var(--fd-forms-background-color);
+          @include fd-var-color("background-color", $fd-forms-background-color);
+          &::after {
+            --fd-forms-background-color: var(--fd-color-action-disabled);
+            @include fd-var-color("background-color", fd-color-state("disabled", "action"));
+          }
+        }
+    }
+}
 input[type="checkbox"],
 .#{$fd-namespace}-checkbox {
     &::before {
@@ -131,49 +251,21 @@ input[type="checkbox"],
     }
     &:checked {
         &::before {
-            border-color: $fd-forms-background-color;
+          --fd-forms-border-color: var(--fd-color-action-2);
+          @include fd-var-color("border-color", $fd-forms-background-color, --fd-forms-border-color);
         }
     }
     &:indeterminate {
+      --fd-forms-border-color: var(--fd-color-action-2);
+      --fd-forms-background-color: var(--fd-color-action-selected);
+      border-width: 3px;
+      border-style: solid;
+      @include fd-var-color("border-color", $fd-forms-background-color);
+      @include fd-var-color("background-color", fd-color-state("selected", "action"));
+      @if $fd-support-css-var-fallback {
+        box-shadow: 0 0 0 1px fd-color-state("selected", "action");
+      }
+      box-shadow: 0 0 0 1px var(--fd-forms-background-color);
 
-            border: 3px solid $fd-forms-background-color;
-            background-color: fd-color-darkest($fd-forms-color--active);
-            box-shadow: 0 0 0 1px fd-color-darkest($fd-forms-color--active);
-
-    }
-    @include fd-disabled {
-        &::before {
-            border-color: $fd-forms-background-color--check-disabled;
-        }
-    }
-}
-
-input[type="radio"],
-.#{$fd-namespace}-radio {
-    border-radius: 50%;
-    &::after {
-        $check-size_: fd-space(2);
-        content: "";
-        border-radius: 50%;
-        width: $check-size_;
-        height: $check-size_;
-        position: absolute;
-        top: calc(50% - (#{$check-size_}/2));
-        left: calc(50% - (#{$check-size_}/2));
-        transition: background-color $fd-forms-transition-params;
-        background-color: transparent;
-    }
-    &:checked {
-        background-color: $fd-forms-background-color;
-        &::after {
-            background-color: fd-color-darkest($fd-forms-color--active);
-        }
-        &[disabled],
-        &[aria-disabled="true"],
-        &.is-disabled {
-            &::after {
-                background-color: $fd-forms-background-color--check-disabled;
-            }
-        }
     }
 }

--- a/scss/core/root.scss
+++ b/scss/core/root.scss
@@ -7,6 +7,10 @@
     --#{$fd-namespace}-color-#{$type}-#{$shade}: #{$value};
     }
   }
+  --fd-color-positive: #{$fd-color--positive};
+  --fd-color-negative: #{$fd-color--negative};
+  --fd-color-alert: #{$fd-color--alert};
+
   //derived states
   --fd-color-action-hover: #{map-get($fd-colors-action-states, "hover")};
   --fd-color-action-focus: #{map-get($fd-colors-action-states, "hover")};
@@ -21,6 +25,10 @@
   --fd-color-background-alert: #{map-get($fd-colors-background-states, "alert")};
   --fd-color-background-negative: #{map-get($fd-colors-background-states, "negative")};
 
+  //form colors
+  --fd-forms-color: #{$fd-color};
+  --fd-forms-border-color: #{$fd-forms-border-color};
+  --fd-forms-background-color: #{$fd-forms-background-color)};
 
   //form metrics
   --fd-forms-height: #{$fd-forms-height};

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -1,3 +1,5 @@
+//DEPRECATE 1.6
+
 // Form Mixins
 @mixin fd-form-base {
     @include fd-reset;
@@ -52,11 +54,6 @@
 
 @mixin fd-form-text() {
     @include fd-form-base;
-    @include fd-var-size("height", $fd-forms-height, --fd-forms-height);
-    &.fd-input--compact,
-    &.fd-select--compact {
-      @include fd-var-size("height", $fd-forms-height--compact, --fd-forms-height-compact);
-    }
     padding-left: $fd-forms-padding;
     padding-right: $fd-forms-padding;
     @content;

--- a/test/resources/controls.js
+++ b/test/resources/controls.js
@@ -136,4 +136,12 @@
             localStorage.setItem("toggleCompactState", false);
         }
     });
+
+    //indeterminate
+    const indeterminates = document.querySelectorAll("[indeterminate=true]");
+    for (let i = 0; i < indeterminates.length; i++) {
+      indeterminates[i].indeterminate = true;
+    }
+
+
 })();

--- a/test/templates/form/component.njk
+++ b/test/templates/form/component.njk
@@ -57,7 +57,7 @@ form-item:
 {%- set _id = utils.id() %}
 <div class="fd-form__item{{ modifier.item | modifier('form__item') }}{{ ' fd-form__item--check' if type == "checkbox" or type == "radio" or type == "toggle" }}">
     {%- if type == "checkbox" or type == "radio" or type == "toggle" %}
-    <label class="fd-form__label{{ ' is-disabled' if state.disabled }}" {{ ' aria-required="'+ state.required +'"'  if state.required }} for="{{_id}}">
+    <label class="fd-form__label" {{ ' aria-required="'+ state.required +'"'  if state.required }} for="{{_id}}">
         {{ form_control(type,_id,properties,state=state,aria=aria,modifier=modifier.control) }}
         {%- if state.required %}
         {{ properties.label+'*' }}

--- a/test/templates/form/index.njk
+++ b/test/templates/form/index.njk
@@ -60,6 +60,7 @@
 {{ form_item("radio",state={ required: true }) }}
 {{ form_item("radio",state={ status: "valid" }) }}
 {{ form_item("radio",state={ disabled: true }) }}
+{{ form_item("radio",state={ disabled: true, checked: true }) }}
 {% endset %}
 {{ format(example) }}
 
@@ -70,7 +71,9 @@
 {{ form_item("checkbox",state={ checked: true }) }}
 {{ form_item("checkbox",state={ required: true }) }}
 {{ form_item("checkbox",state={ status: "valid" }) }}
+{{ form_item("checkbox",state={ indeterminate: true }) }}
 {{ form_item("checkbox",state={ disabled: true }) }}
+{{ form_item("checkbox",state={ disabled: true, checked: true }) }}
 {% endset %}
 {{ format(example) }}
 

--- a/test/templates/forms.njk
+++ b/test/templates/forms.njk
@@ -2,15 +2,16 @@
     properties={ value: "", name: "", id: "" },
     field="input",
     size="",
-    state={ checked: false, disabled: false, readonly: false, status: "" },
+    state={ checked: false, disabled: false, readonly: false, indeterminate: false, status: "" },
     aria={},
     classes=[])
 -%}
-class="fd-{{field}} {{ size | modifier("input") }}{{ classes | classes | trim }}{{ ' is-'+state.status if state.status }}" id="{{properties.id}}"
+class="fd-{{field}} {{ size | modifier(field) }}{{ classes | classes | trim }}{{ ' is-'+state.status if state.status }}" id="{{properties.id}}"
 {{- ' name="'+properties.name+'"' if properties.name }}
 {{- aria | aria }}
 {{- ' disabled' if state.disabled }}
 {{- ' readonly' if state.readonly }}
+{{- ' indeterminate="true"' if state.indeterminate }}
 {{- ' checked' if state.checked }}{{ ' multiple' if state.multiple }}
 {%- endmacro %}
 
@@ -54,7 +55,7 @@ class="fd-{{field}} {{ size | modifier("input") }}{{ classes | classes | trim }}
     properties={ value: "", id: "" },
     field="checkbox",
     size="",
-    state={ checked: false, disabled: false, status: "" },
+    state={ checked: false, disabled: false, status: "", indeterminate: false },
     aria={},
     classes=[])
 -%}

--- a/test/templates/pages/form-elements.njk
+++ b/test/templates/pages/form-elements.njk
@@ -94,6 +94,18 @@
     {{ button({ label: "Dolor" }, size="compact") }}
 </div>
 
+<h3>textarea</h3>
+<div class="fd-form__item fd-has-display-flex">
+    {{ forms.textarea() }}
+    {{ button({ label: "Dolor"}) }}
+</div>
+
+<div class="fd-form__item fd-has-display-flex">
+    {{ forms.textarea(size="compact") }}
+    {{ button({ label: "Dolor"}) }}
+</div>
+
+
 <h3>select</h3>
 <div class="fd-form__item fd-has-display-flex">
     {{ forms.select() }} {{ button({ label: "Dolor"}) }}
@@ -106,6 +118,9 @@
 <h4>select[multiple]</h4>
 <div class="fd-form__item fd-has-display-flex">
     {{ forms.select(state={ multiple: true }) }} {{ button({ label: "Dolor"}) }}
+</div>
+<div class="fd-form__item fd-has-display-flex">
+    {{ forms.select(size="compact", state={ multiple: true }) }} {{ button({ label: "Dolor"}) }}
 </div>
 
 <h3>input[type=radio]</h3>


### PR DESCRIPTION
Closes sap/fundamental#1034

Adds a compact version of the `select[multiple]` and `textarea` elements. Also improves much for the `core/forms` SASS file and completes conversion of forms to CSS variables.

#### Test

* http://localhost:4000/components/form.html#textarea
* http://localhost:3030/form

#### Changelog

**New**

* Adds compact `textarea` styles and example
* Adds compact version of `select[multiple]` element
* Adds semantic and form base color CSS vars to `core/root`
* Converts all forms colors to CSS vars. IE 11 support must be opt-ed in by toggling the `$fd-support-css-var-fallback` flag
* Checkbox indeterminate state plus disabled and checked state added to test page


**Changed**

* Fixes #1097 where checked and unchecked elements can be disabled and `is-disabled` is incorrectly applied to the label element
* Moves forms mixins into the `core/forms.scss` files since they were not used outside of that file. The `mixins/forms` file remains but will be deprecated
* Checkbox Nunjucks template accepts `state.indeterminate` value



**Removed**

* Removes duplicated and unused CSS rules
