### PR TITLE
#1122 implements CSS vars with fallbacks for layout modules

### DIFF
--- a/scss/layout/app.scss
+++ b/scss/layout/app.scss
@@ -10,6 +10,7 @@
 $block: #{$fd-namespace}-app;
 .#{$block} {
   $fd-app-navigation-background-color: fd-color("background", 2) !default;
+  --fd-app-navigation-background-color: var(--fd-color-background-2);
   $fd-app-navigation-height: fd-space(13) !default;
   $fd-app-sidebar-width: 250px !default;
   position: relative;
@@ -20,7 +21,7 @@ $block: #{$fd-namespace}-app;
     align-content: flex-start;
   }
   &__navigation {
-    background-color: $fd-app-navigation-background-color;
+    @include fd-var-color("background-color", $fd-app-navigation-background-color, --fd-color-background-2);
     height: $fd-app-navigation-height;
     max-height: $fd-app-navigation-height;
     display: flex;

--- a/scss/layout/overlay.scss
+++ b/scss/layout/overlay.scss
@@ -6,28 +6,24 @@
 */
 $block: #{$fd-namespace}-overlay;
 .#{$block} {
-
-  $fd-overlay-background-color: rgba(#4A505C,0.3) !default;
+  $fd-overlay-background-color: rgba(#4A505C, 0.3) !default;
+  --fd-overlay-background-color: #{$fd-overlay-background-color};
   $fd-overlay-alert-top-margin: fd-space(7);
-
   position: fixed;
   display: flex;
   top: 0;
   align-items: center;
   justify-content: center;
   z-index: map-get($fd-z-index-levels, "top");
-
   &[aria-hidden="true"] {
       display: none;
   }
-
-  &--modal{
-    background: $fd-overlay-background-color;
+  &--modal {
+    @include fd-var-color("background-color", $fd-overlay-background-color, --fd-overlay-background-color);
     height: 100vh;
     width: 100vw;
   }
-
-  &--alert{
+  &--alert {
     position: fixed;
     left: 50%;
     transform: translate(-50%, 0);

--- a/scss/layout/page.scss
+++ b/scss/layout/page.scss
@@ -1,29 +1,30 @@
 @import "./../settings";
 @import "./../functions";
 @import "./../mixins";
-
+//$fd-support-css-var-fallback: true;
 $block: #{$fd-namespace}-page;
 .#{$block} {
   $fd-page-background-color: $fd-background-color !default;
+  --fd-page-background-color: var(--fd-color-background-2);
   $fd-page-header-padding-x: $fd-padding--ui !default;
   $fd-page-header-padding-y: 0 !default;
   --fd-page-header-padding-x: var(--fd-padding-ui);
-
   $fd-page-header-height: auto !default;
   $fd-page-header-border-color: fd-color("neutral", 3) !default;
+  --fd-page-header-border-color: var(--fd-color-neutral-3);
   $fd-page-header-border-width: 0 !default;
   $fd-page-header-background-color: transparent !default;
-
+  --fd-page-header-background-color: #{$fd-page-header-background-color};
   display: flex;
   flex-direction: column;
   min-height: 100%;
   width: 100%;
-  background-color: $fd-page-background-color;
+  @include fd-var-color("background-color", $fd-page-background-color, --fd-page-background-color);
   &__header {
     border-style: solid;
     border-width: $fd-page-header-border-width;
-    border-color: $fd-page-header-border-color;
-    background-color: $fd-page-header-background-color;
+    @include fd-var-color("border-color", $fd-page-header-border-color, --fd-page-header-border-color);
+    @include fd-var-color("background-color", $fd-page-header-background-color, --fd-page-header-background-color);
     min-height: $fd-page-header-height;
     padding: $fd-page-header-padding-y $fd-page-header-padding-x;
     padding: $fd-page-header-padding-y var(--fd-page-header-padding-x);

--- a/scss/layout/panel-grid.scss
+++ b/scss/layout/panel-grid.scss
@@ -7,15 +7,14 @@
 $block: #{$fd-namespace}-panel-grid;
 .#{$block} {
   //VARS
-  $fd-panel-grid-border-color: fd-color("background") !default;
+
   $fd-panel-grid-items-per-row: 3 !default;
   $fd-panel-grid-box-shadow: 0 5px 20px 0 rgba(fd-color("text"), 0.08) !default;
-  $fd-panel-grid-border-color: fd-color("background") !default;
+
   display: flex;
   flex-wrap: wrap;
   flex-direction: column;
   position: relative;
-
 
   @include fd-screen(s) {
     /* flex fallback */
@@ -24,7 +23,7 @@ $block: #{$fd-namespace}-panel-grid;
     flex-wrap: wrap;
     display: grid;
     grid-template-columns: repeat(#{$fd-panel-grid-items-per-row}, 1fr);
-    grid-gap: var(--fd-width-gutter);
+    @include fd-var-size("grid-gap", $fd-width--gutter, --fd-width-gutter);
 
     //BLOCK MODIFIERS ************
     @each $n in 1, 2, 3, 4, 5, 6 {

--- a/scss/layout/panel.scss
+++ b/scss/layout/panel.scss
@@ -11,41 +11,62 @@
 
 $block: #{$fd-namespace}-panel;
 .#{$block} {
-    $fd-panel-padding: fd-space("s") fd-space("reg") !default;
-    $fd-panel-border: none !default;
     $fd-panel-background-color: fd-color("background",2) !default;
-    $fd-panel-box-shadow: 0 5px 20px 0 rgba(fd-color("text"), 0.08) !default;
+    --fd-panel-background-color: var(--fd-color-background-2);
+
+    $fd-panel-padding: fd-space("s") fd-space("reg") !default;
+    $fd-panel-border-width: 0 !default;
+    $fd-panel-border-color: transparent !default;
+    --fd-panel-border-color: #{$fd-panel-border-color};
+
+    $fd-panel-box-shadow-color: rgba(fd-color("text"), 0.08) !default;
+    --fd-panel-box-shadow-color: var(--fd-color-neutral-2);
+
     $fd-panel-border-radius: $fd-border-radius !default;
 
     $fd-panel-header-border-color: fd-color("neutral",2) !default;
+    --fd-panel-header-border-color: var(--fd-color-neutral-2);
+
     $fd-panel-title-color: fd-color("text") !default;
+    --fd-panel-title-color: var(--fd-color-text-1);
+
     $fd-panel-filters-padding: fd-space(3) fd-space("reg") !default;
     $fd-panel-filters-border-color: $fd-panel-header-border-color !default;
+    --fd-panel-filters-border-color: var(--fd-panel-header-border-color);
     $fd-panel-footer-padding: fd-space(4) fd-space("reg") !default;
     $fd-panel-footer-border-color: $fd-panel-header-border-color !default;
+    --fd-panel-footer-border-color: var(--fd-panel-header-border-color);
 
     //anim
     $fd-panel-fiters-transition-params: 0.15s ease-in !default;
 
     @include fd-clearfix;
-    background-color: $fd-panel-background-color;
-    box-shadow: $fd-panel-box-shadow;
+    @include fd-var-color("background-color", $fd-panel-background-color, --fd-panel-background-color);
     border-radius: $fd-border-radius;
-    border: $fd-panel-border;
+    border-style: solid;
+    border-width: $fd-panel-border-width;
+    @include fd-var-color("border-color", $fd-panel-border-color, --fd-panel-border-color);
+
+    @if $fd-support-css-var-fallback {
+      box-shadow: 0 5px 20px 0 $fd-panel-box-shadow-color;
+    }
+    box-shadow: 0 5px 20px 0 var(--fd-panel-box-shadow-color);
     &__header {
         min-height: fd-space(10);
         display: flex;
         align-items: center;
-        border-bottom: solid 1px $fd-panel-header-border-color;
+        border-bottom-style: solid;
+        border-bottom-width: 1px;
+        @include fd-var-color("border-bottom-color", $fd-panel-header-border-color, --fd-panel-header-border-color);
         padding: $fd-panel-padding;
         @include fd-type("-1");
-        color: fd-color("text", 3);
+        @include fd-var-color("color", fd-color("text", 3), --fd-color-text-3);
     }
     &__title {
         @include fd-type("1");
         flex: 1;
         margin-bottom: 0;
-        color: $fd-panel-title-color;
+        @include fd-var-color("color", $fd-panel-title-color, --fd-panel-title-color);
     }
     &__description {
         margin-top: fd-space(base);
@@ -57,7 +78,10 @@ $block: #{$fd-namespace}-panel;
     }
     &__filters {
         padding: $fd-panel-filters-padding;
-        border-bottom: solid 1px $fd-panel-filters-border-color;
+        //border-bottom: solid 1px $fd-panel-filters-border-color;
+        border-bottom-style: solid;
+        border-bottom-width: 1px;
+        @include fd-var-color("border-bottom-color", $fd-panel-filters-border-color, --fd-panel-filters-border-color);
         transition: all $fd-panel-fiters-transition-params;
         &.is-hidden,
         &[aria-hidden="true"] {
@@ -78,6 +102,8 @@ $block: #{$fd-namespace}-panel;
         display: flex;
         justify-content: center;
         padding: $fd-panel-footer-padding;
-        border-top: solid 1px $fd-panel-footer-border-color;
+        border-top-style: solid;
+        border-top-width: 1px;
+        @include fd-var-color("border-top-color", $fd-panel-footer-border-color, --fd-panel-footer-border-color);
     }
 }

--- a/scss/layout/section.scss
+++ b/scss/layout/section.scss
@@ -10,7 +10,7 @@
 */
 $block: #{$fd-namespace}-section;
 .#{$block} {
-    $fd-section-border-color: fd-color("neutral", 3) !default;
+
     $fd-section-padding: $fd-padding--ui !default;
     --fd-section-padding-x: var(--fd-padding-ui);
 
@@ -18,6 +18,7 @@ $block: #{$fd-namespace}-section;
     $fd-section-padding--bottom: fd-space("reg") !default;
     $fd-section-header-margin--bottom: fd-space("reg") !default;
     $fd-section-title-color: fd-color("text",2) !default;
+    --fd-section-title-color: var(--fd-color-text-2);
 
     @include fd-clearfix;
     padding: $fd-section-padding--top $fd-section-padding $fd-section-padding--bottom;
@@ -46,7 +47,7 @@ $block: #{$fd-namespace}-section;
     }
     &__title {
         @include fd-type("4");
-        color: $fd-section-title-color;
+        @include fd-var-color("color", $fd-section-title-color, --fd-section-title-color);
         flex: 1;
         margin-bottom: 0;
     }

--- a/scss/layout/shell.scss
+++ b/scss/layout/shell.scss
@@ -11,7 +11,6 @@
 */
 
 $fd-shell-header-fixed: true !default;
-$fd-shell-footer-background-color: fd-color("background", 1) !default;
 $fd-shell-footer-height: 40px !default;
 
 $block: #{$fd-namespace}-shell;
@@ -43,7 +42,7 @@ $block: #{$fd-namespace}-shell;
     }
   }
   &__header {
-    background-color: $fd-shell-header-background-color;
+    @include fd-var-color("background-color", $fd-shell-header-background-color, --fd-color-shell-1);
     position: absolute;
     z-index: map-get($fd-z-index-levels, "first");
     width: 100%;


### PR DESCRIPTION
Closes sap/fundamental#1122

Implements CSS vars with fallbacks for layout modules

#### Test

There should be no discernable visual changes.

* http://localhost:3030/pages/shell
* http://localhost:3030/pages/app
* http://localhost:3030/pages/modal-placement
* http://localhost:3030/pages/page
* http://localhost:3030/pages/section
* http://localhost:3030/pages/page
* http://localhost:3030/panel
* http://localhost:3030/panel-grid


#### Changelog

**New**

* N/A

**Changed**

* To enable the fallbacks, the flag `$fd-support-css-var-fallback` must be set to true in a custom SASS build.

**Removed**

* N/A
