### PR TITLE
#1126 updates css vars for indicators

### DIFF
--- a/scss/components/badge.scss
+++ b/scss/components/badge.scss
@@ -6,15 +6,23 @@
 */
 $block: #{$fd-namespace}-badge;
 .#{$block} {
-  $fd-badge-background-color: fd-color("neutral", 1) !default;
+  $fd-badge-color: fd-color("text", 3);
+  $fd-badge-background-color: transparent !default;
+  $fd-badge-background-color--default: fd-color("neutral", 1) !default;
   $fd-badge-background-color--success: fd-color-state("positive") !default;
   $fd-badge-background-color--warning: fd-color-state("alert") !default;
   $fd-badge-background-color--error: fd-color-state("negative") !default;
 
+  --fd-badge-color: var(--fd-color-text-3);
+  --fd-badge-background-color: transparent;
+
   @include fd-reset;
   @include fd-type("-1");
   @include fd-weight("bold");
-  color: fd-color("text", 3);
+
+  @include fd-var-color("color", $fd-badge-color, --fd-badge-color);
+  @include fd-var-color("background-color", $fd-badge-background-color, --fd-badge-background-color);
+
   text-transform: uppercase;
   line-height: fd-space(4);
   vertical-align: middle;
@@ -24,29 +32,37 @@ $block: #{$fd-namespace}-badge;
   border-radius: $fd-border-radius;
   border-width: 1px;
   border-style: solid;
+
   &--pill {
     border-radius: fd-space(6)/2;
   }
   &--filled {
-    background-color: $fd-badge-background-color;
+    --fd-badge-background-color: var(--fd-color-neutral-1);
+    @include fd-var-color("background-color", $fd-badge-background-color--default);
     border: none;
     &.#{$block}--success {
-      background-color: $fd-badge-background-color--success;
+      --fd-badge-background-color: var(--fd-color-background-positive);
+      @include fd-var-color("background-color", $fd-badge-background-color--success);
     }
     &.#{$block}--warning {
-      background-color: $fd-badge-background-color--warning;
+      --fd-badge-background-color: var(--fd-color-background-alert);
+      @include fd-var-color("background-color", $fd-badge-background-color--warning);
     }
     &.#{$block}--error {
-      background-color: $fd-badge-background-color--error;
+      --fd-badge-background-color: var(--fd-color-background-negative);
+      @include fd-var-color("background-color", $fd-badge-background-color--error);
     }
   }
   &--success {
-    color: $fd-color--success;
+    --fd-badge-color: var(--fd-color-positive);
+    @include fd-var-color("color", $fd-color--success);
   }
   &--warning {
-    color: $fd-color--warning;
+    --fd-badge-color: var(--fd-color-alert);
+    @include fd-var-color("color", $fd-color--warning);
   }
   &--error {
-    color: $fd-color--error;
+    --fd-badge-color: var(--fd-color-negative);
+    @include fd-var-color("color", $fd-color--error);
   }
 }

--- a/scss/components/counter.scss
+++ b/scss/components/counter.scss
@@ -17,8 +17,6 @@ $block: #{$fd-namespace}-counter;
   --fd-counter-background-color: var(--fd-color-status-4);
 
   border-radius: $fd-counter-radius;
-  //background: $fd-counter-background;
-  //color: $fd-counter-color;
   @include fd-var-color("color", $fd-counter-color, --fd-counter-color);
   @include fd-var-color("background-color", $fd-counter-background, --fd-counter-background-color);
   font-size: $fd-counter-font-size;

--- a/scss/components/counter.scss
+++ b/scss/components/counter.scss
@@ -13,23 +13,26 @@ $block: #{$fd-namespace}-counter;
   $fd-counter-color: fd-color("text", 5) !default;
   $fd-counter-font-size: 0.785714285714286em !default;
 
+  --fd-counter-color: var(--fd-color-text-5);
+  --fd-counter-background-color: var(--fd-color-status-4);
+
   border-radius: $fd-counter-radius;
-  background: $fd-counter-background;
-  color: $fd-counter-color;
+  //background: $fd-counter-background;
+  //color: $fd-counter-color;
+  @include fd-var-color("color", $fd-counter-color, --fd-counter-color);
+  @include fd-var-color("background-color", $fd-counter-background, --fd-counter-background-color);
   font-size: $fd-counter-font-size;
   line-height: 1;
   display: inline-block;
   text-align: center;
   padding: fd-space(1);
   &--notification {
-    background-color: fd-color("status", 3);
+    --fd-counter-background-color: var(--fd-color-status-3);
+    @include fd-var-color("background-color", fd-color("status", 3));
     position: absolute;
     transform: translate(-40%, -50%);
-    @at-root {
-      [dir="rtl"] &,
-      &[dir="rtl"] {
-        transform: translate(40%, -50%);
-      }
+    @include fd-rtl {
+      transform: translate(40%, -50%);
     }
   }
 }

--- a/scss/components/identifier.scss
+++ b/scss/components/identifier.scss
@@ -19,7 +19,10 @@ $block: #{$fd-namespace}-identifier;
       xxl: $fd-const-ratio * 28 //112px
     ) !default;
     $fd-identifier-border-radius: $fd-border-radius !default;
