### PR TITLE
chore: bad package-lock is causing travis failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13786,6 +13786,12 @@
       "integrity": "sha512-1CxDIZmCQ3vA0GGnkdMQqxUXVm3xXAFmglPYRS1hr37LzSg22TC7QAWOT38OmdUvMEs/rqcnkFoAsqvzdiluDg==",
       "dev": true
     },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+      "dev": true
+    },
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "http://nexus.wdf.sap.corp:8081/nexus/repository/build.milestones.npm/trim-newlines/-/trim-newlines-1.0.0.tgz",


### PR DESCRIPTION
A bad version of remark-parse was checked in in the package-lock file. This is causing failures on npm install inside of Travis.
