### PR TITLE
CSS var fallbacks for emphasized button on hover - #1111

### DIFF
--- a/scss/components/button.scss
+++ b/scss/components/button.scss
@@ -144,6 +144,9 @@ $block: #{$fd-namespace}-button;
     @include fd-hover {
       --fd-button-background-color: var(--fd-color-action-hover);
       --fd-button-color: var(--fd-color-action-2);
+      @include fd-var-color("color", fd-color("action", 2));
+      @include fd-var-color("background-color", fd-color-state("hover","action"));
+
       @include fd-disabled {
         --fd-button-background-color: var(--fd-color-action-1);
         --fd-button-color: var(--fd-color-action-2);


### PR DESCRIPTION
Closes sap/fundamental https://github.com/SAP/fundamental/issues/1111

I added color and background-color fallbacks for the older browsers but I can't test it tbh.

@xak Can you please check if this is what you want? 