-    $fd-identifier-background: fd-color("text", 3) !default;
+    $fd-identifier-color: fd-color("text", 5) !default;
+    $fd-identifier-background: fd-color("status", 4) !default;
+    --fd-identifier-color: var(--fd-color-text-5);
+    --fd-identifier-background-color: var(--fd-color-status-4);
 
     //BLOCK BASE *******************************************
     @at-root {
@@ -32,8 +35,8 @@ $block: #{$fd-namespace}-identifier;
         background-size: cover;
         background-position: 50%;
         border-radius: $fd-identifier-border-radius;
-        background-color: $fd-identifier-background;
-        color: fd-color("text", 5);
+        @include fd-var-color("background-color", $fd-identifier-background, --fd-identifier-background-color);
+        @include fd-var-color("color", $fd-identifier-color, --fd-identifier-color);
       }
     }
     //BLOCK MODIFIERS ************
@@ -108,8 +111,9 @@ $block: #{$fd-namespace}-identifier;
     }
     //background
     &--transparent {
-      background-color: transparent;
-      color: $fd-color;
+      --fd-identifier-color: var(--fd-color-text-1);
+      --fd-identifier-background-color: transparent;
+      @include fd-var-color("color", $fd-color);
+      @include fd-var-color("background-color", transparent);
     }
-
 }

--- a/scss/components/inline-help.scss
+++ b/scss/components/inline-help.scss
@@ -8,8 +8,9 @@
 $block: #{$fd-namespace}-inline-help;
 .#{$block} {
     //LOCAL VARS
-    $fd-tooltip-content-background-color: fd-color(background, 2) !default;
-    $fd-tooltip-content-color: fd-color(text, 2) !default;
+    $fd-tooltip-icon-background-color: fd-color("status", 4) !default;
+    $fd-tooltip-content-background-color: fd-color("background", 2) !default;
+    $fd-tooltip-content-color: fd-color("text", 2) !default;
     $fd-tooltip-padding: fd-space(xs) !default;
     $fd-tooltip-arrow-offset: fd-space(2) !default ;
     $fd-tooltip-arrow-width: $fd-tooltip-arrow-offset !default;
@@ -17,6 +18,12 @@ $block: #{$fd-namespace}-inline-help;
     $fd-tooltip-transition-params: $fd-animation--speed ease-in !default;
     $fd-tooltip-min-width: 350px !default;
     $fd-tooltip-box-shadow: drop-shadow(rgba(0,0,0,0.1) 0 2px 10px) !default;
+
+    --fd-inline-help-color: var(--fd-color-text-1);
+    --fd-inline-help-background-color: var(--fd-color-background-2);
+    --fd-inline-help-icon-color: var(--fd-color-text-5);
+    --fd-inline-help-icon-background-color: var(--fd-color-status-4);
+    --triangle-color: var(--fd-color-status-4);
 
     //BLOCK BASE *******************************************
     @include fd-reset;
@@ -33,20 +40,20 @@ $block: #{$fd-namespace}-inline-help;
         font-style: normal;
         position: absolute;
         left: 0;
-        color: fd-color("text", 5);
         border-radius: 50%;
