### PR TITLE
#1227 add rtl support to panel

### DIFF
--- a/scss/layout/panel.scss
+++ b/scss/layout/panel.scss
@@ -74,6 +74,10 @@ $block: #{$fd-namespace}-panel;
         margin-left: auto;
         margin-top: -#{fd-space(base)};
         margin-bottom: -#{fd-space(base)};
+        @include fd-rtl() {
+          margin-right: auto;
+          margin-left: 0;          
+        }
     }
     &__filters {
         padding: $fd-panel-filters-padding;

--- a/test/templates/panel/data.json
+++ b/test/templates/panel/data.json
@@ -3,7 +3,7 @@
     "name": "Panel",
     "version": "1.0.0",
     "css_vars": true,
-    "rtl": false,
+    "rtl": true,
     "properties": {
         "title": "Panel Label",
         "description": "Panel Description"


### PR DESCRIPTION
Closes sap/fundamental#1227

Adds `rtl` support to `panel` layout component

> NOTE: I'm not sure why the class name is wrapping in Chrome but actual content seems to work OK

#### Test

* http://localhost:3030/panel
* http://localhost:3030/pages/panel
* http://localhost:3030/panel-grid

#### Changelog

**New**

* N/A

**Changed**

* N/A

**Removed**

* N/A