### PR TITLE
#1124 shellbar components css vars

### DIFF
--- a/scss/components/action-bar.scss
+++ b/scss/components/action-bar.scss
@@ -12,10 +12,11 @@ $block: #{$fd-namespace}-action-bar;
 
     //LOCAL VARS (set all themeable properties, always include !default)
     $fd-action-bar-background-color: transparent !default;
-    $fd-action-bard-description-color: fd-color('text', 3);
+    $fd-action-bar-description-color: fd-color("text", 3);
     $fd-action-bar-height: fd-space(16) !default;
     $fd-action-bar-transition-params: 0.25s ease-in !default;
-    $fd-action-bar-backbtn-seperator-color: fd-color('neutral', 3);
+    --fd-action-bar-backbtn-separator-color: var(--fd-color-neutral-3);
+    $fd-action-bar-backbtn-separator-color: fd-color("neutral", 3);
 
     //LOCAL mixins
     @mixin fd-action-bar-responsive {
@@ -62,21 +63,6 @@ $block: #{$fd-namespace}-action-bar;
     &__back {
         display: block;
         @include fd-hide-on-mobile;
-        &::after {
-                content: '';
-                width: 0;
-                height: 100%;
-                position: absolute;
-                top: - fd-space(1);
-                right: - fd-space(1);
-                border-right: 1px solid $fd-action-bar-backbtn-seperator-color;
-        }
-        button {
-            margin-top: - fd-space(2);
-        }
-    }
-
-    &__back {
         position: relative;
         margin-right: fd-space(5);
         &::after {
@@ -86,10 +72,14 @@ $block: #{$fd-namespace}-action-bar;
                 position: absolute;
                 top: - fd-space(1);
                 right: - fd-space(1);
-                border-right: 1px solid $fd-action-bar-backbtn-seperator-color;
+                border-right-style: solid;
+                border-right-width: 1px;
+                @include fd-var-color("border-right-color", $fd-action-bar-backbtn-separator-color, --fd-action-bar-backbtn-separator-color);
+        }
+        button {
+            margin-top: - fd-space(2);
         }
     }
-
     &__title {
         @include fd-type("4");
         @include fd-action-bar-responsive;
@@ -97,7 +87,7 @@ $block: #{$fd-namespace}-action-bar;
     }
 
     &__description{
-        color: $fd-action-bard-description-color;
+        @include fd-var-color("color", $fd-action-bar-description-color, --fd-color-text-3);
         @include fd-type("0");
         @include fd-hide-on-mobile;
     }

--- a/scss/components/modal.scss
+++ b/scss/components/modal.scss
@@ -19,6 +19,9 @@ $block: #{$fd-namespace}-modal;
   $fd-modal-header-height: 60px !default;
   $fd-modal-footer-height: 68px !default;
 
+  --fd-modal-background-color: var(--fd-color-background-2);
+  --fd-modal-border-color: var(--fd-color-neutral-2);
+
   $fd-modal-border-color: fd-color("neutral", 2) !default;
   $fd-modal-padding-x: $fd-width--gutter !default;
   --fd-modal-padding-x: var(--fd-width-gutter);
@@ -29,7 +32,7 @@ $block: #{$fd-namespace}-modal;
   max-width: $fd-modal-width;
   &__content{
     border-radius: $fd-border-radius;
-    background-color: $fd-modal-inner-content-background;
+    @include fd-var-color("background-color", $fd-modal-inner-content-background, --fd-modal-background-color);
   }
   &__header,
   &__body,
@@ -41,7 +44,9 @@ $block: #{$fd-namespace}-modal;
   }
   &__header {
     position: relative;
-    border-bottom: 1px solid $fd-modal-border-color;
+    border-bottom-style: solid;
+    border-bottom-width: 1px;
+    @include fd-var-color("border-bottom-color", $fd-modal-border-color, --fd-modal-border-color);
   }
   &__title{
     @include fd-type("1");
@@ -67,6 +72,8 @@ $block: #{$fd-namespace}-modal;
   }
   &__footer {
     text-align: right;
-    border-top: 1px solid $fd-modal-border-color;
+    border-top-style: solid;
+    border-top-width: 1px;
+    @include fd-var-color("border-top-color", $fd-modal-border-color, --fd-modal-border-color);
   }
 }

