### PR TITLE
Feature/1102 logo height

### DIFF
--- a/docs/_includes/demo-page-components/shell-header.html
+++ b/docs/_includes/demo-page-components/shell-header.html
@@ -1,7 +1,7 @@
 <div class="fd-shell__header">
    <div class="fd-shellbar">
       <div class="fd-shellbar__group fd-shellbar__group--start">
-         <a href="#" class="fd-shellbar__logo"><img src="//unpkg.com/fiori-fundamentals/dist/images/sap-logo.png" srcset="//unpkg.com/fiori-fundamentals/dist/images/sap-logo@2x.png 1x, //unpkg.com/fiori-fundamentals/dist/images/sap-logo@3x.png 2x, //unpkg.com/fiori-fundamentals/dist/images/sap-logo@4x.png 3x" alt="SAP"></a>
+         <a href="#" class="fd-shellbar__logo"><img src="//unpkg.com/fiori-fundamentals/dist/images/sap-logo.png" srcset="//unpkg.com/fiori-fundamentals/dist/images/sap-logo@2x.png 1x, //unpkg.com/fiori-fundamentals/dist/images/sap-logo@3x.png 2x, //unpkg.com/fiori-fundamentals/dist/images/sap-logo@4x.png 3x" width="48" height="24" alt="SAP"></a>
          <div class="fd-shellbar__product">
            <div class="fd-product-menu">
              <div class="fd-popover fd-popover--right">

--- a/docs/pages/components/shellbar.md
+++ b/docs/pages/components/shellbar.md
@@ -58,7 +58,7 @@ This example shows the minimum shellbar for a single application product with on
 {% capture app-layout %}
 <div class="fd-shellbar">
   <div class="fd-shellbar__group fd-shellbar__group--start">
-    <a href="#" class="fd-shellbar__logo"><img src="//unpkg.com/fiori-fundamentals/dist/images/sap-logo.png" srcset="//unpkg.com/fiori-fundamentals/dist/images/sap-logo@2x.png 1x, //unpkg.com/fiori-fundamentals/dist/images/sap-logo@3x.png 2x, //unpkg.com/fiori-fundamentals/dist/images/sap-logo@4x.png 3x" alt="SAP"></a>
+    <a href="#" class="fd-shellbar__logo"><img src="//unpkg.com/fiori-fundamentals/dist/images/sap-logo.png" srcset="//unpkg.com/fiori-fundamentals/dist/images/sap-logo@2x.png 1x, //unpkg.com/fiori-fundamentals/dist/images/sap-logo@3x.png 2x, //unpkg.com/fiori-fundamentals/dist/images/sap-logo@4x.png 3x" width="48" height="24" alt="SAP"></a>
     <div class="fd-shellbar__product">
       <span class="fd-shellbar__title">Corporate Portal</span>
     </div>
@@ -100,7 +100,7 @@ This example includes the product menu for navigating to applications within the
 {% capture app-layout %}
 <div class="fd-shellbar">
   <div class="fd-shellbar__group fd-shellbar__group--start">
-    <a href="#" class="fd-shellbar__logo"><img src="//unpkg.com/fiori-fundamentals/dist/images/sap-logo.png" srcset="//unpkg.com/fiori-fundamentals/dist/images/sap-logo@2x.png 1x, //unpkg.com/fiori-fundamentals/dist/images/sap-logo@3x.png 2x, //unpkg.com/fiori-fundamentals/dist/images/sap-logo@4x.png 3x" alt="SAP"></a>
+    <a href="#" class="fd-shellbar__logo"><img src="//unpkg.com/fiori-fundamentals/dist/images/sap-logo.png" srcset="//unpkg.com/fiori-fundamentals/dist/images/sap-logo@2x.png 1x, //unpkg.com/fiori-fundamentals/dist/images/sap-logo@3x.png 2x, //unpkg.com/fiori-fundamentals/dist/images/sap-logo@4x.png 3x" width="48" height="24" alt="SAP"></a>
     <div class="fd-shellbar__product">
       <div class="fd-product-menu">
         <div class="fd-popover fd-popover--right">
@@ -187,7 +187,7 @@ When a product has multiple links, the product links should collapse into an ove
 {% capture app-layout %}
 <div class="fd-shellbar">
   <div class="fd-shellbar__group fd-shellbar__group--start">
