### PR TITLE
#1127 list component css vars

### DIFF
--- a/scss/components/list-group.scss
+++ b/scss/components/list-group.scss
@@ -9,12 +9,14 @@
 $block: #{$fd-namespace}-list-group;
 .#{$block} {
   //LOCAL VARS (set all vars used in component, always include !default)
-  $fd-list-group-background-color: none !default;
+  $fd-list-group-background-color: transparent !default;
   $fd-list-group-background-color--hover: fd-color-state("hover") !default;
   $fd-list-group-item-padding-x: fd-space(4) !default;
   $fd-list-group-item-padding-y: fd-space(2) + 2px !default;
   $fd-list-group-action-height: fd-space(10) !default;
   $fd-list-group-transition-params: $fd-animation--speed ease-in !default;
+
+  --fd-list-group-background-color: transparent;
 
   @include fd-reset;
   margin-left: 0;
@@ -23,10 +25,11 @@ $block: #{$fd-namespace}-list-group;
     padding: $fd-list-group-item-padding-y $fd-list-group-item-padding-x;
     display: flex;
     position: relative;
-    background-color: $fd-list-group-background-color;
+    @include fd-var-color("background-color", $fd-list-group-background-color, --fd-list-group-background-color);
     transition: background-color $fd-list-group-transition-params;
     &:hover{
-      background-color: $fd-list-group-background-color--hover;
+      --fd-list-group-background-color: var(--fd-color-background-hover);
+      @include fd-var-color("background-color", $fd-list-group-background-color);
     }
   }
   &__action {

--- a/scss/components/product-tile.scss
+++ b/scss/components/product-tile.scss
@@ -22,9 +22,13 @@ $block: #{$fd-namespace}-product-tile;
   //anim
   $fd-product-tile-transition-params: $fd-animation--speed ease-in !default;
 
+  --fd-product-tile-color: var(--fd-color-text-3);
+  --fd-product-tile-background-color: var(--fd-color-background-2);
+  --fd-product-tile-title-color: var(--fd-color-text-1);
+
   @include fd-reset;
-  color: $fd-product-tile-color;
-  background-color: $fd-product-tile-background-color;
+  @include fd-var-color("color", $fd-product-tile-color, --fd-product-tile-color);
+  @include fd-var-color("background-color", $fd-product-tile-background-color, --fd-product-tile-background-color);
 
   //MODIFICATIONS
   &--button,
@@ -55,7 +59,8 @@ $block: #{$fd-namespace}-product-tile;
   }
   &__title {
     @include fd-type("1");
-    color: $fd-product-tile-title-color;
+    @include fd-var-color("color", $fd-product-tile-title-color, --fd-product-tile-title-color);
+    margin-bottom: 0;
     margin-bottom: 0;
   }
 

--- a/scss/components/table.scss
+++ b/scss/components/table.scss
@@ -14,7 +14,6 @@ $block: #{$fd-namespace}-table;
     $fd-table-border-width: 1px !default;
     $fd-table-link-color: fd-color(action, 1) !default;
     $fd-table-background-color: fd-color("background", 2);
-
     $fd-table-header-color: fd-color("text", 3) !default;
     $fd-table-header-background-color: fd-color("neutral", 1) !default;
     $fd-table-row-background-color--hover:
@@ -28,8 +27,13 @@ $block: #{$fd-namespace}-table;
     $fd-table-transition-params: $fd-animation--speed ease-in !default;
     $fd-table-sort-icon-size: fd-space(3);
     $fd-table-sort-column-header-background-color: fd-color("neutral", 2);
-    $fd-table-sort-column-header-hover-color: #f2f2f3; //hsl +1 of Neutral 2.;
     $fd-table-fixed-column-cell-color: fd-color("background", 2);
+
+    --fd-table-border-color: var(--fd-color-neutral-2);
+    --fd-table-background-color: var(--fd-color-background-2);
+    --fd-table-link-color: var(--fd-color-action-1);
+    --fd-table-header-color: var(--fd-color-text-3);
+    --fd-table-header-background-color: var(--fd-color-neutral-1);
 
     //BLOCK BASE *******************************************
     //set all BLOCK reset and baseline styles