-        background-color: fd-color(text, 3);
+        @include fd-var-color("color", fd-color("text", 5), --fd-inline-help-icon-color);
+        @include fd-var-color("background-color", $fd-tooltip-icon-background-color, --fd-inline-help-icon-background-color);
         text-align: center;
     }
 
     //ELEMENTS *******************************************
     &__content {
         @include fd-type("-1");
-        background: $fd-tooltip-content-background-color;
+        @include fd-var-color("background-color", $fd-tooltip-content-background-color, --fd-inline-help-background-color);
         padding: $fd-tooltip-padding;
         display: block;
         position: absolute;
-        color: $fd-tooltip-content-color;
+        @include fd-var-color("color", $fd-tooltip-content-color, --fd-inline-help-color);
         top: $fd-tooltip-padding * 2.5;
         right: -$fd-tooltip-padding;
         min-width: $fd-tooltip-min-width;
@@ -56,18 +63,19 @@ $block: #{$fd-namespace}-inline-help;
         border-radius: 5px;
         visibility: hidden;
         opacity: 0;
-        border: 1px fd-color('neutral', 4) solid;
-
+        border-width: 1px;
+        border-style: solid;
+        @include fd-var-color("border-color", fd-color("status", 4), --fd-color-status-4);
         filter: $fd-tooltip-box-shadow;
         &::before {
-            @include triangle(13px 8px, fd-color('neutral', 4), up);
+            @include triangle(13px 8px, fd-color("status", 4), up, --fd-color-status-4);
             content: "";
             position: absolute;
             top: -($fd-tooltip-arrow-offset);
             right: $fd-tooltip-arrow-offset * 1.25;
         }
         &::after {
-            @include triangle(13px 8px, fd-color('background', 2), up);
+            @include triangle(13px 8px, fd-color("background", 2), up, --fd-color-background-2);
             content: "";
             position: absolute;
             top: -($fd-tooltip-arrow-offset - 2);

--- a/scss/components/inline-help.scss
+++ b/scss/components/inline-help.scss
@@ -23,7 +23,6 @@ $block: #{$fd-namespace}-inline-help;
     --fd-inline-help-background-color: var(--fd-color-background-2);
     --fd-inline-help-icon-color: var(--fd-color-text-5);
     --fd-inline-help-icon-background-color: var(--fd-color-status-4);
-    --triangle-color: var(--fd-color-status-4);
 
     //BLOCK BASE *******************************************
     @include fd-reset;

--- a/scss/components/label.scss
+++ b/scss/components/label.scss
@@ -7,10 +7,15 @@
 $block: #{$fd-namespace}-label;
 
 .#{$block} {
+
+  $fd-label-color: fd-color("text", 3);
+  --fd-label-color: var(--fd-color-text-3);
+
   @include fd-reset;
   @include fd-type("-1");
   @include fd-weight("bold");
-  color: fd-color("text", 3);
+  @include fd-var-color("color", $fd-label-color, --fd-label-color);
+
   text-transform: uppercase;
   line-height: fd-space(6);
   vertical-align: middle;
@@ -19,14 +24,15 @@ $block: #{$fd-namespace}-label;
   padding-right: fd-space(2);
 
   &--success {
-    color: $fd-color--success;
+    --fd-label-color: var(--fd-color-positive);
+    @include fd-var-color("color", $fd-color--success);
   }
-
   &--warning {
-    color: $fd-color--warning;
+    --fd-label-color: var(--fd-color-alert);
+    @include fd-var-color("color", $fd-color--warning);
   }
-
   &--error {
-    color: $fd-color--error;
+    --fd-label-color: var(--fd-color-negative);
+    @include fd-var-color("color", $fd-color--error);
   }
 }

--- a/scss/components/popover.scss
+++ b/scss/components/popover.scss
@@ -8,7 +8,7 @@ $fd-popover-top-position-noarrow: 100% !default;
 $fd-popover-left-position:        0 !default;
 $fd-popover-border:               solid 1px $fd-forms-border-color !default;
 $fd-popover-z-index:              map-get($fd-z-index-levels, "second") !default;
-$fd-popover-background-color:     fd-color(background, 2) !default;
+$fd-popover-background-color:     fd-color("background", 2) !default;
 $fd-popover-box-shadow:           0 0 1px 0 rgba(218 ,222, 230, .50), 0 2px 8px 0 rgba(0, 8, 26, .20) !default;
 
 $fd-popover-arrow-top-back:       -9px !default;
@@ -48,7 +48,7 @@ $block: #{$fd-namespace}-popover;
 
       @include fd-rtl {
         left: auto;
-        right: -3px;  
+        right: -3px;
 
         &::before {
           right: $fd-popover-arrow-x-offset;
@@ -56,19 +56,18 @@ $block: #{$fd-namespace}-popover;
         &::after {
           right: $fd-popover-arrow-x-offset;
         }
-      }   
-            
+      }
+
       &::before {
-        @include triangle(13px 8px, white, up);
+        @include triangle(13px 8px, $fd-popover-background-color, up, --fd-color-background-2);
         content: "";
         position: absolute;
         top: $fd-popover-arrow-top-front;
         left: $fd-popover-arrow-x-offset;
         z-index: $fd-popover-z-index + 2;
       }
-
       &::after {
-        @include triangle(13px 8px, fd-color('neutral', 4), up);
+        @include triangle(13px 8px, fd-color("neutral", 4), up, --fd-color-neutral-4);
         content: "";
         position: absolute;
         top: $fd-popover-arrow-top-back;
@@ -82,13 +81,13 @@ $block: #{$fd-namespace}-popover;
 
         @include fd-rtl {
           right: -3px;
-          left: auto;     
-          
+          left: auto;
+
           &::before,
           &::after {
             right: $fd-popover-arrow-right;
             left: unset;
-          }             
+          }
         }
 
         &::before,
@@ -104,13 +103,13 @@ $block: #{$fd-namespace}-popover;
 
         @include fd-rtl {
           right: auto;
-          left: -3px;     
-          
+          left: -3px;
+
           &::before,
           &::after {
             left: $fd-popover-arrow-right;
             right: unset;
-          }             
+          }
         }
 
         &::before,
@@ -136,6 +135,6 @@ $block: #{$fd-namespace}-popover;
           opacity: 0;
           visibility: hidden;
           transform: translateY($fd-popover-transition-distance);
-      }   
+      }
     }
 }

