### PR TITLE
Use "a" for words that start with a consonant sound

### DIFF
--- a/docs/pages/foundation/index.md
+++ b/docs/pages/foundation/index.md
@@ -8,7 +8,7 @@ folder: foundation
 summary:
 ---
 
-<p>Fiori Fundamentals is an unified, flexible design system that solves complex
+<p>Fiori Fundamentals is a unified, flexible design system that solves complex
 problems in a meaningful way and creates simple intuitive experience.
 </p>
 


### PR DESCRIPTION
Because "unified" has a consonant sound, the article to be used in front of it is "a".

Here are a few articles that, taken together, can explain this in more detail.
https://www.merriam-webster.com/words-at-play/is-it-a-or-an
https://en.oxforddictionaries.com/explore/is-the-letter-y-a-vowel-or-a-consonant/

Closes sap/fundamental#

{{short description}}

#### Test

* {{test thing}}

#### Changelog

**New**

* {{new thing}}

**Changed**

* {{change thing}}

**Removed**

* {{removed thing}}
