### PR TITLE
fix: Fixed broken postinstall script that caused installation problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "stylelint './scss/**/*.scss' --fix",
     "lint:pre-commit": "printf \"running pre-commit lint...\"  && npm run lint && printf \"done!\n\"",
     "lint": "stylelint './scss/**/*.scss'",
-    "postinstall": "./scripts/create-library-config.js",
+    "postinstall": "npm i && ./scripts/create-library-config.js",
     "release:create": "create-release",
     "release": "./scripts/publish-release.sh",
     "start": "npx gulp default",


### PR DESCRIPTION
`npm i fiori-fundamentals` is currently broken. This fixes it. Although I am not 100% sure that this addresses the root problem.

Maybe we could also add some kind of test to ensure this does not happen again? 