--- a/scss/components/product-menu.scss
+++ b/scss/components/product-menu.scss
@@ -18,9 +18,6 @@ $block: #{$fd-namespace}-product-menu;
     padding-right: 20px;
     padding-left: 0;
     &::after {
-      @if $fd-support-css-var-fallback {
-        border-top-color: fd-color("shell", 2);
-      }
       @include triangle(10px 5px, fd-color("shell", 2), down, --fd-color-shell-2);
       content: "";
       position: absolute;

--- a/scss/components/product-menu.scss
+++ b/scss/components/product-menu.scss
@@ -21,7 +21,7 @@ $block: #{$fd-namespace}-product-menu;
       @if $fd-support-css-var-fallback {
         border-top-color: fd-color("shell", 2);
       }
-      @include triangle(10px 5px, var(--fd-color-shell-2), down);
+      @include triangle(10px 5px, fd-color("shell", 2), down, --fd-color-shell-2);
       content: "";
       position: absolute;
       top: calc(50% - 2.5px);

--- a/scss/components/spinner.scss
+++ b/scss/components/spinner.scss
@@ -12,11 +12,12 @@ $block: #{$fd-namespace}-spinner;
 .#{$block} {
     //LOCAL VARS (set all themeable properties, always include !default)
     $fd-spinner-background-color: fd-color(action, 1) !default;
+    --fd-spinner-background-color: var(--fd-color-action-1);
     $fd-spinner-height: 40px !default;
     $fd-spinner-width--bar: 5px !default;
     $fd-spinner-width--gutter: 3px !default;
     $fd-spinner-animation-speed: 1s !default;
-    $fd-spinner-backdrop-background-color: rgba(fd-color(background, 1),0.95) !default;
+    $fd-spinner-backdrop-opacity: 0.95 !default;
 
     //BLOCK BASE *******************************************
     @include fd-reset;
@@ -43,7 +44,8 @@ $block: #{$fd-namespace}-spinner;
             min-height: $_height;
             &::before {
                 position: absolute;
-                background-color: $fd-spinner-backdrop-background-color;
+                @include fd-var-color("background-color", fd-color("background", 1), --fd-color-background-1);
+                opacity: $fd-spinner-backdrop-opacity;
                 top: 0;
                 right: 0;
                 bottom: 0;
@@ -66,7 +68,7 @@ $block: #{$fd-namespace}-spinner;
         position: relative;
         width: $fd-spinner-width--bar;
         height: 100%;
-        background-color: $fd-spinner-background-color;
+        @include fd-var-color("background-color", $fd-spinner-background-color, --fd-spinner-background-color);
     }
     div {
         &::before,
@@ -75,8 +77,7 @@ $block: #{$fd-namespace}-spinner;
             position: absolute;
             width: $fd-spinner-width--bar;
             height: 100%;
-            background-color: $fd-spinner-background-color;
-        }
+            @include fd-var-color("background-color", $fd-spinner-background-color, --fd-spinner-background-color);        }
         &::before {
             left: $fd-spinner-width--bar + $fd-spinner-width--gutter;
         }

--- a/scss/components/status-label.scss
+++ b/scss/components/status-label.scss
@@ -7,15 +7,57 @@
 */
 
 $block: #{$fd-namespace}-status-label;
+$fd-status-label-color: fd-color("text", 2);
+$fd-status-label-icon-size: fd-space(4) !default;
+%fd-status-icon {
+  padding-left: fd-space(5);
+  &::before {
+    position: absolute;
+    z-index: map-get($fd-z-index-levels, "first");
+    background-repeat: no-repeat;
+    content: "";
+    line-height: 1;
+  }
+  &::after {
+    width: $fd-status-label-icon-size;
+    height: $fd-status-label-icon-size;
+    display: inline-block;
+    content: "";
+    line-height: 1;
+    border-radius: 50%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    @include fd-var-color("background-color", $fd-status-label-color, --fd-status-label-icon-background-color);
+  }
+  @include fd-rtl {
+    padding-left: initial;
+    padding-right: fd-space(5);
+    &:before {
+      left: initial;
+    }
+    &:after {
+      left: initial;
+      right: 0;
+    }
+  }
+}
+
 
 .#{$block} {
 
+
+  --fd-status-label-color: var(--fd-color-text-2);
+  --fd-status-label-icon-background-color: var(--fd-color-text-2);
+
     //LOCAL VARS (set all themeable properties, always include !default)
-    $fd-status-label-icon-size: fd-space(4);
+
     $fd-status-indicator-available: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA2IDUuOSIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgNiA1Ljk7IiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPHN0eWxlIHR5cGU9InRleHQvY3NzIj4KCS5zdDB7ZmlsbDojRkZGRkZGO30KPC9zdHlsZT4KPHBhdGggY2xhc3M9InN0MCIgZD0iTTIuNywzLjJsMS40LTIuOEM0LjQsMCw1LTAuMSw1LjUsMC4xYzAuNCwwLjMsMC42LDAuOCwwLjQsMS4ybC0yLDRDMy42LDUuOSwzLDYuMSwyLjYsNS44CgljLTAuMSwwLTAuMi0wLjEtMC4zLTAuMmwtMi0yYy0wLjQtMC40LTAuNC0xLDAtMS40YzAuNC0wLjQsMS0wLjQsMS40LDBsMCwwTDIuNywzLjJ6Ii8+Cjwvc3ZnPg==" !default;
     $fd-status-indicator-away:"data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA1IDUiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDUgNTsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiNGRkZGRkY7fQo8L3N0eWxlPgo8cGF0aCBjbGFzcz0ic3QwIiBkPSJNMSw1QzAuNCw1LDAsNC42LDAsNFYxYzAtMC42LDAuNC0xLDEtMXMxLDAuNCwxLDF2MmgyYzAuNiwwLDEsMC40LDEsMVM0LjYsNSw0LDVIMXoiLz4KPC9zdmc+" !default;
     $fd-status-indicator-busy:"data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA0IDQiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDQgNDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiNGRkZGRkY7fQo8L3N0eWxlPgo8cGF0aCBjbGFzcz0ic3QwIiBkPSJNNCwyYzAsMS4xLTAuOSwyLTIsMlMwLDMuMSwwLDJzMC45LTIsMi0yUzQsMC45LDQsMiIvPgo8L3N2Zz4=" !default;
     $fd-status-indicator-offline:"data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA3LjkgNy45IiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA3LjkgNy45OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+Cgkuc3Qwe2ZpbGw6I0ZGRkZGRjt9Cjwvc3R5bGU+CjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik03LjksNGMwLDIuMi0xLjgsNC00LDRTMCw2LjIsMCw0czEuOC00LDQtNFM3LjksMS44LDcuOSw0Ii8+Cjwvc3ZnPg==" !default;
