### PR TITLE
Feature/1096 menu separator

### DIFF
--- a/docs/pages/components/menu.md
+++ b/docs/pages/components/menu.md
@@ -28,7 +28,29 @@ The basic stucture of a menu.
 
 {% include display-component.html component=default-menu %}
 
-## Menu w/ Group
+## Menu list with separated items
+Use a modifier on the list element to add separators between the items.
+
+{% capture default-menuwgroup %}
+<nav class="fd-menu">
+    <ul class="fd-menu__list fd-menu__list--separated">
+      <li><a href="#" class="fd-menu__item">Option 1</a>
+    </li>
+      <li><a href="#" class="fd-menu__item">Option 2</a>
+    </li>
+      <li><a href="#" class="fd-menu__item">Option 3</a>
+    </li>
+      <li><a href="#" class="fd-menu__item">Option 4</a>
+    </li>
+    </ul>
+</nav>
+{% endcapture %}
+
+{% include display-component.html component=default-menuwgroup %}
+
+
+
+## Menu with group headers
 You can optionally add hierarchy to menus by grouping sub-menus and adding headers.
 
 {% capture default-menuwgroup %}
@@ -51,26 +73,9 @@ You can optionally add hierarchy to menus by grouping sub-menus and adding heade
 
 {% include display-component.html component=default-menuwgroup %}
 
-## Menu w/ Separator
 
-{% capture default-menuwgroup %}
-<nav class="fd-menu">
-    <ul class="fd-menu__list fd-menu__separator">
-      <li><a href="#" class="fd-menu__item">Option 1</a>
-    </li>
-      <li><a href="#" class="fd-menu__item">Option 2</a>
-    </li>
-      <li><a href="#" class="fd-menu__item">Option 3</a>
-    </li>
-      <li><a href="#" class="fd-menu__item">Option 4</a>
-    </li>
-    </ul>
-</nav>
-{% endcapture %}
-
-{% include display-component.html component=default-menuwgroup %}
-
-## Menu w/ addon before
+## Menu with an addon container
+This is an additional container that can be used for an icon or checkbox before the meni item text.
 
 {% capture default-menuwgroup %}
 <nav class="fd-menu fd-menu--addon-before">

--- a/scss/components/menu.scss
+++ b/scss/components/menu.scss
@@ -20,6 +20,7 @@ $block: #{$fd-namespace}-menu;
     $fd-menu-item-padding: fd-space(3) fd-space(4) !default;
     $fd-menu-item-color--disabled: fd-color("text", 2);
     $fd-menu-item-separator-color: fd-color("neutral", 2);
+    --fd-menu-item-separator-color: var(--fd-color-neutral-2);
 
     //BLOCK BASE *******************************************
     //set all BLOCK reset and baseline styles
@@ -35,20 +36,25 @@ $block: #{$fd-namespace}-menu;
       list-style: none;
       margin-bottom: 0;
     }
+    &__group {
+      padding-left: 0;
+    }
     &__list {
       margin: 0;
       padding: 0;
       list-style: none;
       //modified with separator border
       @at-root {
-        .#{$block}--separated & > * {
+        &--separated {
+          & > *,
+          .#{$block}__list > * {
             border-top-style: solid;
             border-top-width: 1px;
-            border-top-color: $fd-menu-item-separator-color;
-            border-top-color: green;
+            @include fd-var-color("border-top-color", $fd-menu-item-separator-color, --fd-menu-item-separator-color);
             &:first-child {
               border-top-width: 0;
             }
+          }
         }
       }
     }

--- a/scss/components/menu.scss
+++ b/scss/components/menu.scss
@@ -30,15 +30,6 @@ $block: #{$fd-namespace}-menu;
     padding-top: fd-space(base);
     padding-bottom: fd-space(base);
 
