### PR TITLE
#1214 adds new background colors for semantic colors

### DIFF
--- a/docs/_data/colors.yml
+++ b/docs/_data/colors.yml
@@ -17,6 +17,23 @@ group:
     textcolor: 000000
     bordercolor: cfdbe7
 
+# Shell
+- name: Shell
+  key: shell
+  description: Special colors used for the application shellbar background and icons.
+  colors:
+  - colorname: 1
+    colorvalue: 354A5F
+    colorhsl: hsl(210, 28.4%, 29%)
+    textcolor: ffffff
+    bordercolor: ffffff
+
+  - colorname: 2
+    colorvalue: D1E8FF
+    colorhsl: hsl(210, 100%, 91%)
+    textcolor: 000000
+    bordercolor: cfdbe7
+
 # Text
 - name: Text
   key: text
@@ -66,6 +83,26 @@ group:
     colorvalue: FFFFFF
     colorhsl: hsl(210, 0%, 100%)
     textcolor: 000000
+    bordercolor: cfdbe7
+
+  - colorname: 3
+    colorvalue: F1FDF6
+    colorhsl: hsl(145, 77%, 97%)
+    bordercolor: cfdbe7
+
+  - colorname: 4
+    colorvalue: FEF7F1
+    colorhsl: hsl(30, 87.5%, 97%)
+    bordercolor: cfdbe7
+
+  - colorname: 5
+    colorvalue: FFEBEB
+    colorhsl: hsl(0, 100%, 96%)
+    bordercolor: cfdbe7
+
+  - colorname: 6
+    colorvalue: F5FAFF
+    colorhsl: hsl(210, 100%, 98%)
     bordercolor: cfdbe7
 
 # Neutral
@@ -251,36 +288,4 @@ group:
   - colorname: selected-hover
     colorvalue: 0A6ED1
     colorhsl: hsla(210, 91%, 43%, 0.1)
-    bordercolor: cfdbe7
-
-  - colorname: positive
-    colorvalue: E4FCEE
-    colorhsl: hsla(144.7, 77.6%, 94%, 1)
-    bordercolor: cfdbe7
-
-  - colorname: alert
-    colorvalue: FEF7F1
-    colorhsl: hsla(28, 87%, 97%, 1)
-    bordercolor: cfdbe7
-
-  - colorname: negative
-    colorvalue: FFE9E9
-    colorhsl: hsla(0, 100%, 95.7%, 1)
-    bordercolor: cfdbe7
-
-# Shell
-- name: Shell
-  key: shell
-  description: Special colors used for the application shellbar background and icons.
-  colors:
-  - colorname: 1
-    colorvalue: 354A5F
-    colorhsl: hsl(210, 28.4%, 29%)
-    textcolor: ffffff
-    bordercolor: ffffff
-
-  - colorname: 2
-    colorvalue: D1E8FF
-    colorhsl: hsl(210, 100%, 91%)
-    textcolor: 000000
     bordercolor: cfdbe7

--- a/docs/_data/versions.yml
+++ b/docs/_data/versions.yml
@@ -2,7 +2,7 @@
 color:
   status: stable
   since: 1.0.0
-  updated: 1.3.0
+  updated: 1.4.2
 
 spacing:
   status: stable
@@ -32,7 +32,7 @@ shell:
 action-bar:
   status: review
   since: 1.1.0