@@ -39,19 +43,20 @@ $block: #{$fd-namespace}-table;
     max-width: 100%;
     border-collapse: collapse;
     margin-bottom: $fd-margin-bottom;
-    border-top: solid $fd-table-border-width $fd-table-border-color;
-    background-color: $fd-table-background-color;
-    border: 1px solid $fd-table-border-color;
+    @include fd-var-color("background-color", $fd-table-background-color, --fd-table-background-color);
+    border-style: solid;
+    border-width: $fd-table-border-width;
+    @include fd-var-color("border-color", $fd-table-border-color, --fd-table-border-color);
 
     tr {
         transition: background-color $fd-table-transition-params;
         @include fd-hover {
-            background-color: $fd-table-row-background-color--hover;
+          @include fd-var-color("background-color", $fd-table-row-background-color--hover, --fd-color-background-hover);
         }
         @include fd-selected {
-            background-color: $fd-table-row-background-color--selected;
+            @include fd-var-color("background-color", $fd-table-row-background-color--selected, --fd-color-background-selected);
             @include fd-hover {
-                background-color: fd-color-state("selected-hover")
+              @include fd-var-color("background-color", fd-color-state("selected-hover"), --fd-color-background-selected-hover);
             }
         }
         cursor: pointer;
@@ -59,8 +64,8 @@ $block: #{$fd-namespace}-table;
 
     thead {
         @include fd-type("-1");
-        color: $fd-table-header-color;
-        background-color: $fd-table-header-background-color;
+        @include fd-var-color("color", $fd-table-header-color, --fd-table-header-color);
+        @include fd-var-color("background-color", $fd-table-header-background-color, --fd-table-header-background-color);
         text-transform: uppercase;
 
         tr {
@@ -77,7 +82,10 @@ $block: #{$fd-namespace}-table;
     }
     tbody{
         tr{
-            border: $fd-table-border-width solid $fd-table-border-color;
+            //border: $fd-table-border-width solid $fd-table-border-color;
+            border-style: solid;
+            border-width: $fd-table-border-width;
+            @include fd-var-color("border-color", $fd-table-border-color, --fd-table-border-color);
             border-left: none;
             border-right: none;
         }
@@ -101,18 +109,18 @@ $block: #{$fd-namespace}-table;
             min-width: auto;
             text-align: left;
         }
-      
-        > a {
-            color: $fd-table-link-color;
-            &:hover{
-                color: $fd-table-link-color;
-            }
-        }
+        //WHY do we need this specific style?
+        // > a {
+        //     color: $fd-table-link-color;
+        //     &:hover{
+        //         color: $fd-table-link-color;
+        //     }
+        // }
     }
 
     &__sort-column {
         &:hover {
-            background: $fd-table-sort-column-header-hover-color;
+            @include fd-var-color("background-color", $fd-table-sort-column-header-background-color, --fd-color-neutral-2);
             cursor: pointer;
         }
         &::after {
@@ -124,10 +132,12 @@ $block: #{$fd-namespace}-table;
             margin: 0 $fd-table-sort-icon-size;
             vertical-align: text-top;
         }
-
+        //these are the selected states, should be .is-selected, aria-selected=true
+        &--asc,
+        &--dsc {
+          @include fd-var-color("background-color", $fd-table-sort-column-header-background-color, --fd-color-neutral-2);
+        }
         &--asc {
-            background: $fd-table-sort-column-header-background-color;
-
             &::after
             {
                 background-image: url($fd-table-column-sort-icon--asc)
@@ -135,8 +145,6 @@ $block: #{$fd-namespace}-table;
         }
 
         &--dsc {
-            background: $fd-table-sort-column-header-background-color;
-
             &::after {
                 background-image: url($fd-table-column-sort-icon--dsc)
             }
@@ -158,7 +166,7 @@ $block: #{$fd-namespace}-table;
 
     th.fd-table__context-menu {
         &:hover {
-            background: $fd-table-sort-column-header-hover-color;
+            @include fd-var-color("background-color", $fd-table-sort-column-header-background-color, --fd-color-neutral-2);
             cursor: pointer;
         }
     }
@@ -169,13 +177,19 @@ $block: #{$fd-namespace}-table;
     }
 
     th.fd-table__fixed-col {
-        background: $fd-table-sort-column-header-background-color;
+        @include fd-var-color("background-color", $fd-table-sort-column-header-background-color, --fd-color-neutral-2);
         z-index: map-get($fd-z-index-levels, "second");
-        box-shadow: 2px 0 0 0 rgba(0, 0, 0, 0.08);
+        @if $fd-support-css-var-fallback {
+          box-shadow: 2px 0 0 0 $fd-table-border-color;
+        }
+        box-shadow: 2px 0 0 0 var(--fd-table-border-color);
     }
     td.fd-table__fixed-col {
-        background: $fd-table-fixed-column-cell-color;
-        box-shadow: 2px 0 0 0 rgba(0, 0, 0, 0.08);
+        @include fd-var-color("background-color", $fd-table-fixed-column-cell-color, --fd-color-background-2);
+        @if $fd-support-css-var-fallback {
+          box-shadow: 2px 0 0 0 $fd-table-border-color;
+        }
+        box-shadow: 2px 0 0 0 var(--fd-table-border-color);
     }
 
     &--fixed-wrapper {
@@ -198,8 +212,8 @@ $block: #{$fd-namespace}-table;
     }
 
     &--striped {
-        & tbody tr:nth-child(even) {
-            background-color: fd-color-state("hover");
+        tbody tr:nth-child(even) {
+            @include fd-var-color("background-color", fd-color-state("hover"), --fd-color-background-hover);
         }
     }
 }

--- a/scss/components/tile-grid.scss
+++ b/scss/components/tile-grid.scss
@@ -7,8 +7,10 @@
 $block: #{$fd-namespace}-tile-grid;
 .#{$block} {
   //VARS
-  $fd-tile-grid-border-color: fd-color("background") !default;
+  $fd-tile-grid-border-color: fd-color("neutral", 2) !default;
   $fd-tile-grid-items-per-row: 3 !default;
+
+  --fd-tile-grid-border-color: var(--fd-color-neutral-2);
   display: flex;
   flex-wrap: wrap;
   flex-direction: column;
@@ -18,7 +20,8 @@ $block: #{$fd-namespace}-tile-grid;
     margin-bottom: 0;
     border-radius: 0 !important;
     position: relative;
-    border: solid 1px $fd-tile-grid-border-color;
+    border-style: solid;
+    @include fd-var-color("border-color", $fd-tile-grid-border-color, --fd-tile-grid-border-color);
     border-width: 0 1px 1px 0;
   }
   @include fd-screen(s) {

--- a/scss/components/tile.scss
+++ b/scss/components/tile.scss
@@ -15,7 +15,7 @@ $block: #{$fd-namespace}-tile;
   //VARS
   $fd-tile-color: fd-color("text",3) !default;
   $fd-tile-background-color: fd-color("background",2) !default;
-  $fd-tile-title-color: fd-color("text",2) !default;
+  $fd-tile-title-color: fd-color("text", 1) !default;
   $fd-tile-content-padding: fd-space(4) fd-space("reg") !default;
   $fd-tile-content-padding-x: fd-space("small") !default;
   $fd-tile-content-padding-y: fd-space(2) + 2px !default;
@@ -23,10 +23,14 @@ $block: #{$fd-namespace}-tile;
   //anim
   $fd-tile-transition-params: $fd-animation--speed ease-in !default;
 
+  --fd-tile-color: var(--fd-color-text-3);
+  --fd-tile-background-color: var(--fd-color-background-2);
+  --fd-tile-title-color: var(--fd-color-text-1);
+
   @include fd-reset;
   display: flex;
-  color: $fd-tile-color;
-  background-color: $fd-tile-background-color;
+  @include fd-var-color("color", $fd-tile-color, --fd-tile-color);
+  @include fd-var-color("background-color", $fd-tile-background-color, --fd-tile-background-color);
 
   //MODIFICATIONS
   &--button,
@@ -59,7 +63,7 @@ $block: #{$fd-namespace}-tile;
   }
   &__title {
     @include fd-type("0");
-    color: $fd-tile-title-color;
+    @include fd-var-color("color", $fd-tile-title-color, --fd-tile-title-color);
     margin-bottom: 0;
   }
   &__actions {

--- a/scss/components/tree.scss
+++ b/scss/components/tree.scss
@@ -14,13 +14,14 @@
 $block: #{$fd-namespace}-tree;
 .#{$block} {
     //LOCAL VARS (set all themeable properties, always include !default)
-    $fd-tree-border-color: transparent !default;
-    $fd-tree-border-width: 0 !default;
+    $fd-tree-background-color:  fd-color("background", 2) !default;
+    $fd-tree-border-color: fd-color("neutral", 2) !default;
+    $fd-tree-border-width: 1px !default;
     $fd-tree-link-color: fd-color(action, 1) !default;
     $fd-tree-cell-spacing: $fd-width--gutter !default;
     --fd-tree-cell-spacing: var(--fd-width-gutter);
     $fd-tree-cell-padding: fd-space(3) !default;
-
+    $fd-tree-header-color: fd-color("text", 3) !default;
     $fd-tree-header-background-color: fd-color("neutral", 2) !default;
     $fd-tree-row-background-color--hover: fd-color-state("hover") !default;
 
@@ -28,12 +29,22 @@ $block: #{$fd-namespace}-tree;
     $fd-tree-control-margin-right: fd-space(2) !default;
     $fd-tree-transition-params: $fd-animation--speed ease-in !default;
 
+    --fd-tree-border-color: var(--fd-color-neutral-2);
+    --fd-tree-background-color: var(--fd-color-background-2);
+    --fd-tree-link-color: var(--fd-color-action-1);
+    --fd-tree-header-color: var(--fd-color-text-3);
+    --fd-tree-header-background-color: var(--fd-color-neutral-2);
+
     @include fd-reset;
     @include fd-last-child;
     position: relative;
     width: 100%;
     max-width: 100%;
-    border-bottom: solid $fd-tree-border-width $fd-tree-border-color;
+    @include fd-var-color("background-color", $fd-tree-background-color, --fd-tree-background-color);
+    border-bottom-style: solid;
+    border-bottom-width: $fd-tree-border-width;
+    @include fd-var-color("border-bottom-color", $fd-tree-border-color, --fd-tree-border-color);
+
     margin-bottom: $fd-margin-bottom;
     margin-left: 0;
     &:last-child {
@@ -41,9 +52,11 @@ $block: #{$fd-namespace}-tree;
     }
     &--header {
         border-bottom: 0;
-        border-top: solid $fd-tree-border-width $fd-tree-border-color;
+        border-top-style: solid;
+        border-top-width: $fd-tree-border-width;
+        @include fd-var-color("border-top-color", $fd-tree-border-color, --fd-tree-border-color);
         margin-bottom: 0;
-        background-color: $fd-tree-header-background-color;
+        @include fd-var-color("background-color", $fd-tree-header-background-color, --fd-tree-header-background-color);
     }
     &__group {
         //see addt'l group classes under __col--first below
@@ -60,7 +73,9 @@ $block: #{$fd-namespace}-tree;
         }
     }
     &__item {
-        border-top: solid $fd-tree-border-width $fd-tree-border-color;
+        border-top-style: solid;
+        border-top-width: $fd-tree-border-width;
+        @include fd-var-color("border-top-color", $fd-tree-border-color, --fd-tree-border-color);
         margin-bottom: 0;
         list-style: none;
     }
@@ -75,12 +90,12 @@ $block: #{$fd-namespace}-tree;
         position: relative;
         transition: background-color $fd-tree-transition-params;
         @include fd-hover {
-            background-color: $fd-tree-row-background-color--hover;
+        @include fd-var-color("background-color", $fd-tree-row-background-color--hover, --fd-color-background-hover);
         }
         &--header {
             @include fd-type("-1");
-            color: fd-color("text", 3);
-            background-color: fd-color("background",1);
+            @include fd-var-color("color", $fd-tree-header-color, --fd-tree-header-color);
+            @include fd-var-color("background-color", $fd-tree-header-background-color, --fd-tree-header-background-color);
             text-transform: uppercase;
             @include fd-hover {
                 background-color: initial;
@@ -88,6 +103,7 @@ $block: #{$fd-namespace}-tree;
         }
         @include fd-selected {
             background-color: fd-color-state("selected");
+            @include fd-var-color("background-color", fd-color-state("selected"), --fd-color-background-selected);
         }
     }
     $_row_padding: $fd-tree-control-width + $fd-tree-control-margin-right + 4;
@@ -127,18 +143,18 @@ $block: #{$fd-namespace}-tree;
         vertical-align: middle;
         transition: transform $fd-animation--speed linear;
         @include fd-icon("nav-back");
-        color: $fd-link-color;
+        @include fd-var-color("color", $fd-link-color, --fd-color-action-1);
         @include fd-focus;
         &[aria-pressed="true"],
         &.is-pressed {
             transform: rotate(270deg);
         }
     }
-    a {
-        color: $fd-tree-link-color;
-        @include fd-hover{
-            color: $fd-tree-link-color;
-        }
-    }
-
+    //WHY do we need this specific style?
+    // a {
+    //     color: $fd-tree-link-color;
+    //     @include fd-hover{
+    //         color: $fd-tree-link-color;
+    //     }
+    // }
 }

