### PR TITLE
#1054 confines fd-selected mixin, adds combo state mixins

### DIFF
--- a/scss/components/button.scss
+++ b/scss/components/button.scss
@@ -97,7 +97,7 @@ $block: #{$fd-namespace}-button;
             @include fd-var-color("background-color", fd-color("background",2));
           }
       }
-      @include fd-selected {
+      @include fd-active-pressed-selected {
         --fd-button-background-color: var(--fd-color-action-selected);
         --fd-button-color: var(--fd-color-action-2);
         @include fd-var-color("color", fd-color("action", 2));
@@ -231,7 +231,7 @@ $block: #{$fd-namespace}-button;
         @include fd-var-color("background-color", transparent);
       }
     }
-    @include fd-selected {
+    @include fd-active-pressed-selected {
       --fd-button-background-color: var(--fd-color-action-selected);
       --fd-button-color: var(--fd-color-action-2);
       @include fd-var-color("color", fd-color("action", 2));
@@ -263,7 +263,7 @@ $block: #{$fd-namespace}-button;
           --fd-button-color: var(--fd-color-status-4);
         }
       }
-      @include fd-selected {
+      @include fd-active-pressed-selected {
         --fd-button-background-color: var(--fd-color-status-4);
         --fd-button-color: var(--fd-color-action-2);
         @include fd-var-color("color", fd-color("action", 2));
@@ -279,7 +279,7 @@ $block: #{$fd-namespace}-button;
           --fd-button-color: var(--fd-color-status-3);
         }
       }
-      @include fd-selected {
+      @include fd-active-pressed-selected {
         --fd-button-background-color: var(--fd-color-status-3);
         --fd-button-color: var(--fd-color-action-2);
         @include fd-var-color("color", fd-color("action", 2));
@@ -295,7 +295,7 @@ $block: #{$fd-namespace}-button;
           --fd-button-color: var(--fd-color-status-1);
         }
       }
-      @include fd-selected {
+      @include fd-active-pressed-selected {
         --fd-button-background-color: var(--fd-color-status-1);
         --fd-button-color: var(--fd-color-action-2);
         @include fd-var-color("color", fd-color("action", 2));
@@ -311,7 +311,7 @@ $block: #{$fd-namespace}-button;
           --fd-button-color: var(--fd-color-status-2);
         }
       }
-      @include fd-selected {
+      @include fd-active-pressed-selected {
         --fd-button-background-color: var(--fd-color-status-2);
         --fd-button-color: var(--fd-color-action-2);
         @include fd-var-color("color", fd-color("action", 2));
@@ -329,7 +329,7 @@ $block: #{$fd-namespace}-button;
     @include fd-hover {
       --fd-button-color: var(--fd-color-action-2);
     }
-    @include fd-selected {
+    @include fd-active-pressed-selected {
       --fd-button-color: var(--fd-color-action-2);
     }
   }
@@ -349,7 +349,7 @@ $block: #{$fd-namespace}-button;
         @include fd-var-color("color", fd-color("status",4));
       }
     }
-    @include fd-selected {
+    @include fd-active-pressed-selected {
       --fd-button-background-color: var(--fd-color-status-4);
       @include fd-var-color("background-color", fd-color("status", 4));
       @include fd-var-color("color", fd-color("action", 2));
@@ -369,7 +369,7 @@ $block: #{$fd-namespace}-button;
         @include fd-var-color("color", fd-color("status",1));
       }
     }
-    @include fd-selected {
+    @include fd-active-pressed-selected {
       --fd-button-background-color: var(--fd-color-status-1);
       @include fd-var-color("background-color", fd-color("status", 1));
     }
@@ -388,7 +388,7 @@ $block: #{$fd-namespace}-button;
         @include fd-var-color("color", fd-color("status",2));
       }
     }
-    @include fd-selected {
+    @include fd-active-pressed-selected {
       --fd-button-background-color: var(--fd-color-status-2);
       @include fd-var-color("background-color", fd-color("status", 2));
     }
@@ -407,7 +407,7 @@ $block: #{$fd-namespace}-button;
         @include fd-var-color("color", fd-color("status",3));
       }
     }
-    @include fd-selected {
+    @include fd-active-pressed-selected {
         --fd-button-background-color: var(--fd-color-status-3);
         @include fd-var-color("background-color", fd-color("status", 3));
     }
@@ -447,7 +447,7 @@ $block: #{$fd-namespace}-button;
         @include fd-var-color("background-color", transparent);
       }
     }
-    @include fd-selected {
+    @include fd-active-pressed-selected {
       --fd-button-color: var(--fd-color-shell-2);
       --fd-button-border-color: transparent;
       --fd-button-background-color: hsl(217, 21%, 21%);
@@ -562,7 +562,7 @@ $block: #{$fd-namespace}-button;
           --fd-button-color: var(--fd-color-action-1);
         }
       }
-      @include fd-selected {
+      @include fd-active-pressed-selected {
         --fd-button-background-color: var(--fd-color-action-selected);
         --fd-button-color: var(--fd-color-action-2);
       }
@@ -578,7 +578,7 @@ $block: #{$fd-namespace}-button;
             --fd-button-color: var(--fd-color-status-3);
           }
         }
-        @include fd-selected {
+        @include fd-active-pressed-selected {
           --fd-button-background-color: var(--fd-color-status-3);
           --fd-button-color: var(--fd-color-action-2);
         }
@@ -596,7 +596,7 @@ $block: #{$fd-namespace}-button;
             --fd-button-color: var(--fd-color-status-1);
           }
         }