-    <a href="#" class="fd-shellbar__logo"><img src="//unpkg.com/fiori-fundamentals/dist/images/sap-logo.png" srcset="//unpkg.com/fiori-fundamentals/dist/images/sap-logo@2x.png 1x, //unpkg.com/fiori-fundamentals/dist/images/sap-logo@3x.png 2x, //unpkg.com/fiori-fundamentals/dist/images/sap-logo@4x.png 3x" alt="SAP"></a>
+    <a href="#" class="fd-shellbar__logo"><img src="//unpkg.com/fiori-fundamentals/dist/images/sap-logo.png" srcset="//unpkg.com/fiori-fundamentals/dist/images/sap-logo@2x.png 1x, //unpkg.com/fiori-fundamentals/dist/images/sap-logo@3x.png 2x, //unpkg.com/fiori-fundamentals/dist/images/sap-logo@4x.png 3x" width="48" height="24" alt="SAP"></a>
     <div class="fd-shellbar__product">
       <span class="fd-shellbar__title">Corporate Portal</span>
     </div>
@@ -276,7 +276,7 @@ When a product has multiple links, the product links should collapse into an ove
 ## Product Switcher and CoPilot
 {: .docs-header-h2}
 
-This example shows an application with CoPilot and integration with other products.
+This example shows an application with CoPilot, integration with other products, and a customized logo.
 
 {% capture app-layout %}
 

--- a/scss/components/shellbar.scss
+++ b/scss/components/shellbar.scss
@@ -4,7 +4,6 @@
 
 // Brand
 $fd-shellbar-logo-height: 24px !default;
-$fd-shellbar-logo-max-height: 28px !default;
 $fd-shellbar-logo-width: 48px !default;
 $fd-shellbar-logo-max-width: 60px !default;
 $fd-shellbar-logo-background-image-url: "data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0MTIuMzggMjA0Ij48ZGVmcz48c3R5bGU+LmNscy0xLC5jbHMtMntmaWxsLXJ1bGU6ZXZlbm9kZH0uY2xzLTF7ZmlsbDp1cmwoI2xpbmVhci1ncmFkaWVudCl9LmNscy0ye2ZpbGw6I2ZmZn08L3N0eWxlPjxsaW5lYXJHcmFkaWVudCBpZD0ibGluZWFyLWdyYWRpZW50IiB4MT0iMjA2LjE5IiB4Mj0iMjA2LjE5IiB5Mj0iMjA0IiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSI+PHN0b3Agb2Zmc2V0PSIwIiBzdG9wLWNvbG9yPSIjMDBiOGYxIi8+PHN0b3Agb2Zmc2V0PSIuMDIiIHN0b3AtY29sb3I9IiMwMWI2ZjAiLz48c3RvcCBvZmZzZXQ9Ii4zMSIgc3RvcC1jb2xvcj0iIzBkOTBkOSIvPjxzdG9wIG9mZnNldD0iLjU4IiBzdG9wLWNvbG9yPSIjMTc3NWM4Ii8+PHN0b3Agb2Zmc2V0PSIuODIiIHN0b3AtY29sb3I9IiMxYzY1YmYiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiMxZTVmYmIiLz48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48dGl0bGU+U0FQX2dyYWRfUl9zY3JuX1plaWNoZW5mbMOkY2hlIDE8L3RpdGxlPjxwYXRoIGNsYXNzPSJjbHMtMSIgZD0iTTAgMjA0aDIwOC40MUw0MTIuMzggMEgwdjIwNCIvPjxwYXRoIGNsYXNzPSJjbHMtMiIgZD0iTTI0NC43MyAzOC4zNmgtNDAuNnY5Ni41MmwtMzUuNDYtOTYuNTVoLTM1LjE2bC0zMC4yNyA4MC43MkMxMDAgOTguNyA3OSA5MS42NyA2Mi40IDg2LjQgNTEuNDYgODIuODkgMzkuODUgNzcuNzIgNDAgNzJjLjA5LTQuNjggNi4yMy05IDE4LjM4LTguMzggOC4xNy40MyAxNS4zNyAxLjA5IDI5LjcxIDhsMTQuMS0yNC41NUM4OS4wNiA0MC40MiA3MSAzNi4yMSA1Ni4xNyAzNi4xOWgtLjA5Yy0xNy4yOCAwLTMxLjY4IDUuNi00MC42IDE0LjgzQTM0LjIzIDM0LjIzIDAgMCAwIDUuNzcgNzQuN0M1LjU0IDg3LjE1IDEwLjExIDk2IDE5LjcxIDEwM2M4LjEgNS45NCAxOC40NiA5Ljc5IDI3LjYgMTIuNjIgMTEuMjcgMy40OSAyMC40NyA2LjUzIDIwLjM2IDEzQTkuNTcgOS41NyAwIDAgMSA2NSAxMzVjLTIuODEgMi45LTcuMTMgNC0xMy4wOSA0LjEtMTEuNDkuMjQtMjAtMS41Ni0zMy42MS05LjU5TDUuNzcgMTU0LjQyYTkzLjc3IDkzLjc3IDAgMCAwIDQ2IDEyLjIyaDIuMTFjMTQuMjQtLjI1IDI1Ljc0LTQuMzEgMzQuOTItMTEuNzEuNTMtLjQxIDEtLjg0IDEuNDktMS4yOGwtNC4xMiAxMC44NUgxMjNsNi4xOS0xOC44MmE2Ny40NiA2Ny40NiAwIDAgMCAyMS42OCAzLjQzIDY4LjMzIDY4LjMzIDAgMCAwIDIxLjE2LTMuMjVsNiAxOC42NGg2MC4xNHYtMzloMTMuMTFjMzEuNzEgMCA1MC40Ni0xNi4xNSA1MC40Ni00My4yIDAtMzAuMTEtMTguMjItNDMuOTQtNTcuMDEtNDMuOTR6TTE1MC45MSAxMjFhMzYuOTMgMzYuOTMgMCAwIDEtMTMtMi4yOGwxMi44Ny00MC41OWguMjJsMTIuNjUgNDAuNzFhMzguNSAzOC41IDAgMCAxLTEyLjc0IDIuMTZ6bTk2LjItMjMuMzNoLTguOTRWNjQuOTFoOC45NGMxMS45MyAwIDIxLjQ0IDQgMjEuNDQgMTYuMTQgMCAxMi42LTkuNTEgMTYuNTctMjEuNDQgMTYuNTciLz48L3N2Zz4=" !default;
