### PR TITLE
docs: removes status labels and adds alert messaging on landing

### DIFF
--- a/docs/_data/versions.yml
+++ b/docs/_data/versions.yml
@@ -1,82 +1,66 @@
 ## Version data
 color:
-  status: stable
   since: 1.0.0
   updated: 1.4.2
 
 spacing:
-  status: stable
   since: 1.0.0
   updated:
 
 grid:
-  status: review
   since: 1.0.0
   updated:
 
 type:
-  status: stable
   since: 1.0.0
   updated: 1.3.0
 
 breakpoints:
-  status: new
   since: 1.0.0
   updated: 1.4.0
 
 shell:
-  status: new
   since: 1.4.0
   updated:
 
 action-bar:
-  status: review
   since: 1.1.0
   updated:
 
 ui:
-  status: deprecated
   since: 1.0.0
   updated:
   remove: 1.7.0
 
 app:
-  status: new
   since: 1.4.0
   updated:
 
 page:
-  status: stable
   since: 1.0.0
   updated:
 
 overlay:
-  status: stable
   since: 1.0.0
   updated:
 
 section:
-  status: stable
   since: 1.0.0
   updated:
 
 container:
-  status: review
   since: 1.0.0
   updated:
 
 col:
-  status: review
   since: 1.0.0
   updated:
 
 panel:
-  status: stable
   since: 1.0.0
   updated: 1.1.0
 
 panel-grid:
-  status: stable
   since: 1.0.0
   updated:
 
@@ -84,289 +68,233 @@ panel-grid:
 
 
 alert:
-  status: new
   since: 1.0.0
   updated: 1.4.0
 
 button:
-  status: stable
   since: 1.0.0
   updated: 1.3.0
 
 button-group:
-  status: stable
   since: 1.0.0
   updated: 1.3.0
 
 breadcrumb:
-  status: review
   since: 1.0.0
   updated:
 
 calendar:
-  status: experimental
   since: 1.1.0
   updated:
 
 card-group:
-  status: deprecated
   since: 1.0.0
   updated:
   remove: 1.4.0
 
 card:
-  status: deprecated
   since: 1.0.0
   updated:
   remove: 1.4.0
 
 combobox-input:
-  status: experimental
   since: 1.2.0
   updated: 1.2.1
 
 contextual-menu:
-  status: review
   since: 1.0.0
   updated: 1.4.1
 
 counter:
-  status: new
   since: 1.4.0
   updated:
 
 date-picker:
-  status: experimental
   since: 1.1.0
   updated:
 
 dropdown:
-  status: deprecated
   since: 1.0.0
   updated: 1.2.0
   remove: 1.5.0
 
 global-nav:
-  status: deprecated
   since: 1.0.0
   updated:
   remove: 1.7.0
 
 form:
-  status: stable
   since: 1.0.0
   updated:
 
 checkbox:
-  status: stable
   since: 1.0.0
   updated: 1.3.2
 
 input:
-  status: stable
   since: 1.3.0
   updated:
 
 radio:
-  status: stable
   since: 1.0.0
   updated:
 
 select:
-  status: stable
   since: 1.0.0
   updated: 1.3.0
 
 textarea:
-  status: new
   since: 1.0.0
   updated: 1.4.1
 
 
 icon:
-  status: stable
   since: 1.0.0
   updated:
 
 identifier:
-  status: new
   since: 1.0.0
   updated: 1.3.2
 
 image:
-  status: review
   since: 1.0.0
   updated:
 
 inline-help:
-  status: stable
   since: 1.0.0
   updated: 1.3.0
 
 input-group:
-  status: stable
   since: 1.0.0
   updated:
 
 list-group:
-  status: review
   since: 1.0.0
   updated:
 
 link:
-  status: stable
   since: 1.0.0
   updated:
 
 spinner:
-  status: review
   since: 1.0.0
   updated:
 
 localization-editor:
-  status: experimental
   since: 1.2.0
   updated:
 
 mega-menu:
-  status: deprecated
   since: 1.0.0
   updated:
   remove: 1.7.0
 
 menu:
-  status:
   since: 1.1.0
   updated:
 
 modal:
-  status: review
   since: 1.0.0
   updated:
 
 multi-input:
-  status: experimental
   since: 1.1.0
   updated: 1.2.1
 
 pagination:
-  status: stable
   since: 1.0.0
   updated:
 
 popover:
-  status: review
   since: 1.1.0
   updated: 1.2.1
 
 search-input:
-  status: experimental
   since: 1.2.0
   updated: 1.4.0
 
 shellbar:
-  status: new
   since: 1.4.0
   updated:
 
 product-menu:
-  status: experimental
   since: 1.4.0
   updated:
 
 product-switcher:
-  status: experimental
   since: 1.4.0
   updated:
 
 user-menu:
-  status: experimental
   since: 1.4.0
   updated:
 
 side-nav:
-  status: review
   since: 1.0.0
   updated:
 
 nav:
-  status: review
   since: 1.0.0
   updated:
 
 table:
-  status: review
   since: 1.0.0
   updated: 1.2.0
 
 tabs:
-  status: stable
   since: 1.0.0
   updated:
 
 tag:
-  status: deprecated
   since: 1.0.0
   updated:
   remove: 1.5.0
 
 token:
-  status: stable
   since: 1.3.0
   updated:
 
 toolbar:
-  status: deprecated
   since: 1.0.0
   updated:
   remove: 1.4.0
 
 tile:
-  status: review
   since: 1.0.0
   updated:
 
 tile-grid:
-  status: stable
   since: 1.0.0
   updated:
 
 time:
-  status: review
   since: 1.1.0
   updated:
 
 toggle:
-  status: stable
   since: 1.0.0
   updated:
 
 time-picker:
-  status: experimental
   since: 1.1.0
   updated: 1.3.0
 
 product-tile:
-  status: review
   since: 1.0.0
   updated:
 
 tree:
-  status: review
   since: 1.0.0
   updated:
 
 badge:
-  status: stable
   since: 1.0.0
   updated:
 
 label:
-  status: stable
   since: 1.0.0
   updated:
 
 status-label:
-  status: stable
   since: 1.1.0
   updated:

--- a/docs/_includes/status-container.html
+++ b/docs/_includes/status-container.html
@@ -2,9 +2,6 @@
 {% assign status = site.data.status[version.status] %}
 {% if version %}
 <p class="docs-status">
-  <span class="fd-badge{% if status.type %} fd-badge--{{ status.type }}{% endif %}" style="cursor: help;" title="{{ status.description }}">
-    {{ status.label }}
-  </span>
   <span class="fd-label fd-has-font-weight-normal">
     Available since {{ version.since }}
   </span>

--- a/docs/css/fui-site.css
+++ b/docs/css/fui-site.css
@@ -9228,6 +9228,9 @@ blockquote {
   line-height: 1.4;
   font-weight: 400; }
 
+.docs-alert {
+  margin: 0 0 30px 0; }
+
 #mobile-sidenav-btn {
   display: none; }
   @media (max-width: 768px) {
@@ -9617,7 +9620,7 @@ blockquote {
       .docs-ui-kit_hero-heading {
         font-size: 40px; } }
   .docs-ui-kit_hero-description {
-    max-width: 350px;
+    max-width: 500px;
     margin: 0 auto; }
   .docs-ui-kit_hero-content {
     padding: 60px; }

--- a/docs/pages/components/index.html
+++ b/docs/pages/components/index.html
@@ -7,6 +7,11 @@ permalink: components/index.html
 folder: components
 layout: full-width-page
 ---
+<div class="docs-alert">
+  <div class="fd-alert fd-alert--information" role="alert">
+    In an effort to align component statuses with SAP Global Design and ongoing workstreams, the previous statuses have been removed and will be replaced with updated information soon.
+  </div>
+</div>
 
 <div class="docs-component-grid">
     {% for component in site.data.components.items %}

--- a/docs/scss/_docs-general.scss
+++ b/docs/scss/_docs-general.scss
@@ -84,7 +84,7 @@ pre {
     background-color: #fff;
     border: 1px solid #ccc;
     border-radius: 5px;
-  
+
     code {
       padding: 0;
       font-size: inherit;
@@ -151,6 +151,10 @@ pre {
 
 .docs-intro {
   @include fd-type("3");
+}
+
+.docs-alert {
+  margin: 0 0 30px 0;
 }
 
 


### PR DESCRIPTION
As a result of some confusion around the messaging of the status of components, this removes status labels on individual component pages and adds messaging to the component landing page explaining that there will be additional communication coming.