-  updated: 
+  updated:
 
 ui:
   status: deprecated

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -89,7 +89,11 @@ $fd-colors: map-merge((
   ),
   "background": (
     1: hsl(210, 9%, 93.5%), // #EDEFF0 body background
-    2: hsl(210, 0%, 100%)  // #FFFFFF content background
+    2: hsl(210, 0%, 100%),  // #FFFFFF content background
+    3: hsl(145, 77%, 97%),  // #F1FDF6 positive background
+    4: hsl(30, 87.5%, 97%), // #FEF7F1 alert background
+    5: hsl(0, 100%, 96%),  // #FFEBEB negative background
+    6: hsl(210, 100%, 98%), // #F5FAFF information background
   ),
   "neutral": (
     1: hsl(210, 3%, 98%), // #FAFAFA
@@ -164,9 +168,10 @@ $fd-colors-background-states: map-merge((
   "hover": map-get($fd-colors-neutral, 1),
   "selected": change-color($fd-color--action, $alpha: .07),
   "selected-hover": change-color($fd-color--action, $alpha: .1),
-  "positive": adjust-color($fd-color--positive, $lightness: 66%),
-  "negative": adjust-color($fd-color--negative, $lightness: 49%),
-  "alert": adjust-color($fd-color--alert, $lightness: 49%),
+  "positive": map-get($fd-colors-background, 3),
+  "negative": map-get($fd-colors-background, 5),
+  "alert": map-get($fd-colors-background, 4),
+  "information": map-get($fd-colors-background, 6),
 ), $fd-colors-background-states);
 
 //————————^ FIORI FUNDAMENTALS FOUNDATION ————————^

--- a/scss/components/alert.scss
+++ b/scss/components/alert.scss
@@ -20,7 +20,7 @@ $block: #{$fd-namespace}-alert;
     $fd-alert-background-color--warning: fd-color-state("alert") !default;
     $fd-alert-background-color--error: fd-color-state("negative") !default;
     $fd-alert-background-color--success: fd-color-state("positive") !default;
-    $fd-alert-background-color--information: fd-color-state("selected") !default;
+    $fd-alert-background-color--information: fd-color-state("information") !default;
 
     --fd-alert-background-color: var(--fd-color-neutral-1);
     --fd-alert-border-color: var(--fd-color-neutral-4);
@@ -140,7 +140,7 @@ $block: #{$fd-namespace}-alert;
       }
     }
     &--information {
-      --fd-alert-background-color: var(--fd-color-background-selected);
+      --fd-alert-background-color: var(--fd-color-background-information);
       --fd-alert-border-color: var(--fd-color-action-1);
       &::before,
       &::after {

--- a/scss/components/token.scss
+++ b/scss/components/token.scss
@@ -15,9 +15,9 @@ $block: #{$fd-namespace}-token;
     //LOCAL VARS (set all themeable properties, always include !default)
     $fd-token-border-color: transparent !default;
     $fd-token-color: fd-color("text", 2) !default;
-    $fd-token-background-color: fd-color-state("selected") !default;
+    $fd-token-background-color: fd-color-state("information") !default;
     --fd-token-color: var(--fd-color-text-2);
-    --fd-token-background-color: var(--fd-color-background-selected);
+    --fd-token-background-color: var(--fd-color-background-information);
     --fd-token-border-color: transparent;
 
     @include fd-reset;

--- a/scss/core/root.scss
+++ b/scss/core/root.scss
@@ -14,6 +14,7 @@
   --fd-color-background-hover: #{map-get($fd-colors-background-states, "hover")};
   --fd-color-background-selected: #{map-get($fd-colors-background-states, "selected")};
   --fd-color-background-selected-hover: #{map-get($fd-colors-background-states, "selected-hover")};
+  --fd-color-background-information: #{map-get($fd-colors-background-states, "information")};
   --fd-color-background-positive: #{map-get($fd-colors-background-states, "positive")};
   --fd-color-background-alert: #{map-get($fd-colors-background-states, "alert")};
   --fd-color-background-negative: #{map-get($fd-colors-background-states, "negative")};

--- a/test/templates/pages/styles.njk
+++ b/test/templates/pages/styles.njk
@@ -44,7 +44,11 @@
 
   "background": [
     "hsl(210, 9%, 93.5%) / #EDEFF0 body background",
-    "hsl(210, 9%, 93.5%) / #EDEFF0 body background"
+    "hsl(210, 9%, 93.5%) / #EDEFF0 content background",
+    "hsl(145, 77%, 97%) / #F1FDF6 positive background",
+    "hsl(30, 87.5%, 97%) / #FEF7F1 alert background",
+    "hsl(0, 100%, 96%) / #FFEBEB negative background",
+    "hsl(210, 100%, 98%) / #F5FAFF information background"
   ],
 
   "neutral": [
@@ -95,10 +99,7 @@
   "background": [
     ["hover", "hsla(210, 3%, 98%, 1) / #fafafa"],
     ["selected", "hsla(210, 91%, 43%, 0.07) / n/a"],
-    ["selected-hover", "hsla(210, 91%, 43%, 0.1) / n/a"],
-    ["positive", "hsla(144.86486, 77.62238%, 94.03922%, 1) / #e4fcee"],
-    ["alert", "hsla(28, 87%, 97%, 1) / #fef7f1"],
-    ["negative", "hsla(0, 100%, 95.66667%, 1) / #ffe9e9"]
+    ["selected-hover", "hsla(210, 91%, 43%, 0.1) / n/a"]
   ]
 } %}
 


### PR DESCRIPTION
Closes sap/fundamental#1214

Fixes alert transparency bug by adding semantic background colors to the background colors map. These values are no longer calculated based on the status colors and must be managed when theming.

#### Test

* http://localhost:3030/pages/styles
* http://localhost:4000/foundation/colors.html
* http://localhost:3030/alert
* http://localhost:3030/token

#### Changelog

**New**

* `$fd-colors` map now has status backgrounds as shades 3-6.
* CSS var `--fd-color-background-information` now available

**Changed**

* `alert--information` and `token` now use `information` background instead of `selected` state

**Removed**

* Status backgrounds are no longer listed under state colors but the state color function, e.g., `fd-color-state("positive")`, still works as before