@@ -70,8 +69,12 @@ $block: #{$fd-namespace}-shellbar;
         vertical-align: middle;
     }
     &__logo {
-      height: $fd-shellbar-logo-height;
-      max-height: $fd-shellbar-logo-height;
+      //outline: solid 1px red;
+      //height: $fd-shellbar-logo-height;
+      display: flex;
+      align-items: center;
+      vertical-align: middle;
+      max-height: fd-space(10);
       background-repeat: no-repeat;
       background-size: contain;
       //the logo inside the menu (show only on small screen)
@@ -87,13 +90,14 @@ $block: #{$fd-namespace}-shellbar;
       }
       img,
       svg {
-        max-height: $fd-shellbar-logo-height;
+        max-height: fd-space(10);
         width: auto;
+        display: block;
       }
       &--image-replaced {
         background-image: url(#{$fd-shellbar-logo-background-image-url});
         width: $fd-shellbar-logo-width;
-        max-width: $fd-shellbar-logo-max-width;
+        height: $fd-shellbar-logo-height;
       }
     }
     &__product {

--- a/test/templates/shellbar/component.njk
+++ b/test/templates/shellbar/component.njk
@@ -140,7 +140,7 @@ shellbar:
     {%- if logo.src %}
     {%- set comma = joiner() %}
       <img src="{{ logo.src }}"{% if logo.srcset %} srcset="{% for item in logo.srcset %}{{ comma() -}} {{ item }} {{ loop.index }}x
-      {%- endfor %}"{% endif %} alt="">
+      {%- endfor %}"{% endif %}{% if logo.width %} width="{{logo.width}}"{% endif %}{% if logo.height %} height="{{logo.height}}"{% endif %} alt="">
     {%- endif %}
     {%- if logo.svg %}
       {{ logo.svg }}

--- a/test/templates/shellbar/index.njk
+++ b/test/templates/shellbar/index.njk
@@ -95,7 +95,8 @@
     {% set airlines = {
         name: "Airlines",
         logo: {
-            src: "static/logos/airlines-logo.png"
+            src: "static/logos/airlines-logo.png",
+            height: 30
         }
     } %}
     {% set example %}
@@ -116,7 +117,9 @@
         name: "SAP",
         logo: {
             src: "static/logos/sap-logo.png",
-            srcset: ["static/logos/sap-logo@2x.png","static/logos/sap-logo@3x.png","static/logos/sap-logo@4x.png"]
+            srcset: ["static/logos/sap-logo@2x.png","static/logos/sap-logo@3x.png","static/logos/sap-logo@4x.png"],
+            width: 48,
+            height: 24
         }
     } %}
     {% set example %}
