### PR TITLE
chore: add missing script netlify script

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,9 +7,9 @@
 
 [build]
   publish = "docs/_site"
-  command = "npm run build-doc"
+  command = "npm run postinstall && npm run build-doc"
 
 # Production context: All deploys to the main
 # repository branch will inherit these settings.
 [context.production]
-  command = "npm run build-doc"
+  command = "npm run postinstall && npm run build-doc"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Fiori Fundamentals is a Design System and HTML/CSS Component Library used to build modern Product User Experiences with the SAP look and feel. Learn more about this project at - http://sap.github.io/fundamental/",
   "main": "index.js",
   "scripts": {
-    "build-doc": "npm run postinstall && gulp docs-site && cd docs && bundle install && bundle exec jekyll build --config _config.yml,_config-library.yml && cd ..",
+    "build-doc": "gulp docs-site && cd docs && bundle install && bundle exec jekyll build --config _config.yml,_config-library.yml && cd ..",
     "build": "npx gulp build:dist",
     "deploy": "gh-pages -d docs",
     "lint:fix": "stylelint './scss/**/*.scss' --fix",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Fiori Fundamentals is a Design System and HTML/CSS Component Library used to build modern Product User Experiences with the SAP look and feel. Learn more about this project at - http://sap.github.io/fundamental/",
   "main": "index.js",
   "scripts": {
-    "build-doc": "gulp docs-site && cd docs && bundle install && bundle exec jekyll build --config _config.yml,_config-library.yml && cd ..",
+    "build-doc": "npm run postinstall && gulp docs-site && cd docs && bundle install && bundle exec jekyll build --config _config.yml,_config-library.yml && cd ..",
     "build": "npx gulp build:dist",
     "deploy": "gh-pages -d docs",
     "lint:fix": "stylelint './scss/**/*.scss' --fix",


### PR DESCRIPTION
The netlify config was missing a step that generated the `_config-library.yml` file. 

See error here:
<img width="1336" alt="Screen Shot 2019-03-16 at 8 09 38 PM" src="https://user-images.githubusercontent.com/29607818/54484752-3f0a2800-4829-11e9-99cf-7ef9716f430b.png">


Logs for previews can be accessed via this link: https://app.netlify.com/sites/sad-jones-0308ea/deploys