### PR TITLE
fix: modify build-doc script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Fiori Fundamentals is a Design System and HTML/CSS Component Library used to build modern Product User Experiences with the SAP look and feel. Learn more about this project at - http://sap.github.io/fundamental/",
   "main": "index.js",
   "scripts": {
-    "build-doc": "gulp docs-site && cd docs && bundle install && bundle exec jekyll build --config _config.yml,_config-library.yml && cd ..",
+    "build-doc": "npm run postinstall && gulp docs-site && cd docs && bundle install && bundle exec jekyll build --config _config.yml,_config-library.yml && cd ..",
     "build": "npx gulp build:dist",
     "deploy": "gh-pages -d docs",
     "lint:fix": "stylelint './scss/**/*.scss' --fix",


### PR DESCRIPTION

Docs site is currently missing version number.

<img width="1365" alt="Screen Shot 2019-03-21 at 3 31 07 PM" src="https://user-images.githubusercontent.com/29607818/54789016-6462b180-4bee-11e9-928b-1d9258e85319.png">

Travis was not running the `postinstall` script as expected. This pr explicitly adds it to the `build-docs` script so that Travis will run it.

After running new `build-docs` script:
<img width="648" alt="Screen Shot 2019-03-21 at 3 32 40 PM" src="https://user-images.githubusercontent.com/29607818/54789085-9ecc4e80-4bee-11e9-83e3-dd5d0f80457f.png">