@@ -138,6 +141,24 @@
         name: "Fiori",
         logo: {
             svg: '<svg width="286" height="143" viewBox="0 0 286 143" xmlns="http://www.w3.org/2000/svg"><defs><linearGradient x1="-91.234%" y1="50%" x2="98.574%" y2="50%" id="a"><stop stop-color="#32B79D" stop-opacity=".59" offset="0%"/><stop stop-color="#33EAFF" stop-opacity=".59" offset="35.525%"/><stop stop-color="#7FCAFF" stop-opacity=".59" offset="73.603%"/><stop stop-color="#84A2FF" stop-opacity=".59" offset="100%"/></linearGradient></defs><g transform="translate(-19)" fill="url(#a)" fill-rule="evenodd"><path d="M114.232.963h190.464c0 16.966-13.754 30.72-30.72 30.72H83.512c0-16.966 13.754-30.72 30.72-30.72zM80.44 56.259h116.736c0 16.966-13.754 30.72-30.72 30.72H49.72c0-16.966 13.754-30.72 30.72-30.72zM49.72 111.555h18.432c0 16.966-13.754 30.72-30.72 30.72H19c0-16.966 13.754-30.72 30.72-30.72z"/></g></svg>'
+        }
+    } %}
+    {% set example %}
+      {{ shellbar(
+        product={ title: "Portal" },
+        copilot=false,
+        actions=false,
+        user=false,
+        switcher=false,
+        search=false,
+        brand=fiori
+      )}}
+    {% endset %}
+    {{ format(example) }}
+    {% set fiori = {
+        name: "SAP",
+        logo: {
+            svg: '<svg width="48" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 412.38 204"><defs><style>.cls-1,.cls-2{fill-rule:evenodd}.cls-1{fill:url(#linear-gradient)}.cls-2{fill:#fff}</style><linearGradient id="linear-gradient" x1="206.19" x2="206.19" y2="204" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#00b8f1"/><stop offset=".02" stop-color="#01b6f0"/><stop offset=".31" stop-color="#0d90d9"/><stop offset=".58" stop-color="#1775c8"/><stop offset=".82" stop-color="#1c65bf"/><stop offset="1" stop-color="#1e5fbb"/></linearGradient></defs><title>SAP_grad_R_scrn_Zeichenfläche 1</title><path class="cls-1" d="M0 204h208.41L412.38 0H0v204"/><path class="cls-2" d="M244.73 38.36h-40.6v96.52l-35.46-96.55h-35.16l-30.27 80.72C100 98.7 79 91.67 62.4 86.4 51.46 82.89 39.85 77.72 40 72c.09-4.68 6.23-9 18.38-8.38 8.17.43 15.37 1.09 29.71 8l14.1-24.55C89.06 40.42 71 36.21 56.17 36.19h-.09c-17.28 0-31.68 5.6-40.6 14.83A34.23 34.23 0 0 0 5.77 74.7C5.54 87.15 10.11 96 19.71 103c8.1 5.94 18.46 9.79 27.6 12.62 11.27 3.49 20.47 6.53 20.36 13A9.57 9.57 0 0 1 65 135c-2.81 2.9-7.13 4-13.09 4.1-11.49.24-20-1.56-33.61-9.59L5.77 154.42a93.77 93.77 0 0 0 46 12.22h2.11c14.24-.25 25.74-4.31 34.92-11.71.53-.41 1-.84 1.49-1.28l-4.12 10.85H123l6.19-18.82a67.46 67.46 0 0 0 21.68 3.43 68.33 68.33 0 0 0 21.16-3.25l6 18.64h60.14v-39h13.11c31.71 0 50.46-16.15 50.46-43.2 0-30.11-18.22-43.94-57.01-43.94zM150.91 121a36.93 36.93 0 0 1-13-2.28l12.87-40.59h.22l12.65 40.71a38.5 38.5 0 0 1-12.74 2.16zm96.2-23.33h-8.94V64.91h8.94c11.93 0 21.44 4 21.44 16.14 0 12.6-9.51 16.57-21.44 16.57"/></svg>'
         }
     } %}
     {% set example %}


### PR DESCRIPTION
Closes sap/fundamental#1102

Allows for taller logos in shellbar up to 40px.

> NOTE: Any logo that needs to be smaller than the 40px max **MUST** include the height and width attributes with the SVG or IMG or the logo must be sized exactly.  This includes the SAP logo at 24px tall.

#### Test

* http://localhost:3030/shellbar
* http://localhost:4000/components/shellbar.html

#### Changelog

**New**

* Nunjucks template now accepts `logo.width` and `logo.height` values

**Changed**

* Adds width and height attributes to `img` logos
* Increases the max-height from 24px to 40px

**Removed**

* N/A