--- a/test/templates/alert/data.json
+++ b/test/templates/alert/data.json
@@ -1,6 +1,7 @@
 {
   "id": "alert",
   "name": "Alert",
+  "css_vars": true,
   "since": "1.0.0",
   "updated": "1.4.1",
   "status": "new",

--- a/test/templates/button/data.json
+++ b/test/templates/button/data.json
@@ -1,4 +1,7 @@
 {
+    "id": "button",
+    "name": "Button",
+    "css_vars": true,
     "version": "1.0.0",
     "properties": {
         "label": "BUTTON_LABEL",

--- a/test/templates/layout.njk
+++ b/test/templates/layout.njk
@@ -83,12 +83,17 @@
           <code>{{ data.id }}</code>
         </h1>
         <div style="text-align; right;align-self: center;">
+          {% if data.css_vars == true %}
+            <span class="status-label">✅ CSS vars</span>
+          {% endif %}
+        </div>
+        {# <div style="text-align; right;align-self: center;">
           <span class="status-label {{data.status}}">{{data.status}}</span> /
           <span class="status-since">since {{data.since}}</span>
           {% if data.updated %}
             <span class="status-updated">/ updated {{data.updated}}</span>
           {% endif %}
-        </div>
+        </div> #}
 
       </div>
 

--- a/test/templates/list-group/data.json
+++ b/test/templates/list-group/data.json
@@ -1,4 +1,7 @@
 {
+    "id": "list-group",
+    "name": "List Group",
+    "css_vars": true,
     "version": "1.0.0",
     "type": "text",
     "properties": {

--- a/test/templates/list-group/index.njk
+++ b/test/templates/list-group/index.njk
@@ -8,21 +8,21 @@
 
 {% block content %}
 
-<h1>Lists</h1>
+<h2>default</h2>
 {% set example %}
 {{  list_group({ items: data.properties.items }) }}
 {% endset %}
 {{ format(example) }}
 
 <br><br>
-<h1>List with actions</h1>
+<h2>with actions</h2>
 {% set example %}
 {{ list_group(data.properties) }}
 {% endset %}
 {{ format(example) }}
 
 <br><br>
-<h1>List with checkboxes</h1>
+<h2>with checkboxes</h2>
 {% set example %}
 {{  list_group(
       properties={

--- a/test/templates/product-tile/data.json
+++ b/test/templates/product-tile/data.json
@@ -1,6 +1,7 @@
 {
     "id": "product-tile",
     "name": "Product Tile",
+    "css_vars": true,
     "version": "1.0.0",
     "properties": {
         "title": "Product Tile Label",

--- a/test/templates/product-tile/index.njk
+++ b/test/templates/product-tile/index.njk
@@ -13,7 +13,6 @@
     max-width: 25%;
   }
 </style>
-    <h1>product-tile</h1>
 
   {%- set product_tile_image %}
   {%- call product_tile() -%}
@@ -25,6 +24,7 @@
   {% endset %}
 
 
+<h2>default</h2>
     {% set example %}
   {{product_tile_image}}
     {% endset %}

--- a/test/templates/table/data.json
+++ b/test/templates/table/data.json
@@ -1,6 +1,7 @@
 {
     "id": "table",
     "name": "Table",
+    "css_vars": true,
     "version": "1.0.0",
     "properties": {
         "rows": [

--- a/test/templates/table/index.njk
+++ b/test/templates/table/index.njk
@@ -9,7 +9,6 @@
 
 {% block content %}
 
-<h1>table</h1>
 {% set headers = [
         { label: "Header Column" },
         { label: "Header Column" },
@@ -39,7 +38,7 @@
 {% set checkbox_row_selected = ['<input type="checkbox" checked>', '<a class="fd-has-font-weight-semi">user.name@email.com</a>', 'First Name', 'Last Name', '01/26/17'] %}
 
 <!-- output the component example and the code snippet -->
-<h3>Default Table</h3>
+<h2>default</h2>
 {% set example %}
 {{  table(properties={
         rows: [row, row, row],

--- a/test/templates/tile-grid/data.json
+++ b/test/templates/tile-grid/data.json
@@ -1,6 +1,7 @@
 {
     "id": "tile-grid",
     "name": "Tile Grid",
+    "css_vars": true,
     "version": "1.0.0",
     "properties": {
         "items": [ "#/tile","#/product-tile" ]

--- a/test/templates/tile-grid/index.njk
+++ b/test/templates/tile-grid/index.njk
@@ -50,10 +50,6 @@
 {%- endcall %}
 {% endset %}
 
-
-
-    <h1>tile-grid</h1>
-
 <h2>3-col grid (default)</h2>
 <p>Also available as a modifier class <code>--3col</code>
 </p>

--- a/test/templates/tile/data.json
+++ b/test/templates/tile/data.json
@@ -1,6 +1,7 @@
 {
     "id": "tile",
-    "name": "title",
+    "name": "Tile",
+    "css_vars": true,
     "version": "1.0.0",
     "properties": {
         "title": "Tile Title",

--- a/test/templates/tile/index.njk
+++ b/test/templates/tile/index.njk
@@ -10,13 +10,12 @@
 {% block content %}
 <style media="screen">
 main {
-  background-color: lightgray;
+/* background-color: lightgray; */
 }
   .fd-tile {
     margin-bottom: 10px;
   }
 </style>
-    <h1>{{ data.name }}</h1>
 
 {% set icon = identifier(
   properties={ icon: "home" },

--- a/test/templates/tree/data.json
+++ b/test/templates/tree/data.json
@@ -1,6 +1,7 @@
 {
     "id": "tree",
     "name": "Tree",
+    "css_vars": true,
     "version": "1.0.0",
     "properties": {
         "headers": ["Column Header", "Column Header", "Column Header", "Status"],

--- a/test/templates/tree/index.njk
+++ b/test/templates/tree/index.njk
@@ -7,7 +7,7 @@
 {% set css_deps = ['fonts','helpers','icons','components/label','components/button'] %}
 
 {% block content %}
-    <h1>tree</h1>
+<h2>default</h2>
 
     <!-- output the component example and the code snippet -->
     {% set example %}


### PR DESCRIPTION
Closes sap/fundamental#1127

Implements CSS vars with fallbacks for list type components

#### Test

There should be no discernable visual changes.

* http://localhost:3030/list-group
* http://localhost:3030/tile
* http://localhost:3030/product-tile
* http://localhost:3030/tile-grid
* http://localhost:3030/table
* http://localhost:3030/tree


#### Changelog

**New**

* Adds a label to completed test pages to help track which components have been updated to use CSS vars

**Changed**

* To enable the fallbacks, the flag `$fd-support-css-var-fallback` must be set to `true` in a custom SASS build.


**Removed**

* N/A