-    &__separator>li {
-      border: none;
-      border-top: 1px solid $fd-menu-item-separator-color;
-      margin: 0;
-    }
-
-    &__separator>li:first-child {
-      border-top: 0;
-    }
     &__group,
     &__list {
       list-style: none;
@@ -48,6 +39,18 @@ $block: #{$fd-namespace}-menu;
       margin: 0;
       padding: 0;
       list-style: none;
+      //modified with separator border
+      @at-root {
+        .#{$block}--separated & > * {
+            border-top-style: solid;
+            border-top-width: 1px;
+            border-top-color: $fd-menu-item-separator-color;
+            border-top-color: green;
+            &:first-child {
+              border-top-width: 0;
+            }
+        }
+      }
     }
     &__title {
       display: block;
@@ -69,7 +72,6 @@ $block: #{$fd-namespace}-menu;
       > .fd-checkbox {
         margin: 0 10px 0 0;
       }
-
       @include fd-hover {
         color: $fd-menu-item-color--hover;
         background-color: $fd-menu-item-background-color--hover;

--- a/test/templates/menu/component.njk
+++ b/test/templates/menu/component.njk
@@ -19,7 +19,7 @@ menu:
       {{ optgroup(item)| indent(2) }}
     {%- else %}
       {%- if loop.first %}
-    <ul class="fd-menu__list {{ 'fd-menu__separator' if properties.separator }}">
+    <ul class="fd-menu__list">
       {%- endif %}
       {{ option(item, properties) }}
       {%- if loop.last %}

--- a/test/templates/menu/component.njk
+++ b/test/templates/menu/component.njk
@@ -16,10 +16,10 @@ menu:
     {%- if not loop.first %}
     </ul>
       {%- endif %}
-      {{ optgroup(item)| indent(2) }}
+      {{ optgroup(item, properties.separator)| indent(2) }}
     {%- else %}
       {%- if loop.first %}
-    <ul class="fd-menu__list">
+    <ul class="fd-menu__list{{ 'separated' | modifier('menu__list') if properties.separator }}">
       {%- endif %}
       {{ option(item, properties) }}
       {%- if loop.last %}
@@ -31,7 +31,6 @@ menu:
 {%- endmacro %}
 
 {%- macro option(item={}, properties={}) -%}
-
     <li>
         {%- if properties.addon_before -%}
         <div class="fd-menu__addon-before">
@@ -42,13 +41,12 @@ menu:
         {%- endif -%}
         <a role="button" class="fd-menu__item">{{ item.label }}</a>
     </li>
-
 {%- endmacro %}
 
-{% macro optgroup(properties={}) -%}
+{% macro optgroup(properties={}, separated=false) -%}
     <div class="fd-menu__group">
       <h1 class="fd-menu__title">{{ properties.label }}</h1>
-      <ul class="fd-menu__list">
+      <ul class="fd-menu__list{{ 'separated' | modifier('menu__list') if separated }}">
           {%- for item in properties.items %}
             {{ option(item) }}
           {%- endfor %}

--- a/test/templates/menu/data.json
+++ b/test/templates/menu/data.json
@@ -9,7 +9,8 @@
             { "label": "Option 2" },
             { "label": "Option 3" },
             { "label": "Option 4" }
-        ]
+        ],
+        "separator": false
     },
     "modifier": {
         "block": ""

--- a/test/templates/menu/index.njk
+++ b/test/templates/menu/index.njk
@@ -23,7 +23,7 @@
       { "label": "Option 2"},
       { "label": "Separator"},
       { "label": "Option 3" },
-      {  "label": "Group Header",
+      { "label": "Group Header",
         "items": [
             { "label": "Option 4" },
             { "label": "Option 5" },
@@ -46,9 +46,9 @@
       { "label": "Option 2"},
       { "label": "Option 3" },
       { "label": "Option 4" }
-    ],
-    separator: true
-  })
+    ]
+  },
+  modifier=["separated"])
 }}
 {% endset %}
 {{ format(example) }}

--- a/test/templates/menu/index.njk
+++ b/test/templates/menu/index.njk
@@ -7,7 +7,38 @@
 
 {% block content %}
 
-<h1>defatult menu</h1>
+
+{#
+<h1>** Test with non-UL and LI content **</h1>
+<nav class="fd-menu">
+  <div class="fd-menu__list fd-menu__list--separated">
+    <a href="#" class="fd-menu__item">Option 1</a>
+    <a href="#" class="fd-menu__item">Option 2</a>
+    <a href="#" class="fd-menu__item">Option 3</a>
+    <a href="#" class="fd-menu__item">Option 4</a>
+  </div>
+</nav>
+<br>
+<h1>** Test with nested UL **</h1>
+<nav class="fd-menu">
+  <ul class="fd-menu__list fd-menu__list--separated">
+    <li class="fd-menu__item">Option 1</li>
+    <li class="fd-menu__item">Option 2</li>
+    <li class="fd-menu__item">Option 3</li>
+    <li class="fd-menu__group">
+      <h1 class="fd-menu__title">Group Header</h1>
+      <ul class="fd-menu__list">
+        <li class="fd-menu__item">Option 3</li>
+        <li class="fd-menu__item">Option 3</li>
+        <li class="fd-menu__item">Option 3</li>
+      </ul>
+    </li>
+  </ul>
+</nav>
+#}
+
+
+<h1>default</h1>
 {% set example %}
 {{ menu(properties=data.properties) }}
 {% endset %}
@@ -15,15 +46,14 @@
 
 <br><br><br>
 
-<h1>menu with groups</h1>
+<h2>grouped</h2>
 {% set example %}
 {{ menu(properties={
   items: [
       { "label": "Option 1" },
       { "label": "Option 2"},
-      { "label": "Separator"},
       { "label": "Option 3" },
-      { "label": "Group Header",
+      {  "label": "Group Header",
         "items": [
             { "label": "Option 4" },
             { "label": "Option 5" },
@@ -36,9 +66,10 @@
 {% endset %}
 {{ format(example) }}
 
+
 <br><br><br>
 
-<h1>menu with separators</h1>
+<h1>menu list with separators</h1>
 {% set example %}
 {{ menu(properties={
   items: [
@@ -46,14 +77,43 @@
       { "label": "Option 2"},
       { "label": "Option 3" },
       { "label": "Option 4" }
-    ]
-  },
-  modifier=["separated"])
+    ],
+    separator: true
+  })
 }}
 {% endset %}
 {{ format(example) }}
 
 <br><br><br>
+
+<h2>separated and grouped</h2>
+{% set example %}
+{{ menu(properties={
+  items: [
+      {
+        "label": "Group Header",
+        "items": [
+            { "label": "Option 1" },
+            { "label": "Option 2" },
+            { "label": "Option 3" }
+        ]
+      },
+      {
+        "label": "Group Header",
+        "items": [
+            { "label": "Option 1" },
+            { "label": "Option 2" },
+            { "label": "Option 3" }
+        ]
+      }
+    ],
+    separator: true
+  })
+}}
+{% endset %}
+{{ format(example) }}
+
+
 
 <h1>menu with icons</h1>
 {% set example %}


### PR DESCRIPTION
Closes sap/fundamental#1096

Use modifier `--separated` on menu list elements to show separators between the menu list items

#### Test

* http://localhost:3030/menu
* http://localhost:4000/components/menu.html

#### Changelog

**New**

* Adds `fd-menu__list--separated`

**Changed**

* N/A

**Removed**

* N/A