-        @include fd-selected {
+        @include fd-active-pressed-selected {
           --fd-button-background-color: var(--fd-color-status-1);
           --fd-button-color: var(--fd-color-action-2);
         }
@@ -608,7 +608,7 @@ $block: #{$fd-namespace}-button;
       --fd-button-border-color: var(--fd-color-neutral-3);
       --fd-button-background-color: var(--fd-color-neutral-1);
       @include fd-focus(--fd-color-neutral-3);
-      @include fd-selected {
+      @include fd-active-pressed-selected {
         --fd-button-background-color: var(--fd-color-action-selected);
         --fd-button-color: var(--fd-color-action-2);
       }

--- a/scss/components/shellbar.scss
+++ b/scss/components/shellbar.scss
@@ -219,19 +219,6 @@ $block: #{$fd-namespace}-shellbar;
         }
     }
 
-    .#{$fd-namespace}-user-menu {
-        &--control {
-            border-radius: $fd-border-radius;
-
-            @include fd-hover {
-              background-color: hsl(217, 21%, 25%);
-            }
-            @include fd-selected {
-              background-color: hsl(217, 21%, 21%);
-            }
-        }
-    }
-
     @include fd-screen(s) {
         padding: $fd-shellbar-outer-spacing-tb $fd-shellbar-outer-spacing-lr-small;
     }

--- a/scss/core/elements.scss
+++ b/scss/core/elements.scss
@@ -84,7 +84,7 @@ a {
     @include fd-hover {
       color: fd-color-state("hover", "action");
     }
-    @include fd-selected {
+    @include fd-active-pressed-selected {
         color: fd-color-state("selected", "action");
         outline: none;
     }

--- a/scss/mixins/_mixins.scss
+++ b/scss/mixins/_mixins.scss
@@ -213,7 +213,7 @@
     color: map-get($fd-colors-action-states, "visited");
     border-bottom-color: map-get($fd-colors-action-states, "visited");
   }
-  @include fd-selected {
+  @include fd-active-pressed-selected {
       color: map-get($fd-colors-action-states, "selected");
       border-bottom-color: map-get($fd-colors-action-states, "selected");
   }

--- a/scss/mixins/_states.scss
+++ b/scss/mixins/_states.scss
@@ -1,4 +1,26 @@
 @import "./../functions/color";
+// These mixins ensure that all state selectors — ARIA, pseudos, `is` fallbacks — get applied properly.
+
+// ACTIVE state (press and hold)
+@mixin fd-active {
+  &:active,
+  &.is-active {
+    @content;
+  }
+}
+
+// DISABLED state (not editable, not focusable, not submitted with `form`)
+@mixin fd-disabled {
+  &[aria-disabled="true"],
+  &.is-disabled,
+  &:disabled {
+    @content;
+  }
+}
+
+// FOCUS state (tab onto, click into)
+// override params $shadow-var, $shadow-value
+// `.is-focus` is for demo purposes
 @mixin fd-focus($shadow-var: --fd-color-action-focus, $shadow-value: fd-color-state("hover","action")) {
   &:focus,
   &.is-focus {
@@ -10,9 +32,45 @@
   }
 }
 
+// HOVER state (mouseover)
+// `.is-hover` is for demo purposes
+@mixin fd-hover {
+  &:hover,
+  .is-hover {
+    @content;
+  }
+}
+
+// PRESSED state (toggle with full press-and-release)
+@mixin fd-pressed {
+  &[aria-pressed="true"],
+  &.is-pressed {
+    @content;
+  }
+}
+
+// READONLY state (not editable, focusable, submitted with `form`)
+@mixin fd-readonly {
+  &[aria-readonly="true"],
+  &.is-readonly,
+  &[readonly] {
+    @content;
+  }
+}
+
+// SELECTED state (current item in nav)
 @mixin fd-selected {
-  &:active,
-  &.is-active,
+  &[aria-selected="true"],
+  &.is-selected {
+    @content;
+  }
+}
+
+// COMBO MIXINS
+// convenience mixins for various elements like buttons
+
+// PRESSED and SELECTED state
+@mixin fd-pressed-selected {
   &[aria-selected="true"],
   &.is-selected,
   &[aria-pressed="true"],
@@ -21,16 +79,14 @@
   }
 }
 
-@mixin fd-disabled {
-  &[aria-disabled="true"],
-  &.is-disabled,
-  &:disabled {
-    @content;
-  }
-}
-
-@mixin fd-hover {
-  &:hover {
+// ACTIVE, PRESSED and SELECTED state
+@mixin fd-active-pressed-selected {
+  &:active,
+  &.is-active,
+  &[aria-selected="true"],
+  &.is-selected,
+  &[aria-pressed="true"],
+  &.is-pressed {
     @content;
   }
 }


### PR DESCRIPTION
Closes sap/fundamental#1054

Removes `pressed` and `active` selectors from the `fd-selected` mixin, implements new combo mixin `fd-active-pressed-selected`

#### Test

* http://localhost:3030/table

#### Changelog

**New**

* Use the combo mixin `fd-active-pressed-selected` for buttons and elements that can have multiple states but with the same styling
* The `fd-selected` can be used for table rows and list items that only need to support the `selected` state

**Changed**

* Fixes bug with table row states

**Removed**

* N/A