--- a/scss/components/product-switcher.scss
+++ b/scss/components/product-switcher.scss
@@ -11,14 +11,14 @@ $fd-product-switcher-product-height: 40px;
 */
 $block: #{$fd-namespace}-product-switcher;
 
+
 .#{$block} {
   position: relative;
   display: inline-block;
 
   &__body {
     padding: 20px 10px 0 10px;
-    color: $fd-color;
-
+    color: initial;
     > nav {
       > ul {
           margin: 0;

--- a/scss/components/shellbar.scss
+++ b/scss/components/shellbar.scss
@@ -2,42 +2,45 @@
 @import "./../mixins";
 @import "./../functions";
 
-// Brand
-$fd-shellbar-logo-height: 24px !default;
-$fd-shellbar-logo-width: 48px !default;
-$fd-shellbar-logo-max-width: 60px !default;
-$fd-shellbar-logo-background-image-url: "data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0MTIuMzggMjA0Ij48ZGVmcz48c3R5bGU+LmNscy0xLC5jbHMtMntmaWxsLXJ1bGU6ZXZlbm9kZH0uY2xzLTF7ZmlsbDp1cmwoI2xpbmVhci1ncmFkaWVudCl9LmNscy0ye2ZpbGw6I2ZmZn08L3N0eWxlPjxsaW5lYXJHcmFkaWVudCBpZD0ibGluZWFyLWdyYWRpZW50IiB4MT0iMjA2LjE5IiB4Mj0iMjA2LjE5IiB5Mj0iMjA0IiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSI+PHN0b3Agb2Zmc2V0PSIwIiBzdG9wLWNvbG9yPSIjMDBiOGYxIi8+PHN0b3Agb2Zmc2V0PSIuMDIiIHN0b3AtY29sb3I9IiMwMWI2ZjAiLz48c3RvcCBvZmZzZXQ9Ii4zMSIgc3RvcC1jb2xvcj0iIzBkOTBkOSIvPjxzdG9wIG9mZnNldD0iLjU4IiBzdG9wLWNvbG9yPSIjMTc3NWM4Ii8+PHN0b3Agb2Zmc2V0PSIuODIiIHN0b3AtY29sb3I9IiMxYzY1YmYiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiMxZTVmYmIiLz48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48dGl0bGU+U0FQX2dyYWRfUl9zY3JuX1plaWNoZW5mbMOkY2hlIDE8L3RpdGxlPjxwYXRoIGNsYXNzPSJjbHMtMSIgZD0iTTAgMjA0aDIwOC40MUw0MTIuMzggMEgwdjIwNCIvPjxwYXRoIGNsYXNzPSJjbHMtMiIgZD0iTTI0NC43MyAzOC4zNmgtNDAuNnY5Ni41MmwtMzUuNDYtOTYuNTVoLTM1LjE2bC0zMC4yNyA4MC43MkMxMDAgOTguNyA3OSA5MS42NyA2Mi40IDg2LjQgNTEuNDYgODIuODkgMzkuODUgNzcuNzIgNDAgNzJjLjA5LTQuNjggNi4yMy05IDE4LjM4LTguMzggOC4xNy40MyAxNS4zNyAxLjA5IDI5LjcxIDhsMTQuMS0yNC41NUM4OS4wNiA0MC40MiA3MSAzNi4yMSA1Ni4xNyAzNi4xOWgtLjA5Yy0xNy4yOCAwLTMxLjY4IDUuNi00MC42IDE0LjgzQTM0LjIzIDM0LjIzIDAgMCAwIDUuNzcgNzQuN0M1LjU0IDg3LjE1IDEwLjExIDk2IDE5LjcxIDEwM2M4LjEgNS45NCAxOC40NiA5Ljc5IDI3LjYgMTIuNjIgMTEuMjcgMy40OSAyMC40NyA2LjUzIDIwLjM2IDEzQTkuNTcgOS41NyAwIDAgMSA2NSAxMzVjLTIuODEgMi45LTcuMTMgNC0xMy4wOSA0LjEtMTEuNDkuMjQtMjAtMS41Ni0zMy42MS05LjU5TDUuNzcgMTU0LjQyYTkzLjc3IDkzLjc3IDAgMCAwIDQ2IDEyLjIyaDIuMTFjMTQuMjQtLjI1IDI1Ljc0LTQuMzEgMzQuOTItMTEuNzEuNTMtLjQxIDEtLjg0IDEuNDktMS4yOGwtNC4xMiAxMC44NUgxMjNsNi4xOS0xOC44MmE2Ny40NiA2Ny40NiAwIDAgMCAyMS42OCAzLjQzIDY4LjMzIDY4LjMzIDAgMCAwIDIxLjE2LTMuMjVsNiAxOC42NGg2MC4xNHYtMzloMTMuMTFjMzEuNzEgMCA1MC40Ni0xNi4xNSA1MC40Ni00My4yIDAtMzAuMTEtMTguMjItNDMuOTQtNTcuMDEtNDMuOTR6TTE1MC45MSAxMjFhMzYuOTMgMzYuOTMgMCAwIDEtMTMtMi4yOGwxMi44Ny00MC41OWguMjJsMTIuNjUgNDAuNzFhMzguNSAzOC41IDAgMCAxLTEyLjc0IDIuMTZ6bTk2LjItMjMuMzNoLTguOTRWNjQuOTFoOC45NGMxMS45MyAwIDIxLjQ0IDQgMjEuNDQgMTYuMTQgMCAxMi42LTkuNTEgMTYuNTctMjEuNDQgMTYuNTciLz48L3N2Zz4=" !default;
-
-// Paddings
-$fd-shellbar-outer-spacing-lr-large: map-get($fd-spacing, "m") !default;
-$fd-shellbar-outer-spacing-lr-medium: map-get($fd-spacing, "s") !default;
-$fd-shellbar-outer-spacing-lr-small: map-get($fd-spacing, "xxs") !default;
-$fd-shellbar-outer-spacing-tb: map-get($fd-spacing, "base") !default;
-
-$fd-shellbar-title-spacing: map-get($fd-spacing, "base") !default;
-$fd-shellbar-item-spacing: map-get($fd-spacing, "xs") !default;
-
-// Heights
-$fd-shellbar-height: 48px !default;
-
-$fd-shellbar-copilot-height: 30px !default;
-$fd-shellbar-copilot-width: 30px !default;
-
-
-
-// Colors
-$fd-shellbar-color: fd-color("text", 5) !default; // White
-$fd-shellbar-background-color: fd-color("shell", 1) !default;
-
 $block: #{$fd-namespace}-shellbar;
 
 .#{$block} {
+
+  // Brand
+  $fd-shellbar-logo-height: 24px !default;
+  $fd-shellbar-logo-width: 48px !default;
+  $fd-shellbar-logo-max-width: 60px !default;
+  $fd-shellbar-logo-background-image-url: "data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0MTIuMzggMjA0Ij48ZGVmcz48c3R5bGU+LmNscy0xLC5jbHMtMntmaWxsLXJ1bGU6ZXZlbm9kZH0uY2xzLTF7ZmlsbDp1cmwoI2xpbmVhci1ncmFkaWVudCl9LmNscy0ye2ZpbGw6I2ZmZn08L3N0eWxlPjxsaW5lYXJHcmFkaWVudCBpZD0ibGluZWFyLWdyYWRpZW50IiB4MT0iMjA2LjE5IiB4Mj0iMjA2LjE5IiB5Mj0iMjA0IiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSI+PHN0b3Agb2Zmc2V0PSIwIiBzdG9wLWNvbG9yPSIjMDBiOGYxIi8+PHN0b3Agb2Zmc2V0PSIuMDIiIHN0b3AtY29sb3I9IiMwMWI2ZjAiLz48c3RvcCBvZmZzZXQ9Ii4zMSIgc3RvcC1jb2xvcj0iIzBkOTBkOSIvPjxzdG9wIG9mZnNldD0iLjU4IiBzdG9wLWNvbG9yPSIjMTc3NWM4Ii8+PHN0b3Agb2Zmc2V0PSIuODIiIHN0b3AtY29sb3I9IiMxYzY1YmYiLz48c3RvcCBvZmZzZXQ9IjEiIHN0b3AtY29sb3I9IiMxZTVmYmIiLz48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48dGl0bGU+U0FQX2dyYWRfUl9zY3JuX1plaWNoZW5mbMOkY2hlIDE8L3RpdGxlPjxwYXRoIGNsYXNzPSJjbHMtMSIgZD0iTTAgMjA0aDIwOC40MUw0MTIuMzggMEgwdjIwNCIvPjxwYXRoIGNsYXNzPSJjbHMtMiIgZD0iTTI0NC43MyAzOC4zNmgtNDAuNnY5Ni41MmwtMzUuNDYtOTYuNTVoLTM1LjE2bC0zMC4yNyA4MC43MkMxMDAgOTguNyA3OSA5MS42NyA2Mi40IDg2LjQgNTEuNDYgODIuODkgMzkuODUgNzcuNzIgNDAgNzJjLjA5LTQuNjggNi4yMy05IDE4LjM4LTguMzggOC4xNy40MyAxNS4zNyAxLjA5IDI5LjcxIDhsMTQuMS0yNC41NUM4OS4wNiA0MC40MiA3MSAzNi4yMSA1Ni4xNyAzNi4xOWgtLjA5Yy0xNy4yOCAwLTMxLjY4IDUuNi00MC42IDE0LjgzQTM0LjIzIDM0LjIzIDAgMCAwIDUuNzcgNzQuN0M1LjU0IDg3LjE1IDEwLjExIDk2IDE5LjcxIDEwM2M4LjEgNS45NCAxOC40NiA5Ljc5IDI3LjYgMTIuNjIgMTEuMjcgMy40OSAyMC40NyA2LjUzIDIwLjM2IDEzQTkuNTcgOS41NyAwIDAgMSA2NSAxMzVjLTIuODEgMi45LTcuMTMgNC0xMy4wOSA0LjEtMTEuNDkuMjQtMjAtMS41Ni0zMy42MS05LjU5TDUuNzcgMTU0LjQyYTkzLjc3IDkzLjc3IDAgMCAwIDQ2IDEyLjIyaDIuMTFjMTQuMjQtLjI1IDI1Ljc0LTQuMzEgMzQuOTItMTEuNzEuNTMtLjQxIDEtLjg0IDEuNDktMS4yOGwtNC4xMiAxMC44NUgxMjNsNi4xOS0xOC44MmE2Ny40NiA2Ny40NiAwIDAgMCAyMS42OCAzLjQzIDY4LjMzIDY4LjMzIDAgMCAwIDIxLjE2LTMuMjVsNiAxOC42NGg2MC4xNHYtMzloMTMuMTFjMzEuNzEgMCA1MC40Ni0xNi4xNSA1MC40Ni00My4yIDAtMzAuMTEtMTguMjItNDMuOTQtNTcuMDEtNDMuOTR6TTE1MC45MSAxMjFhMzYuOTMgMzYuOTMgMCAwIDEtMTMtMi4yOGwxMi44Ny00MC41OWguMjJsMTIuNjUgNDAuNzFhMzguNSAzOC41IDAgMCAxLTEyLjc0IDIuMTZ6bTk2LjItMjMuMzNoLTguOTRWNjQuOTFoOC45NGMxMS45MyAwIDIxLjQ0IDQgMjEuNDQgMTYuMTQgMCAxMi42LTkuNTEgMTYuNTctMjEuNDQgMTYuNTciLz48L3N2Zz4=" !default;
+
+  // Paddings
+  $fd-shellbar-outer-spacing-lr-large: map-get($fd-spacing, "m") !default;
+  $fd-shellbar-outer-spacing-lr-medium: map-get($fd-spacing, "s") !default;
+  $fd-shellbar-outer-spacing-lr-small: map-get($fd-spacing, "xxs") !default;
+  $fd-shellbar-outer-spacing-tb: map-get($fd-spacing, "base") !default;
+
+  $fd-shellbar-title-spacing: map-get($fd-spacing, "base") !default;
+  $fd-shellbar-item-spacing: map-get($fd-spacing, "xs") !default;
+
+  // Heights
+  $fd-shellbar-height: 48px !default;
+
+  $fd-shellbar-copilot-height: 30px !default;
+  $fd-shellbar-copilot-width: 30px !default;
+
+  // Colors
+  $fd-shellbar-color: fd-color("text", 5) !default; // White
+  $fd-shellbar-background-color: fd-color("shell", 1) !default;
+
+  --fd-shellbar-color: var(--fd-color-text-5);
+  --fd-shellbar-background-color: var(--fd-color-shell-1);
+  --fd-shellbar-link-color: var(--fd-color-shell-2);
+
     @include fd-reset;
-    background: $fd-shellbar-background-color;
+    @include fd-var-color("background-color", $fd-shellbar-background-color, --fd-shellbar-background-color);
     height: $fd-shellbar-height;
     display: flex;
     align-items: center;
-    color: $fd-shellbar-color;
+    @include fd-var-color("color", $fd-shellbar-color, --fd-shellbar-color);
     position: relative;
     padding: $fd-shellbar-outer-spacing-tb $fd-shellbar-outer-spacing-lr-large;
     justify-content: space-between;
@@ -115,7 +118,7 @@ $block: #{$fd-namespace}-shellbar;
         @include fd-type("1");
         @include fd-weight("bold");
         line-height: 1;
-        color: fd-color("text", 5);
+        @include fd-var-color("color", $fd-shellbar-color, --fd-shellbar-color);
         white-space: nowrap;
         overflow: hidden;
         max-width: 100%;
@@ -214,9 +217,9 @@ $block: #{$fd-namespace}-shellbar;
         .fd-input {
             border-style: solid;
             border-width: 1px;
-            @include fd-var-color("border-color", fd-color("shell", 2), --fd-color-shell-2);
-            @include fd-var-color("background-color", fd-color("shell", 1), --fd-color-shell-1);
-            @include fd-var-color("color", fd-color("shell",2), --fd-color-shell-2);
+            @include fd-var-color("border-color", fd-color("shell", 2), --fd-shellbar-link-color);
+            @include fd-var-color("background-color", fd-color("shell", 1), --fd-shellbar-background-color);
+            @include fd-var-color("color", fd-color("shell",2), --fd-shellbar-link-color);
             &:focus {
               box-shadow: none;
             }

--- a/test/templates/action-bar/data.json
+++ b/test/templates/action-bar/data.json
@@ -1,6 +1,7 @@
 {
     "id": "action-bar",
     "name": "Action Bar",
+    "css_vars": true,
     "since": "1.1.0",
     "updated": "",
     "status": "review",

--- a/test/templates/modal/data.json
+++ b/test/templates/modal/data.json
@@ -1,4 +1,7 @@
 {
+    "id": "modal",
+    "name": "Modal",
+    "css_vars": true,
     "version": "1.0.0",
     "type": "text",
     "properties": {

--- a/test/templates/modal/index.njk
+++ b/test/templates/modal/index.njk
@@ -20,8 +20,8 @@ NOTE: The <code>modal</code> itself does not provide the outer container. Use th
             header: "Modal Header",
             body: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
             actions: [
-              {type: 'primary', label: 'Confirm'},
-              {type: 'secondary', label: 'Cancel'}
+              { label: 'Confirm'},
+              {type: 'light', label: 'Cancel'}
             ]
           }
       )

--- a/test/templates/modal/index.njk
+++ b/test/templates/modal/index.njk
@@ -6,7 +6,6 @@
 
 {% block content %}
 
-<h1>modal</h1>
 
 <p>
 NOTE: The <code>modal</code> itself does not provide the outer container. Use the <code>.fd-overlay</code> layout component in conjunction with the <code>.fd-ui__overlay</code> template container to hide and show the modal. See <a href="http://localhost:3030/pages/overlay">the overlay example</a>.

--- a/test/templates/product-menu/data.json
+++ b/test/templates/product-menu/data.json
@@ -1,6 +1,7 @@
 {
     "id": "product-menu",
     "name": "Product Menu",
+    "css_vars": true,
     "properties": {
       "title": "Product Name",
       "subtitle": "Subtitle",

--- a/test/templates/product-menu/index.njk
+++ b/test/templates/product-menu/index.njk
@@ -8,7 +8,6 @@
 
 {% block content %}
 
-    <h1>product-menu</h1>
 
     <!-- output the component example and the code snippet -->
     {% set example %}

--- a/test/templates/product-switcher/data.json
+++ b/test/templates/product-switcher/data.json
@@ -1,6 +1,7 @@
 {
   "id": "product-switcher",
   "name": "Product Switcher",
+  "css_vars": true,
     "version": "1.0.0",
     "type": "text",
     "properties": {

--- a/test/templates/product-switcher/data.json
+++ b/test/templates/product-switcher/data.json
@@ -1,4 +1,6 @@
 {
+  "id": "product-switcher",
+  "name": "Product Switcher",
     "version": "1.0.0",
     "type": "text",
     "properties": {

--- a/test/templates/product-switcher/index.njk
+++ b/test/templates/product-switcher/index.njk
@@ -6,10 +6,9 @@
 
 {% block content %}
 <style media="screen">
-    .fd-product-switcher{ margin-left: 500px; background: #ccc;}
+    .fd-product-switcher{ margin-left: 500px; }
 </style>
 
-    <h1>Product Switcher</h1>
     {% set basic_product_switcher %}
         {{ product_switcher(properties={ "items": data.properties.items }) }}
     {% endset %}

--- a/test/templates/shellbar/data.json
+++ b/test/templates/shellbar/data.json
@@ -1,5 +1,5 @@
 {
-    "id": "shell-header",
+    "id": "shellbar",
     "name": "Shell Header",
     "version": "1.0.0",
     "properties": {

--- a/test/templates/shellbar/data.json
+++ b/test/templates/shellbar/data.json
@@ -1,6 +1,7 @@
 {
     "id": "shellbar",
     "name": "Shell Header",
+    "css_vars": true,
     "version": "1.0.0",
     "properties": {
         "brand": {

--- a/test/templates/shellbar/index.njk
+++ b/test/templates/shellbar/index.njk
@@ -32,31 +32,29 @@
 %}
 {% block content %}
 
-<style media="screen">
-    .fd-shellbar{
-        margin: 40px 0;
-    }
-</style>
 
 <div style="background-color: #f3f4f5; margin:-20px; padding:20px;">
-    <h1>shellbar</h1>
 
+  <h2>typical implentation</h2>
+    {% set example %}
+        {{  shellbar(switcher=true) }}
+    {% endset %}
+    {{ format(example) }}
+<br><br>
+<h2>search open</h2>
     {% set example %}
         {{  shellbar(switcher=true) }}
     {% endset %}
     {{ format(example) }}
 
-    {% set example %}
-        {{  shellbar(switcher=true) }}
-    {% endset %}
-    {{ format(example) }}
-
+    <br><br>
+<h2>no switcher</h2>
     {% set example %}
         {{  shellbar(switcher=false) }}
     {% endset %}
     {{ format(example) }}
 
-
+<br><br>
     {% set example %}
         {{  shellbar(product={ title: "Sales Cloud"}) }}
     {% endset %}

--- a/test/templates/user-menu/data.json
+++ b/test/templates/user-menu/data.json
@@ -1,6 +1,7 @@
 {
     "version": "1.0.0",
     "type": "text",
+    "css_vars": true,
     "properties": {
       "initials": "EB",
       "name": "Eric Boyer",

--- a/test/templates/user-menu/index.njk
+++ b/test/templates/user-menu/index.njk
@@ -9,8 +9,8 @@
 
 </style>
 <div style="background-color: #f3f4f5; margin:-20px; padding:50px 100px;">
-  <h1><code>user-menu__control</code> types
-    </h1>
+
+<h2>types</h2>
 
   {% set controls %}
     {{ user_menu_control(thumbnail="") }}


### PR DESCRIPTION
Closes sap/fundamental#1124

Implements CSS vars with fallbacks for shell and floorplan components

#### Test

There should be no discernable visual changes.

* http://localhost:3030/action-bar
* http://localhost:3030/modal
* http://localhost:3030/product-menu
* http://localhost:3030/product-switcher
* http://localhost:3030/shellbar
* http://localhost:3030/user-menu

#### Changelog

**New**

* N/A

**Changed**

* To enable the fallbacks, the flag `$fd-support-css-var-fallback` must be set to `true` in a custom SASS build.


**Removed**

* N/A
