### PR TITLE
fix: no-duplicate-selectors

### DIFF
--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -1,30 +1,81 @@
+# master ruleset availabe here
+# https://stylelint.io/user-guide/rules/
+
 rules:
-  block-closing-brace-empty-line-before: never
-  block-no-empty: true
-  block-opening-brace-space-before: always
+  # Possible errors
+
+  ## Color
   color-no-invalid-hex: true
+  
+  ## Font family
+  font-family-no-duplicate-names: true
+
+  ## String
+  string-no-newline: true
+  
+  ## Unit
+  unit-no-unknown: true
+  
+  ## Keyframe declaration
+  keyframe-declaration-no-important: true
+
+  ## Block
+  block-no-empty: true
+
+  ## Selector
+  selector-pseudo-class-no-unknown: true
+
+  ## General / Sheet
+  no-duplicate-selectors: true
+  no-empty-source: true
+  no-extra-semicolons: true
+
+
+  # Limit language features
+
+  ## Declaration
+  #declaration-property-value-blacklist: [ { '/^outline$/': 'none' }]
+
+
+  # Stylistic issues
+
+  ## Number
+  number-no-trailing-zeros: true
+
+  ## Length
+  length-zero-no-unit: true
+
+  ## Unit
+  unit-case: lower
+
+  ## Value
+
+  ## Value list
+  max-empty-lines: 2
+
+  ## Property
+  property-case: lower
+
+  ## Declaration
   declaration-bang-space-before: always
-  declaration-block-trailing-semicolon: always
   declaration-colon-space-after: always
   declaration-colon-space-before: never
-  #declaration-property-value-blacklist: [ { '/^outline$/': 'none' }]
-  font-family-no-duplicate-names: true
-  #indentation: 4
-  keyframe-declaration-no-important: true
-  length-zero-no-unit: true
-  max-empty-lines: 2
-  #no-duplicate-selectors: true
-  no-empty-source: true
-  no-eol-whitespace: true
-  no-extra-semicolons: true
-  number-leading-zero: always
-  number-no-trailing-zeros: true
-  property-case: lower
-  selector-list-comma-space-after: always-single-line
-  selector-list-comma-space-before: never
-  selector-pseudo-class-no-unknown: true
+
+  ## Declaration block
+  declaration-block-trailing-semicolon: always
+
+  ## Block
+  block-closing-brace-empty-line-before: never
+  block-opening-brace-space-before: always
+
+  ## Selector
   selector-pseudo-element-case: lower
   selector-pseudo-element-colon-notation: double
-  string-no-newline: true
-  unit-case: lower
-  unit-no-unknown: true
+
+  ## Selector list
+  selector-list-comma-space-after: always-single-line
+  selector-list-comma-space-before: never
+
+  ## General / Sheet
+  #indentation: 4
+  no-eol-whitespace: true

--- a/scss/components/button.scss
+++ b/scss/components/button.scss
@@ -467,7 +467,7 @@ $block: #{$fd-namespace}-button;
   @extend .#{$block}--standard;
 }
 
-
+/* stylelint-disable no-duplicate-selectors */
 //DEPRECATED
 .#{$block} {
   //SETTINGS
@@ -623,3 +623,4 @@ $block: #{$fd-namespace}-button;
       }
     }
 }
+/* stylelint-enable */

--- a/scss/components/calendar.scss
+++ b/scss/components/calendar.scss
@@ -204,14 +204,12 @@ $fd-calendar-table-width: $fd-calendar-table-item-width * 7 !default;
     padding-left: 0;
     padding-right: 0;
   }
-  &__item {
-    @extend %fd-calendar-item;
-  }
   &__day-of-week {
     @include fd-type("-1");
     @include fd-var-color("color", fd-color("text", 3), --fd-color-text-1);
   }
   &__item {
+    @extend %fd-calendar-item;
     &--other-month {
       @extend %fd-calendar-item-other-month;
     }

--- a/scss/components/dropdown.scss
+++ b/scss/components/dropdown.scss
@@ -80,14 +80,6 @@ $block: #{$fd-namespace}-dropdown;
       &--no-border {
         border: none;
       }
-      &.fd-button--compact {
-          padding-top: fd-space(1) - 1;
-        &::after {
-            margin-top: -3px;
-            height: $fd-forms-height - 6;
-            padding-top: fd-space(2) - 1;
-        }
-      }
       // DEPCRECATE these other sizes -------V
       &.fd-button--xs {
         &::after {

--- a/scss/components/spinner.scss
+++ b/scss/components/spinner.scss
@@ -70,6 +70,11 @@ $block: #{$fd-namespace}-spinner;
         height: 100%;
         @include fd-var-color("background-color", $fd-spinner-background-color, --fd-spinner-background-color);
     }
+    //1
+    &::before {
+        animation: line-scale $fd-spinner-animation-speed infinite ease;
+        animation-delay: -($fd-spinner-animation-speed);
+    }
     div {
         &::before,
         &::after {
@@ -77,28 +82,17 @@ $block: #{$fd-namespace}-spinner;
             position: absolute;
             width: $fd-spinner-width--bar;
             height: 100%;
-            @include fd-var-color("background-color", $fd-spinner-background-color, --fd-spinner-background-color);        }
-        &::before {
-            left: $fd-spinner-width--bar + $fd-spinner-width--gutter;
+            @include fd-var-color("background-color", $fd-spinner-background-color, --fd-spinner-background-color);
         }
-        &::after {
-            right: $fd-spinner-width--bar + $fd-spinner-width--gutter;
-        }
-    }
-
-    //1
-    &::before {
-        animation: line-scale $fd-spinner-animation-speed infinite ease;
-        animation-delay: -($fd-spinner-animation-speed);
-    }
-    div {
         //2
         &::before {
+            left: $fd-spinner-width--bar + $fd-spinner-width--gutter;
             animation: line-scale $fd-spinner-animation-speed infinite ease;
             animation-delay: -($fd-spinner-animation-speed - 0.1s);
         }
         //3
         &::after {
+            right: $fd-spinner-width--bar + $fd-spinner-width--gutter;
             animation: line-scale $fd-spinner-animation-speed infinite ease;
             animation-delay: -($fd-spinner-animation-speed - 0.2s);
         }


### PR DESCRIPTION
reorg stylelintrc.yml to match https://stylelint.io/user-guide/rules/ a bit closer.

enable rule:  no-duplicate-selectors

skip no-duplicate-selectors, button.scss - seems to have been called out as to be deprecated.