+
+
 
     @mixin fd-status-icon-bg {
         width: $fd-status-label-icon-size;
@@ -28,7 +70,6 @@ $block: #{$fd-namespace}-status-label;
         top: 0;
         left: 0;
     }
-
     @mixin fd-status-icon{
         position: absolute;
         z-index: map-get($fd-z-index-levels, "first");
@@ -40,7 +81,12 @@ $block: #{$fd-namespace}-status-label;
     //BLOCK BASE *******************************************
     position: relative;
     @include fd-reset;
-    color: fd-color("text", 2);
+
+    @include fd-var-color("color", $fd-status-label-color, --fd-status-label-color);
+
+
+
+
 
     &::before{
         vertical-align: -8%;
@@ -50,114 +96,92 @@ $block: #{$fd-namespace}-status-label;
     }
 
     //BLOCK MODIFIERS ************
-    &--available,
-    &--away,
-    &--busy,
-    &--offline {
-        padding-left: fd-space(5);
-
-        @include fd-rtl {    
-            padding-left: initial;
-            padding-right: fd-space(5);
-
-            &:before {
-                left: initial;
-            }
-
-            &:after {
-                left: initial;
-                right: 0;
-            }            
-        }
-    }
-
-    &--available {
-        &:before{
-            @include fd-status-icon;
-            width: 7px;
-            height: 7px;
-            top: 4px;
-            left: 4px;
-            background-image: url($fd-status-indicator-available);
-        }
-        &:after{
-            @include fd-status-icon-bg;
-            background-color: $fd-color--success;
-        }
-    }
-
-    &--away {
-        &:before{
-            @include fd-status-icon;
-            width: 6px;
-            height: 6px;
-            top: 4px;
-            left: 6px;
-            background-image: url($fd-status-indicator-away);
-        }
-        &:after{
-            @include fd-status-icon-bg;
-            background-color: $fd-color--warning;
-        }
-    }
-
-    &--busy {
-        &:before{
-            @include fd-status-icon;
-            width: 4px;
-            height: 4px;
-            top: 6px;
-            left: 6px;
-            background-image: url($fd-status-indicator-busy);
-        }
-        &:after{
-            @include fd-status-icon-bg;
-            background-color: $fd-color--error;
-        }
-
-        @include fd-rtl {    
-            &:before {
-                right: 6px;
-            }        
-        }
-    }
-
-    &--offline {
-        &:before{
-            @include fd-status-icon;
-            width: 8px;
-            height: 8px;
-            top: 4px;
-            left: 4px;
-            background-image: url($fd-status-indicator-offline);
-        }
-        &:after{
-            @include fd-status-icon-bg;
-            background-color: fd-color("text", 2);
-        }
-    }
-
     &--success {
-        color: $fd-color--success;
+      --fd-status-label-color: var(--fd-color-positive);
+      @include fd-var-color("color", $fd-color--success);
     }
-
     &--warning {
-        color: $fd-color--warning;
+      --fd-status-label-color: var(--fd-color-alert);
+      @include fd-var-color("color", $fd-color--warning);
     }
-
     &--error {
-        color: $fd-color--error;
+      --fd-status-label-color: var(--fd-color-negative);
+      @include fd-var-color("color", $fd-color--error);
     }
-
-    &--available,
-    &--away,
-    &--offline {
-        @include fd-rtl {    
-            &:before {
-                right: 4px;
-            }
+    &--available {
+      --fd-status-label-icon-background-color: var(--fd-color-positive);
+      @extend %fd-status-icon;
+      &:before{
+        width: 7px;
+        height: 7px;
+        top: 4px;
+        left: 4px;
+        background-image: url($fd-status-indicator-available);
+      }
+      &:after{
+        @include fd-var-color("background-color", $fd-color--success);
+      }
+      @include fd-rtl {
+        &:before {
+          right: 4px;
         }
+      }
     }
+    &--away {
+      --fd-status-label-icon-background-color: var(--fd-color-alert);
+      @extend %fd-status-icon;
+      &:before{
+        width: 6px;
+        height: 6px;
+        top: 4px;
+        left: 6px;
+        background-image: url($fd-status-indicator-away);
+      }
+      &:after{
+        @include fd-var-color("background-color", $fd-color--warning);
+      }
+      @include fd-rtl {
+        &:before {
+          right: 4px;
+        }
+      }
+    }
+    &--busy {
+      --fd-status-label-icon-background-color: var(--fd-color-negative);
+      @extend %fd-status-icon;
+      &:before{
+        width: 4px;
+        height: 4px;
+        top: 6px;
+        left: 6px;
+        background-image: url($fd-status-indicator-busy);
+      }
+      &:after{
+        @include fd-var-color("background-color", $fd-color--error);
+      }
+      @include fd-rtl {
+        &:before {
+          right: 6px;
+        }
+      }
+    }
+    &--offline {
+      @extend %fd-status-icon;
+      &:before{
+          width: 8px;
+          height: 8px;
+          top: 4px;
+          left: 4px;
+          background-image: url($fd-status-indicator-offline);
+      }
+      &:after{
+        //default
+      }
+      @include fd-rtl {
+        &:before {
+          right: 4px;
+        }
+      }
+    }
+
 }
-
-

--- a/scss/components/token.scss
+++ b/scss/components/token.scss
@@ -14,12 +14,16 @@ $block: #{$fd-namespace}-token;
 .#{$block} {
     //LOCAL VARS (set all themeable properties, always include !default)
     $fd-token-border-color: transparent !default;
+    $fd-token-color: fd-color("text", 2) !default;
     $fd-token-background-color: fd-color-state("selected") !default;
+    --fd-token-color: var(--fd-color-text-2);
+    --fd-token-background-color: var(--fd-color-background-selected);
+    --fd-token-border-color: transparent;
 
     @include fd-reset;
     @include fd-type("-1");
-    color: fd-color("text", 2);
-    background-color: $fd-token-background-color;
+    @include fd-var-color("color", $fd-token-color, --fd-token-color);
+    @include fd-var-color("background-color", $fd-token-background-color, --fd-token-background-color);
     line-height: fd-space(6);
     vertical-align: middle;
     display: inline-block;
@@ -28,19 +32,17 @@ $block: #{$fd-namespace}-token;
     border-radius: $fd-border-radius;
     border-width: 1px;
     border-style: solid;
-    border-color: $fd-token-border-color;
+    @include fd-var-color("border-color", $fd-token-border-color, --fd-token-border-color);
     cursor: pointer;
-
     @include fd-icon("sys-cancel", "s", "after") {
-        color: fd-color("action", 1);
+        @include fd-var-color("color", fd-color("action", 1), --fd-color-action-1);
         margin-left: fd-space(base);
         vertical-align: bottom;
         line-height: fd-space(6);
     };
-
     @include fd-rtl {
         @include fd-icon("sys-cancel", "s", "before") {
-            color: fd-color("action", 1);
+            @include fd-var-color("color", fd-color("action", 1), --fd-color-action-1);
             margin-left: fd-space(base);
             vertical-align: bottom;
             line-height: fd-space(6);

--- a/scss/mixins/_mixins.scss
+++ b/scss/mixins/_mixins.scss
@@ -44,7 +44,7 @@
 	}
 }
 //Taken from https://github.com/thoughtbot/bourbon/blob/master/core/bourbon/library/_triangle.scss
-@mixin triangle($size, $color, $direction) {
+@mixin triangle($size, $color, $direction, $varcolor:null) {
   $width: nth($size, 1);
   $height: nth($size, length($size));
   $foreground-color: nth($color, 1);
@@ -55,26 +55,41 @@
   @if ($direction == up) or ($direction == down) or ($direction == right) or ($direction == left) {
     $width: $width / 2;
     $height: if(length($size) > 1, $height, $height/2);
-
     @if $direction == up {
       border-width: 0 $width $height $width;
-      border-bottom-color:  $foreground-color;
+      @if $varcolor {
+        @include fd-var-color("border-bottom-color", $foreground-color, $varcolor);
+      } @else {
+        border-bottom-color:  $foreground-color;
+      }
       border-left-color:  $background-color;
       border-right-color:  $background-color;
     } @else if $direction == right {
       border-width: $width 0 $width $height;
       border-bottom-color: $background-color;
-      border-left-color: $foreground-color;
+      @if $varcolor {
+        @include fd-var-color("border-left-color", $foreground-color, $varcolor);
+      } @else {
+        border-left-color:  $foreground-color;
+      }
       border-top-color: $background-color;
     } @else if $direction == down {
       border-width: $height $width 0 $width;
-      border-top-color: $foreground-color;
+      @if $varcolor {
+        @include fd-var-color("border-top-color", $foreground-color, $varcolor);
+      } @else {
+        border-top-color:  $foreground-color;
+      }
       border-left-color: $background-color;
       border-right-color: $background-color;
     } @else if $direction == left {
       border-width: $width $height $width 0;
       border-bottom-color: $background-color;
-      border-right-color: $foreground-color;
+      @if $varcolor {
+        @include fd-var-color("border-right-color", $foreground-color, $varcolor);
+      } @else {
+        border-right-color:  $foreground-color;
+      }
       border-top-color: $background-color;
     }
   } @else if ($direction == up-right) or ($direction == up-left) {

--- a/test/templates/badge/data.json
+++ b/test/templates/badge/data.json
@@ -1,7 +1,7 @@
 {
     "id": "badge",
     "name": "Badge",
-	  "css_vars": true,
+	"css_vars": true,
     "version": "1.0.0",
     "properties": {
         "label": "Badge Label"

--- a/test/templates/badge/data.json
+++ b/test/templates/badge/data.json
@@ -1,6 +1,7 @@
 {
     "id": "badge",
     "name": "Badge",
+	  "css_vars": true,
     "version": "1.0.0",
     "properties": {
         "label": "Badge Label"

--- a/test/templates/badge/index.njk
+++ b/test/templates/badge/index.njk
@@ -8,8 +8,8 @@
 
 {% block content %}
 
-    <h1>badge</h1>
 
+<h2>default</h2>
     <!-- output the component example and the code snippet -->
     {% set example %}
 {{  badge({label: "Default"}) }}
@@ -66,6 +66,28 @@
 }}
     {% endset %}
     {{ format(example) }}
+
+
+    <br><br>
+        <h2>pill + filled</h2>
+
+        {% set example %}
+    {{  badge(
+            {label: "Default"},
+            modifier={ block: ["filled", "pill"] }
+        )
+    }}
+    {{  badge({label: "Default"},
+            modifier={block: ["success", "filled", "pill"]})
+    }}
+    {{  badge({label: "Default"},
+            modifier={block: ["warning", "filled", "pill"]})
+    }}
+    {{  badge({label: "Default"},
+            modifier={block: ["error", "filled", "pill"]})
+    }}
+        {% endset %}
+        {{ format(example) }}
 
 
 

--- a/test/templates/counter/data.json
+++ b/test/templates/counter/data.json
@@ -1,6 +1,7 @@
 {
     "id": "counter",
     "name": "Counter",
+	  "css_vars": true,
     "version": "1.3.3",
     "properties": {
       "count": 1

--- a/test/templates/counter/data.json
+++ b/test/templates/counter/data.json
@@ -1,7 +1,7 @@
 {
     "id": "counter",
     "name": "Counter",
-	  "css_vars": true,
+	"css_vars": true,
     "version": "1.3.3",
     "properties": {
       "count": 1

--- a/test/templates/counter/index.njk
+++ b/test/templates/counter/index.njk
@@ -6,7 +6,6 @@
 
 {% block content %}
 <div>
-    <h1>Counter</h1>
 
     <h2>default</h2>
     <p>Show nothing when 0, max is 999</p>

--- a/test/templates/identifier/data.json
+++ b/test/templates/identifier/data.json
@@ -1,6 +1,7 @@
 {
     "id": "identifier",
     "name": "Identifier",
+	  "css_vars": true,
     "version": "1.0.0",
     "properties": {
       "initials": "WW",

--- a/test/templates/identifier/data.json
+++ b/test/templates/identifier/data.json
@@ -1,7 +1,7 @@
 {
     "id": "identifier",
     "name": "Identifier",
-	  "css_vars": true,
+	"css_vars": true,
     "version": "1.0.0",
     "properties": {
       "initials": "WW",

--- a/test/templates/image/data.json
+++ b/test/templates/image/data.json
@@ -1,6 +1,7 @@
 {
     "id": "image",
     "name": "Image",
+	  "css_vars": true,
     "version": "1.0.0",
     "properties": {
         "url": "https://placeimg.com/400/400/nature"

--- a/test/templates/image/data.json
+++ b/test/templates/image/data.json
@@ -1,7 +1,7 @@
 {
     "id": "image",
     "name": "Image",
-	  "css_vars": true,
+	"css_vars": true,
     "version": "1.0.0",
     "properties": {
         "url": "https://placeimg.com/400/400/nature"

--- a/test/templates/inline-help/data.json
+++ b/test/templates/inline-help/data.json
@@ -1,6 +1,7 @@
 {
     "id": "inline-help",
-    "name": "Inline-Help",
+    "name": "Inline Help",
+	  "css_vars": true,
     "version": "1.0.0",
     "properties": {
         "content": ""

--- a/test/templates/inline-help/data.json
+++ b/test/templates/inline-help/data.json
@@ -1,7 +1,7 @@
 {
     "id": "inline-help",
     "name": "Inline Help",
-	  "css_vars": true,
+	"css_vars": true,
     "version": "1.0.0",
     "properties": {
         "content": ""

--- a/test/templates/inline-help/index.njk
+++ b/test/templates/inline-help/index.njk
@@ -9,7 +9,6 @@
 
 {% block content %}
 
-<h1>Inline Help</h1>
 
 <div style="text-align:center;">
 

--- a/test/templates/label/data.json
+++ b/test/templates/label/data.json
@@ -1,6 +1,7 @@
 {
     "id": "label",
     "name": "Label",
+	  "css_vars": true,
     "version": "1.0.0",
     "properties": {
         "label": "Label Label"

--- a/test/templates/label/data.json
+++ b/test/templates/label/data.json
@@ -1,7 +1,7 @@
 {
     "id": "label",
     "name": "Label",
-	  "css_vars": true,
+	"css_vars": true,
     "version": "1.0.0",
     "properties": {
         "label": "Label Label"

--- a/test/templates/label/index.njk
+++ b/test/templates/label/index.njk
@@ -6,8 +6,7 @@
 {% set css_deps = ['fonts'] %}
 
 {% block content %}
-    <h1>label</h1>
-
+<h2>default</h2>
     <!-- output the component example and the code snippet -->
     {% set example %}
 {{  label({label: "Default"}) }}

--- a/test/templates/spinner/data.json
+++ b/test/templates/spinner/data.json
@@ -1,7 +1,7 @@
 {
     "id": "spinner",
     "name": "Spinner",
-	  "css_vars": true,
+	"css_vars": true,
     "version": "1.0.0",
     "properties": {
 

--- a/test/templates/spinner/data.json
+++ b/test/templates/spinner/data.json
@@ -1,6 +1,7 @@
 {
     "id": "spinner",
     "name": "Spinner",
+	  "css_vars": true,
     "version": "1.0.0",
     "properties": {
 

--- a/test/templates/spinner/index.njk
+++ b/test/templates/spinner/index.njk
@@ -8,7 +8,6 @@
 
 {% block content %}
 
-    <h1>spinner</h1>
 <p>Toggle the <code>aria-hidden</code> attribute to hide/show the spinner.</p>
     <!-- output the component example and the code snippet -->
     {% set example %}

--- a/test/templates/status-label/data.json
+++ b/test/templates/status-label/data.json
@@ -1,7 +1,7 @@
 {
     "id": "status-label",
     "name": "Status Label",
-	  "css_vars": true,
+	"css_vars": true,
     "version": "1.0.0",
     "properties": {
         "label": ""

--- a/test/templates/status-label/data.json
+++ b/test/templates/status-label/data.json
@@ -1,6 +1,7 @@
 {
     "id": "status-label",
     "name": "Status Label",
+	  "css_vars": true,
     "version": "1.0.0",
     "properties": {
         "label": ""

--- a/test/templates/status-label/index.njk
+++ b/test/templates/status-label/index.njk
@@ -8,7 +8,40 @@
 
 {% block content %}
 
-<h1>status-label with build-in icons</h1>
+<h2>default</h2>
+
+{% set example %}
+
+{{  status_label(
+        properties={ label: "Status with no icon" }
+    )
+}}
+
+{{  status_label(
+        properties={ label: "Success with no icon" },
+        modifier={ block: 'success'}
+    )
+}}
+
+{{  status_label(
+        properties={ label: "Warning with no icon" },
+        modifier={ block: 'warning'}
+    )
+}}
+
+{{  status_label(
+        properties={ label: "Error with no icon" },
+        modifier={ block: 'error'}
+    )
+}}
+
+{% endset %}
+{{ format(example) }}
+
+<br><br>
+
+<h2>w/ built-in icons</h2>
+
 
 <!-- output the component example and the code snippet -->
 {% set example %}
@@ -19,15 +52,11 @@
     )
 }}
 
-<br><br>
-
 {{  status_label(
         properties={ label: "Away" },
         modifier={ block: 'away' }
     )
 }}
-
-<br><br>
 
 {{  status_label(
         properties={ label: "Busy" },
@@ -35,10 +64,8 @@
     )
 }}
 
-<br><br>
-
 {{  status_label(
-        properties={ label: "Appear Offline" },
+        properties={ label: "Offline" },
         modifier={ block: 'offline' }
     )
 }}
@@ -48,11 +75,7 @@
 
 <br><br>
 
-<hr>
-
-<br>
-
-<h1>status-label any sap icon and colors</h1>
+<h1>with sap icon and colors</h1>
 
 {% set example %}
 
@@ -62,16 +85,12 @@
     )
 }}
 
-<br><br>
-
 {{  status_label(
         properties={ label: "Success" },
         modifier={ block: 'success' },
         classes="sap-icon--message-success"
     )
 }}
-
-<br><br>
 
 {{  status_label(
         properties={ label: "Warning" },
@@ -80,7 +99,6 @@
     )
 }}
 
-<br><br>
 
 {{  status_label(
         properties={ label: "Error" },
@@ -92,46 +110,5 @@
 {% endset %}
 {{ format(example) }}
 
-<br><br>
-
-<hr>
-
-<br>
-
-<h1>status-label any sap icon and colors</h1>
-
-{% set example %}
-
-{{  status_label(
-        properties={ label: "Status with no icon" }
-    )
-}}
-
-<br><br>
-
-{{  status_label(
-        properties={ label: "Success with no icon" },
-        modifier={ block: 'success'}
-    )
-}}
-
-<br><br>
-
-{{  status_label(
-        properties={ label: "Warning with no icon" },
-        modifier={ block: 'warning'}
-    )
-}}
-
-<br><br>
-
-{{  status_label(
-        properties={ label: "Error with no icon" },
-        modifier={ block: 'error'}
-    )
-}}
-
-{% endset %}
-{{ format(example) }}
 
 {% endblock %}

--- a/test/templates/token/data.json
+++ b/test/templates/token/data.json
@@ -1,7 +1,7 @@
 {
     "id": "token",
     "name": "Token",
-	  "css_vars": true,
+	"css_vars": true,
     "version": "1.0.0",
     "properties": {
         "label": "Filter"

--- a/test/templates/token/data.json
+++ b/test/templates/token/data.json
@@ -1,6 +1,7 @@
 {
     "id": "token",
     "name": "Token",
+	  "css_vars": true,
     "version": "1.0.0",
     "properties": {
         "label": "Filter"

--- a/test/templates/token/index.njk
+++ b/test/templates/token/index.njk
@@ -7,11 +7,7 @@
 {% set css_deps = ['icons','helpers','components/button'] %}
 
 {% block content %}
-<style media="screen">
-  /* main {
-    background-color: white;
-  } */
-</style>
+
     <h1>token</h1>
     <p>Example shows the link for "Clear All" even though it is not part of the component.</p>
 

--- a/test/templates/token/index.njk
+++ b/test/templates/token/index.njk
@@ -8,9 +8,9 @@
 
 {% block content %}
 <style media="screen">
-  main {
+  /* main {
     background-color: white;
-  }
+  } */
 </style>
     <h1>token</h1>
     <p>Example shows the link for "Clear All" even though it is not part of the component.</p>


### PR DESCRIPTION
Closes sap/fundamental#1126

Implements CSS vars with fallbacks for indicators

#### Test

There should be no discernable visual changes.

* http://localhost:3030/badge
* http://localhost:3030/identifier
* http://localhost:3030/inline-help
* http://localhost:3030/label
* http://localhost:3030/spinner
* http://localhost:3030/status-label 
* http://localhost:3030/token
* http://localhost:3030/counter

Affected by refactoring of the triangle mixin.

* http://localhost:3030/product-menu
* http://localhost:3030/popover

#### Changelog

**New**

* The triangle mixin now accepts a fourth param for a CSS var which is the foreground color. The refactoring only handles foreground color and only for `up`, `down`, `left` and `right` since those are the only combinations used. 

**Changed**

* To enable the fallbacks, the flag `$fd-support-css-var-fallback` must be set to true in a custom SASS build.


**Removed**

* N/A
