### PR TITLE
fix: add trailing semi's

### DIFF
--- a/scss/components/popover.scss
+++ b/scss/components/popover.scss
@@ -39,7 +39,7 @@ $block: #{$fd-namespace}-popover;
       white-space: nowrap;
       z-index: $fd-popover-z-index;
       border-radius: $fd-border-radius;
-      @include fd-var-color("background-color", $fd-popover-background-color, --fd-popover-background-color)
+      @include fd-var-color("background-color", $fd-popover-background-color, --fd-popover-background-color);
       @if $fd-support-css-var-fallback {
         box-shadow: 0 5px 20px 0 fd-color("neutral", 3), 0 2px 8px 0 fd-color("neutral", 2);
       }

--- a/scss/core/forms.scss
+++ b/scss/core/forms.scss
@@ -152,7 +152,7 @@ select,
         left: calc(50% - 10px/2);
     }
     &[multiple] {
-        @include fd-var-size("height", $fd-forms-height * 3)
+        @include fd-var-size("height", $fd-forms-height * 3);
         height: calc(var(--fd-forms-height) * 3);
         background-image: none;
         padding-top: $fd-forms-padding;


### PR DESCRIPTION
fixes #1328 

add missing trailing space. found one other instance, and fixed there as well.

unable to locate a lint-rule to cover this.