### PR TITLE
#1225 removes default padding from ul which was affecting rtl mode

### DIFF
--- a/scss/components/nav.scss
+++ b/scss/components/nav.scss
@@ -15,7 +15,7 @@ $block: #{$fd-namespace}-nav;
   @include fd-reset;
   display: flex;
   flex-wrap: wrap;
-  padding-left: 0;
+  padding: 0;
   margin-bottom: $fd-nav-margin-bottom;
   list-style: none;
   //MODIFIERS *******************************************

--- a/scss/core/elements.scss
+++ b/scss/core/elements.scss
@@ -61,7 +61,7 @@ body {
 * Default styles for lists
 */
 ul, ol {
-    padding-left: 0;
+    padding: 0;
 }
 
 /*!

--- a/test/templates/nav/data.json
+++ b/test/templates/nav/data.json
@@ -2,7 +2,7 @@
     "id": "nav",
     "name": "Nav",
     "css_vars": true,
-    "rtl": false,
+    "rtl": true,
     "version": "1.0.0",
     "properties": {
         "items": [


### PR DESCRIPTION
Closes sap/fundamental#1225

Updates `ol, ul` padding to `0` all around to fix `rtl` start indentation

#### Test

* http://localhost:3030/nav

#### Changelog

**New**

* N/A

**Changed**

* N/A

**Removed**

* N/A