### PR TITLE
fix: default header changed for components

### DIFF
--- a/docs/_data/strings.yml
+++ b/docs/_data/strings.yml
@@ -1,3 +1,4 @@
 # placed here for translation purposes
+headerDisclaimer: Although the following examples use the `<h3>` tag for the title element, the styling provided by Fiori Fundamentals will remain consistent for any heading level used. `<h1>` should be reserved for the page title.
 search_placeholder_text: search...
 search_no_results_text: No results found

--- a/docs/_includes/demo-page-components/app-sidebar-content.html
+++ b/docs/_includes/demo-page-components/app-sidebar-content.html
@@ -84,7 +84,7 @@
                         </ul>
                     </div>
                     <div class="fd-side-nav__group">
-                        <h1 class="fd-side-nav__title">Group</h1>
+                        <h3 class="fd-side-nav__title">Group</h3>
                         <ul class="fd-side-nav__list">
                             <li class="fd-side-nav__item">
                                 <a class="fd-side-nav__link" href="#">
@@ -107,9 +107,9 @@
                     <header class="fd-page__header">
                         <div class="fd-action-bar">
                             <div class="fd-action-bar__header">
-                                <h1 class="fd-action-bar__title">
+                                <h3 class="fd-action-bar__title">
                                     Page Title
-                                </h1>
+                                </h3>
                                 <p class="fd-action-bar__description">Optional page intro lorem ipsum dolor</p>
                             </div>
                             <div class="fd-action-bar__actions">

--- a/docs/_includes/demo-page-components/fd-page__header.html
+++ b/docs/_includes/demo-page-components/fd-page__header.html
@@ -1,9 +1,9 @@
 <header class="fd-page__header">
     <div class="fd-action-bar">
         <div class="fd-action-bar__header">
-          <h1 class="fd-action-bar__title">
+          <h3 class="fd-action-bar__title">
               {{ include.title }}
-          </h1>
+          </h3>
           <p class="fd-action-bar__description">Optional page intro lorem ipsum dolor</p>
         </div>
         {% if include.hide-add-btn != "true" %}

--- a/docs/_includes/demo-page-components/modal-app-overlay.html
+++ b/docs/_includes/demo-page-components/modal-app-overlay.html
@@ -2,7 +2,7 @@
     <div class="fd-modal" role="dialog">
       <div class="fd-modal__content" role="document">
           <header class="fd-modal__header">
-              <h1 class="fd-modal__title">Modal Header</h1>
+              <h3 class="fd-modal__title">Modal Header</h3>
               <button class="fd-button--light fd-modal__close"></button>
           </header>
           <div class="fd-modal__body">

--- a/docs/_includes/demo-page-components/table-page-content.html
+++ b/docs/_includes/demo-page-components/table-page-content.html
@@ -2,9 +2,9 @@
     <section class="fd-section">
         <div class="fd-panel">
             <div class="fd-panel__header">
-                <h1 class="fd-panel__title">
+                <h3 class="fd-panel__title">
                     Items (1180)
-                </h1>
+                </h3>
                 <div class="fd-panel__actions">
                     <div class="fd-dropdown">
                         <div class="fd-popover">

--- a/docs/_includes/demo-page-components/tile-page-content.html
+++ b/docs/_includes/demo-page-components/tile-page-content.html
@@ -20,7 +20,7 @@
                             <span class=" fd-identifier--m sap-icon--person-placeholder fd-has-background-color-accent-1"></span>
                         </div>
                         <div class="fd-tile__content">
-                            <h2 class="fd-tile__title">Lorem ipsum</h2><p>Second line</p>
+                            <h3 class="fd-tile__title">Lorem ipsum</h3><p>Second line</p>
                             <p>
                                 <span class="fd-badge fd-badge--success fd-badge--filled fd-sap-icon--accept">
                                     Active
@@ -36,7 +36,7 @@
                             <span class=" fd-identifier--m sap-icon--person-placeholder fd-has-background-color-accent-1"></span>
                         </div>
                         <div class="fd-tile__content">
-                            <h2 class="fd-tile__title">Lorem ipsum</h2><p>Second line</p>
+                            <h3 class="fd-tile__title">Lorem ipsum</h3><p>Second line</p>
                             <p>
                                 <span class="fd-badge fd-badge--success fd-badge--filled fd-sap-icon--accept">
                                     Active
@@ -52,7 +52,7 @@
                             <span class=" fd-identifier--m sap-icon--person-placeholder fd-has-background-color-accent-1"></span>
                         </div>
                         <div class="fd-tile__content">
-                            <h2 class="fd-tile__title">Lorem ipsum</h2><p>Second line</p>
+                            <h3 class="fd-tile__title">Lorem ipsum</h3><p>Second line</p>
                             <p>
                                 <span class="fd-badge fd-badge--success fd-badge--filled fd-sap-icon--accept">
                                     Active
@@ -68,7 +68,7 @@
                             <span class=" fd-identifier--m sap-icon--person-placeholder fd-has-background-color-accent-1"></span>
                         </div>
                         <div class="fd-tile__content">
-                            <h2 class="fd-tile__title">Lorem ipsum</h2><p>Second line</p>
+                            <h3 class="fd-tile__title">Lorem ipsum</h3><p>Second line</p>
                             <p>
                                 <span class="fd-badge fd-badge--success fd-badge--filled fd-sap-icon--accept">
                                     Active
@@ -84,7 +84,7 @@
                             <span class=" fd-identifier--m sap-icon--person-placeholder fd-has-background-color-accent-1"></span>
                         </div>
                         <div class="fd-tile__content">
-                            <h2 class="fd-tile__title">Lorem ipsum</h2><p>Second line</p>
+                            <h3 class="fd-tile__title">Lorem ipsum</h3><p>Second line</p>
                             <p>
                                 <span class="fd-badge fd-badge--success fd-badge--filled fd-sap-icon--accept">
                                     Active
@@ -100,7 +100,7 @@
                             <span class=" fd-identifier--m sap-icon--person-placeholder fd-has-background-color-accent-1"></span>
                         </div>
                         <div class="fd-tile__content">
-                            <h2 class="fd-tile__title">Lorem ipsum</h2><p>Second line</p>
+                            <h3 class="fd-tile__title">Lorem ipsum</h3><p>Second line</p>
                             <p>
                                 <span class="fd-badge fd-badge--success fd-badge--filled fd-sap-icon--accept">
                                     Active
@@ -116,7 +116,7 @@
                             <span class=" fd-identifier--m sap-icon--person-placeholder fd-has-background-color-accent-1"></span>
                         </div>
                         <div class="fd-tile__content">
-                            <h2 class="fd-tile__title">Lorem ipsum</h2><p>Second line</p>
+                            <h3 class="fd-tile__title">Lorem ipsum</h3><p>Second line</p>
                             <p>
                                 <span class="fd-badge fd-badge--success fd-badge--filled fd-sap-icon--accept">
                                     Active
@@ -132,7 +132,7 @@
                             <span class=" fd-identifier--m sap-icon--person-placeholder fd-has-background-color-accent-1"></span>
                         </div>
                         <div class="fd-tile__content">
-                            <h2 class="fd-tile__title">Lorem ipsum</h2><p>Second line</p>
+                            <h3 class="fd-tile__title">Lorem ipsum</h3><p>Second line</p>
                             <p>
                                 <span class="fd-badge fd-badge--success fd-badge--filled fd-sap-icon--accept">
                                     Active
@@ -148,7 +148,7 @@
                             <span class=" fd-identifier--m sap-icon--person-placeholder fd-has-background-color-accent-1"></span>
                         </div>
                         <div class="fd-tile__content">
-                            <h2 class="fd-tile__title">Lorem ipsum</h2><p>Second line</p>
+                            <h3 class="fd-tile__title">Lorem ipsum</h3><p>Second line</p>
                             <p>
                                 <span class="fd-badge fd-badge--success fd-badge--filled fd-sap-icon--accept">
                                     Active
@@ -164,7 +164,7 @@
                             <span class=" fd-identifier--m sap-icon--person-placeholder fd-has-background-color-accent-1"></span>
                         </div>
                         <div class="fd-tile__content">
-                            <h2 class="fd-tile__title">Lorem ipsum</h2><p>Second line</p>
+                            <h3 class="fd-tile__title">Lorem ipsum</h3><p>Second line</p>
                             <p>
                                 <span class="fd-badge fd-badge--success fd-badge--filled fd-sap-icon--accept">
                                     Active
@@ -180,7 +180,7 @@
                             <span class=" fd-identifier--m sap-icon--person-placeholder fd-has-background-color-accent-1"></span>
                         </div>
                         <div class="fd-tile__content">
-                            <h2 class="fd-tile__title">Lorem ipsum</h2><p>Second line</p>
+                            <h3 class="fd-tile__title">Lorem ipsum</h3><p>Second line</p>
                             <p>
                                 <span class="fd-badge fd-badge--success fd-badge--filled fd-sap-icon--accept">
                                     Active
@@ -196,7 +196,7 @@
                             <span class=" fd-identifier--m sap-icon--person-placeholder fd-has-background-color-accent-1"></span>
                         </div>
                         <div class="fd-tile__content">
-                            <h2 class="fd-tile__title">Lorem ipsum</h2><p>Second line</p>
+                            <h3 class="fd-tile__title">Lorem ipsum</h3><p>Second line</p>
                             <p>
                                 <span class="fd-badge fd-badge--success fd-badge--filled fd-sap-icon--accept">
                                     Active
@@ -212,7 +212,7 @@
                             <span class=" fd-identifier--m sap-icon--person-placeholder fd-has-background-color-accent-1"></span>
                         </div>
                         <div class="fd-tile__content">
-                            <h2 class="fd-tile__title">Lorem ipsum</h2><p>Second line</p>
+                            <h3 class="fd-tile__title">Lorem ipsum</h3><p>Second line</p>
                             <p>
                                 <span class="fd-badge fd-badge--success fd-badge--filled fd-sap-icon--accept">
                                     Active
@@ -228,7 +228,7 @@
                             <span class=" fd-identifier--m sap-icon--person-placeholder fd-has-background-color-accent-1"></span>
                         </div>
                         <div class="fd-tile__content">
-                            <h2 class="fd-tile__title">Lorem ipsum</h2><p>Second line</p>
+                            <h3 class="fd-tile__title">Lorem ipsum</h3><p>Second line</p>
                             <p>
                                 <span class="fd-badge fd-badge--success fd-badge--filled fd-sap-icon--accept">
                                     Active
@@ -244,7 +244,7 @@
                             <span class=" fd-identifier--m sap-icon--person-placeholder fd-has-background-color-accent-1"></span>
                         </div>
                         <div class="fd-tile__content">
-                            <h2 class="fd-tile__title">Lorem ipsum</h2><p>Second line</p>
+                            <h3 class="fd-tile__title">Lorem ipsum</h3><p>Second line</p>
                             <p>
                                 <span class="fd-badge fd-badge--success fd-badge--filled fd-sap-icon--accept">
                                     Active
@@ -260,7 +260,7 @@
                             <span class=" fd-identifier--m sap-icon--person-placeholder fd-has-background-color-accent-1"></span>
                         </div>
                         <div class="fd-tile__content">
-                            <h2 class="fd-tile__title">Lorem ipsum</h2><p>Second line</p>
+                            <h3 class="fd-tile__title">Lorem ipsum</h3><p>Second line</p>
                             <p>
                                 <span class="fd-badge fd-badge--success fd-badge--filled fd-sap-icon--accept">
                                     Active
@@ -276,7 +276,7 @@
                             <span class=" fd-identifier--m sap-icon--person-placeholder fd-has-background-color-accent-1"></span>
                         </div>
                         <div class="fd-tile__content">
-                            <h2 class="fd-tile__title">Lorem ipsum</h2><p>Second line</p>
+                            <h3 class="fd-tile__title">Lorem ipsum</h3><p>Second line</p>
                             <p>
                                 <span class="fd-badge fd-badge--success fd-badge--filled fd-sap-icon--accept">
                                     Active
@@ -292,7 +292,7 @@
                             <span class=" fd-identifier--m sap-icon--person-placeholder fd-has-background-color-accent-1"></span>
                         </div>
                         <div class="fd-tile__content">
-                            <h2 class="fd-tile__title">Lorem ipsum</h2><p>Second line</p>
+                            <h3 class="fd-tile__title">Lorem ipsum</h3><p>Second line</p>
                             <p>
                                 <span class="fd-badge fd-badge--success fd-badge--filled fd-sap-icon--accept">
                                     Active

--- a/docs/_includes/demo-page-components/tile-page-content.html
+++ b/docs/_includes/demo-page-components/tile-page-content.html
@@ -2,9 +2,9 @@
     <section class="fd-section">
         <div class="fd-panel">
             <div class="fd-panel__header">
-                <h1 class="fd-panel__title">
+                <h3 class="fd-panel__title">
                     Items (18)
-                </h1>
+                </h3>
                 <div class="fd-panel__actions">
                     <button class="fd-button--compact fd-button--standard sap-icon--search" aria-label="Search"></button>
                     <div class="fd-button-group" role="group" aria-label="Show as">

--- a/docs/_includes/demo-page-components/tree-page-content.html
+++ b/docs/_includes/demo-page-components/tree-page-content.html
@@ -2,9 +2,9 @@
     <section class="fd-section">
         <div class="fd-panel">
             <div class="fd-panel__header">
-                <h1 class="fd-panel__title">
+                <h3 class="fd-panel__title">
                     Categories
-                </h1>
+                </h3>
             </div>
             <div class="fd-panel__body fd-panel__body--bleed">
                 <div class="fd-tree fd-tree--header">

--- a/docs/pages/components/action-bar.md
+++ b/docs/pages/components/action-bar.md
@@ -22,9 +22,9 @@ The Action Bar is located at the top of the page and is used for the following:
         <button class="fd-button--light fd-button--compact sap-icon--nav-back"></button>
     </div>
     <div class="fd-action-bar__header">
-        <h1 class="fd-action-bar__title">
+        <h3 class="fd-action-bar__title">
         Page Title
-        </h1>
+        </h3>
         <p class="fd-action-bar__description">Action bar Description </p>
     </div>
     <div class="fd-action-bar__actions">
@@ -42,9 +42,9 @@ The Action Bar is located at the top of the page and is used for the following:
 {% capture default-action-bar-multi %}
 <div class="fd-action-bar">
     <div class="fd-action-bar__header">
-        <h1 class="fd-action-bar__title">
+        <h3 class="fd-action-bar__title">
             Page Title
-        </h1>
+        </h3>
         <p class="fd-action-bar__description">Action bar Description </p>
     </div>
     <div class="fd-action-bar__actions">
@@ -65,9 +65,9 @@ When there are several main actions for a page, consider displaying them under a
 {% capture default-action-bar-menu %}
 <div class="fd-action-bar">
     <div class="fd-action-bar__header">
-      <h1 class="fd-action-bar__title">
+      <h3 class="fd-action-bar__title">
           Page Title
-      </h1>
+      </h3>
     </div>
     <div class="fd-action-bar__actions">
             <div class="fd-popover">
@@ -130,4 +130,4 @@ When there are several main actions for a page, consider displaying them under a
 </div>
 {% endcapture %}
 
-{% include display-component.html component=default-action-bar-multi %}
+{% include display-component.html default-action-bar-multi %}

--- a/docs/pages/components/action-bar.md
+++ b/docs/pages/components/action-bar.md
@@ -12,7 +12,9 @@ The Action Bar is located at the top of the page and is used for the following:
 {: .docs-intro}
 - Page title
 - Main Actions for the page
-
+  
+<br>
+We use an H3 header here, however header sizes from H2 to H6 are also acceptable.
 <br>
 
 ## Action bar with back button, description and action buttons.
@@ -98,7 +100,7 @@ When there are several main actions for a page, consider displaying them under a
 ## Action bar mobile view
 
 {% capture default-action-bar-multi %}
-<div style="width:319px">
+<div style="width:319px;">
     <div class="fd-action-bar">
         <div class="fd-action-bar__back">
             <button class="fd-button--light fd-button--compact sap-icon--nav-back"></button>

--- a/docs/pages/components/action-bar.md
+++ b/docs/pages/components/action-bar.md
@@ -104,9 +104,9 @@ When there are several main actions for a page, consider displaying them under a
             <button class="fd-button--light fd-button--compact sap-icon--nav-back"></button>
         </div>
         <div class="fd-action-bar__header">
-            <h1 class="fd-action-bar__title">
+            <h3 class="fd-action-bar__title">
                 Action Bar with description and back button
-            </h1>
+            </h3>
         </div>
         <div class="fd-action-bar__actions">
             <div class="fd-popover">
@@ -130,4 +130,4 @@ When there are several main actions for a page, consider displaying them under a
 </div>
 {% endcapture %}
 
-{% include display-component.html default-action-bar-multi %}
+{% include display-component.html component=default-action-bar-multi %}

--- a/docs/pages/components/action-bar.md
+++ b/docs/pages/components/action-bar.md
@@ -12,10 +12,9 @@ The Action Bar is located at the top of the page and is used for the following:
 {: .docs-intro}
 - Page title
 - Main Actions for the page
-  
-<br>
-We use an H3 header here, however header sizes from H2 to H6 are also acceptable.
-<br>
+
+> Although the following examples use the `<h3>` tag for the title element, the styling provided by Fiori Fundamentals will remain consistent for any heading level used. `<h1>` should be reserved for the page title.
+
 
 ## Action bar with back button, description and action buttons.
 {% capture default-action-bar %}

--- a/docs/pages/components/action-bar.md
+++ b/docs/pages/components/action-bar.md
@@ -13,7 +13,7 @@ The Action Bar is located at the top of the page and is used for the following:
 - Page title
 - Main Actions for the page
 
-> Although the following examples use the `<h3>` tag for the title element, the styling provided by Fiori Fundamentals will remain consistent for any heading level used. `<h1>` should be reserved for the page title.
+> {{ site.data.strings.headerDisclaimer }}
 
 
 ## Action bar with back button, description and action buttons.

--- a/docs/pages/components/contextual-menu.md
+++ b/docs/pages/components/contextual-menu.md
@@ -21,8 +21,6 @@ Implementation Guidelines:
 - Opening one menu should close all other menus
 - Clicking away from the menu should also close the menu
 
-<br>
-
 > {{ site.data.strings.headerDisclaimer }}
 
 ## With Icon

--- a/docs/pages/components/contextual-menu.md
+++ b/docs/pages/components/contextual-menu.md
@@ -59,7 +59,7 @@ Implementation Guidelines:
                 <li><a href="#" class="fd-menu__item">Option 3</a></li>
             </ul>
             <div class="fd-menu__group">
-                <h1 class="fd-menu__title">Group Header</h1>
+                <h3 class="fd-menu__title">Group Header</h3>
                 <ul class="fd-menu__list">
                     <li><a href="#" class="fd-menu__item">Option 4</a></li>
                     <li><a href="#" class="fd-menu__item">Option 5</a></li>

--- a/docs/pages/components/contextual-menu.md
+++ b/docs/pages/components/contextual-menu.md
@@ -23,6 +23,8 @@ Implementation Guidelines:
 
 <br>
 
+> {{ site.data.strings.headerDisclaimer }}
+
 ## With Icon
 {% capture default-contextualmenu %}
 <div class="fd-popover">

--- a/docs/pages/components/loading-spinner.md
+++ b/docs/pages/components/loading-spinner.md
@@ -41,7 +41,7 @@ The spinner should be included inside the container. Visibility can be toggled i
         <div></div>
     </div>
     <div class="fd-panel__header">
-        <h1 class="fd-panel__title">Lorem ipsum</h1>
+        <h3 class="fd-panel__title">Lorem ipsum</h3>
     </div>
     <!-- Loaded content goes here -->
     <div class="fd-panel__footer">

--- a/docs/pages/components/loading-spinner.md
+++ b/docs/pages/components/loading-spinner.md
@@ -14,7 +14,7 @@ A loading spinner informs the user of an ongoing operation. Only one busy indica
 The aria-hidden attribute is used to hide and show the element.
 Loading indicators are not visible all the time, only when needed. To show and hide the loading indicator the `aria-hidden` attribute is used to hide/show the element.
 
-<br>
+> {{ site.data.strings.headerDisclaimer }}
 
 ## Loader element
 

--- a/docs/pages/components/mega-menu.md
+++ b/docs/pages/components/mega-menu.md
@@ -13,13 +13,15 @@ Mega menu is used in conjunction with Context Switcher within the Global Navigat
 {: .docs-intro}
 
 <br>
+We use an H3 header here, however header sizes from H2 to H6 are also acceptable.
+<br>
 
 ## Default Mega Menu
 
 {% capture default-alert %}
 <nav class="fd-mega-menu" id="">
     <div class="fd-mega-menu__group">
-        <h1 class="fd-mega-menu__title">Group Name</h1>
+        <h3 class="fd-mega-menu__title">Group Name</h3>
         <ul class="fd-mega-menu__list">
             <li class="fd-mega-menu__item">
                 <a class="fd-mega-menu__link" href="#">
@@ -56,7 +58,7 @@ Mega menu is used in conjunction with Context Switcher within the Global Navigat
         </ul>
     </div>
     <div class="fd-mega-menu__group">
-        <h1 class="fd-mega-menu__title">Group Name</h1>
+        <h3 class="fd-mega-menu__title">Group Name</h3>
         <ul class="fd-mega-menu__list">
             <li class="fd-mega-menu__item">
                 <a class="fd-mega-menu__link" href="#">

--- a/docs/pages/components/mega-menu.md
+++ b/docs/pages/components/mega-menu.md
@@ -12,7 +12,7 @@ summary:
 Mega menu is used in conjunction with Context Switcher within the Global Navigation (link to Global Nav page) and supports two levels within a hierarchy.
 {: .docs-intro}
 
-> Although the following examples use the `<h3>` tag for the title element, the styling provided by Fiori Fundamentals will remain consistent for any heading level used. `<h1>` should be reserved for the page title.
+> {{ site.data.strings.headerDisclaimer }}
 
 ## Default Mega Menu
 

--- a/docs/pages/components/mega-menu.md
+++ b/docs/pages/components/mega-menu.md
@@ -12,9 +12,7 @@ summary:
 Mega menu is used in conjunction with Context Switcher within the Global Navigation (link to Global Nav page) and supports two levels within a hierarchy.
 {: .docs-intro}
 
-<br>
-We use an H3 header here, however header sizes from H2 to H6 are also acceptable.
-<br>
+> Although the following examples use the `<h3>` tag for the title element, the styling provided by Fiori Fundamentals will remain consistent for any heading level used. `<h1>` should be reserved for the page title.
 
 ## Default Mega Menu
 

--- a/docs/pages/components/menu.md
+++ b/docs/pages/components/menu.md
@@ -13,10 +13,6 @@ The menu component is the listing structure with optional headers to create menu
 {: .docs-intro}
 Commonly used as the contents when composing "dropdowns", "contextual menus", "mega menu", etc, when paired with the popover component.
 
-<br>
-We use an H3 header here, however header sizes from H2 to H6 are also acceptable.
-<br>
-
 ## Menu
 The basic stucture of a menu.
 
@@ -57,6 +53,8 @@ Use a modifier on the list element to add separators between the items.
 
 ## Menu with group headers
 You can optionally add hierarchy to menus by grouping sub-menus and adding headers.
+
+> Although the following example uses the `<h3>` tag for the menu title element, the styling provided by Fiori Fundamentals will remain consistent for any heading level used. `<h1>` should be reserved for the page title.
 
 {% capture default-menuwgroup %}
 <nav class="fd-menu">

--- a/docs/pages/components/menu.md
+++ b/docs/pages/components/menu.md
@@ -13,6 +13,8 @@ The menu component is the listing structure with optional headers to create menu
 {: .docs-intro}
 Commonly used as the contents when composing "dropdowns", "contextual menus", "mega menu", etc, when paired with the popover component.
 
+> {{ site.data.strings.headerDisclaimer }}
+
 ## Menu
 The basic stucture of a menu.
 
@@ -53,8 +55,6 @@ Use a modifier on the list element to add separators between the items.
 
 ## Menu with group headers
 You can optionally add hierarchy to menus by grouping sub-menus and adding headers.
-
-> Although the following example uses the `<h3>` tag for the menu title element, the styling provided by Fiori Fundamentals will remain consistent for any heading level used. `<h1>` should be reserved for the page title.
 
 {% capture default-menuwgroup %}
 <nav class="fd-menu">

--- a/docs/pages/components/menu.md
+++ b/docs/pages/components/menu.md
@@ -14,6 +14,8 @@ The menu component is the listing structure with optional headers to create menu
 Commonly used as the contents when composing "dropdowns", "contextual menus", "mega menu", etc, when paired with the popover component.
 
 <br>
+We use an H3 header here, however header sizes from H2 to H6 are also acceptable.
+<br>
 
 ## Menu
 The basic stucture of a menu.
@@ -64,7 +66,7 @@ You can optionally add hierarchy to menus by grouping sub-menus and adding heade
         <li><a href="#" class="fd-menu__item">Option 3</a></li>
     </ul>
     <div class="fd-menu__group">
-        <h1 class="fd-menu__title">Group Header</h1>
+        <h3 class="fd-menu__title">Group Header</h3>
         <ul class="fd-menu__list">
             <li><a href="#" class="fd-menu__item">Option 4</a></li>
             <li><a href="#" class="fd-menu__item">Option 5</a></li>

--- a/docs/pages/components/modal.md
+++ b/docs/pages/components/modal.md
@@ -12,9 +12,8 @@ summary:
 The modal is a container generally displayed in response to an action.
 {: .docs-intro}
 It is used for short forms, confirmation messages or to display contextual information that does not require a page. The modal should always be used in conjunction with the [Application Layout Containers](/layouts/application-layout.html#application-with-ui-overlay). See an example [App layout page with Modal](/demo-pages/modal-overlay-demo-page.html)
-<br>
-We use an H3 header here, however header sizes from H2 to H6 are also acceptable.
-<br>  
+
+> Although the following examples use the `<h3>` tag for the title element, the styling provided by Fiori Fundamentals will remain consistent for any heading level used. `<h1>` should be reserved for the page title.
 
 
 ## Informational Modal

--- a/docs/pages/components/modal.md
+++ b/docs/pages/components/modal.md
@@ -12,7 +12,8 @@ summary:
 The modal is a container generally displayed in response to an action.
 {: .docs-intro}
 It is used for short forms, confirmation messages or to display contextual information that does not require a page. The modal should always be used in conjunction with the [Application Layout Containers](/layouts/application-layout.html#application-with-ui-overlay). See an example [App layout page with Modal](/demo-pages/modal-overlay-demo-page.html)
-
+<br>
+We use an H3 header here, however header sizes from H2 to H6 are also acceptable.
 <br>  
 
 
@@ -52,7 +53,7 @@ This is used to confirm with the user before continuing with a destructive or co
 <div class="fd-modal">
     <div class="fd-modal__content" role="document">
         <div class="fd-modal__header">
-            <h1 class="fd-modal__title">Delete</h1>
+            <h3 class="fd-modal__title">Delete</h3>
             <button class="fd-button--light fd-modal__close" aria-label="close"></button>
         </div>
         <div class="fd-modal__body">
@@ -81,7 +82,7 @@ This is used for short forms in order to collect information from the user.
 <div class="fd-modal">
     <div class="fd-modal__content" role="document">
         <div class="fd-modal__header">
-            <h1 class="fd-modal__title">Invite user</h1>
+            <h3 class="fd-modal__title">Invite user</h3>
             <button class="fd-button--light fd-modal__close" aria-label="close"></button>
         </div>
         <div class="fd-modal__body">

--- a/docs/pages/components/modal.md
+++ b/docs/pages/components/modal.md
@@ -25,7 +25,7 @@ This is used to present information to the user but the Alert Component doesn’
 <div class="fd-modal">
     <div class="fd-modal__content" role="document">
         <div class="fd-modal__header">
-            <h1 class="fd-modal__title">Product Added</h1>
+            <h3 class="fd-modal__title">Product Added</h3>
             <button class="fd-button--light fd-modal__close" aria-label="close"></button>
         </div>
         <div class="fd-modal__body">

--- a/docs/pages/components/modal.md
+++ b/docs/pages/components/modal.md
@@ -13,7 +13,7 @@ The modal is a container generally displayed in response to an action.
 {: .docs-intro}
 It is used for short forms, confirmation messages or to display contextual information that does not require a page. The modal should always be used in conjunction with the [Application Layout Containers](/layouts/application-layout.html#application-with-ui-overlay). See an example [App layout page with Modal](/demo-pages/modal-overlay-demo-page.html)
 
-> Although the following examples use the `<h3>` tag for the title element, the styling provided by Fiori Fundamentals will remain consistent for any heading level used. `<h1>` should be reserved for the page title.
+> {{ site.data.strings.headerDisclaimer }}
 
 
 ## Informational Modal

--- a/docs/pages/components/side-navigation.md
+++ b/docs/pages/components/side-navigation.md
@@ -11,9 +11,8 @@ summary:
 
 The left navigation can always display or expand/collapse using the menu icon within the global navigation.
 {: .docs-intro}
-<br>
-We use an H3 header here, however header sizes from H2 to H6 are also acceptable.
-<br>
+
+> Although the following examples use the `<h3>` tag for the title element, the styling provided by Fiori Fundamentals will remain consistent for any heading level used. `<h1>` should be reserved for the page title.
 
 ## Side Navigation with one level
 {% capture default %}

--- a/docs/pages/components/side-navigation.md
+++ b/docs/pages/components/side-navigation.md
@@ -12,7 +12,7 @@ summary:
 The left navigation can always display or expand/collapse using the menu icon within the global navigation.
 {: .docs-intro}
 
-> Although the following examples use the `<h3>` tag for the title element, the styling provided by Fiori Fundamentals will remain consistent for any heading level used. `<h1>` should be reserved for the page title.
+> {{ site.data.strings.headerDisclaimer }}
 
 ## Side Navigation with one level
 {% capture default %}

--- a/docs/pages/components/side-navigation.md
+++ b/docs/pages/components/side-navigation.md
@@ -11,7 +11,8 @@ summary:
 
 The left navigation can always display or expand/collapse using the menu icon within the global navigation.
 {: .docs-intro}
-
+<br>
+We use an H3 header here, however header sizes from H2 to H6 are also acceptable.
 <br>
 
 ## Side Navigation with one level
@@ -61,7 +62,7 @@ Use this to group navigation. Titles are not clickable.
 {% capture default %}
 <nav class="fd-side-nav">
     <div class="fd-side-nav__group">
-        <h1 class="fd-side-nav__title">Group Title</h1>
+        <h3 class="fd-side-nav__title">Group Title</h3>
         <ul class="fd-side-nav__list">
             <li class="fd-side-nav__item">
                 <a class="fd-side-nav__link" href="#">
@@ -91,7 +92,7 @@ Use this to group navigation. Titles are not clickable.
         </ul>
     </div>
     <div class="fd-side-nav__group">
-        <h1 class="fd-side-nav__title">Group Title</h1>
+        <h3 class="fd-side-nav__title">Group Title</h3>
         <ul class="fd-side-nav__list">
             <li class="fd-side-nav__item">
                 <a class="fd-side-nav__link" href="#">
@@ -131,7 +132,7 @@ Use this when there is more than one level of hierarchy in the left navigation. 
 {% capture default %}
 <nav class="fd-side-nav">
     <div class="fd-side-nav__group">
-        <h1 class="fd-side-nav__title">Group Name</h1>
+        <h3 class="fd-side-nav__title">Group Name</h3>
         <ul class="fd-side-nav__list">
             <li class="fd-side-nav__item">
                 <a class="fd-side-nav__link" href="#">
@@ -215,7 +216,7 @@ Use this when there is more than one level of hierarchy in the left navigation. 
 </ul>
 </div>
 <div class="fd-side-nav__group">
-    <h1 class="fd-side-nav__title">Group Name</h1>
+    <h3 class="fd-side-nav__title">Group Name</h3>
     <ul class="fd-side-nav__list">
         <li class="fd-side-nav__item">
             <a class="fd-side-nav__link" href="#">

--- a/docs/pages/components/tile-grid.md
+++ b/docs/pages/components/tile-grid.md
@@ -24,32 +24,32 @@ Also available as a modifier class `--3col`
 <div class="fd-tile-grid">
     <div class="fd-tile">
         <div class="fd-tile__content">
-          <h2 class="fd-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-          <h2 class="fd-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-          <h2 class="fd-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-          <h2 class="fd-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-          <h2 class="fd-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-          <h2 class="fd-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
 </div>
@@ -68,7 +68,7 @@ Also available as a modifier class `--3col`
             <span class=" fd-identifier--m sap-icon--home fd-has-background-color-accent-3"></span>
         </div>
         <div class="fd-tile__content">
-          <h2 class="fd-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
@@ -76,7 +76,7 @@ Also available as a modifier class `--3col`
             <span class=" fd-identifier--m sap-icon--home fd-has-background-color-accent-3"></span>
         </div>
         <div class="fd-tile__content">
-          <h2 class="fd-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
@@ -84,7 +84,7 @@ Also available as a modifier class `--3col`
             <span class=" fd-identifier--m sap-icon--home fd-has-background-color-accent-3"></span>
         </div>
         <div class="fd-tile__content">
-          <h2 class="fd-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
@@ -92,7 +92,7 @@ Also available as a modifier class `--3col`
             <span class=" fd-identifier--m sap-icon--home fd-has-background-color-accent-3"></span>
         </div>
         <div class="fd-tile__content">
-          <h2 class="fd-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
 </div>
@@ -107,42 +107,42 @@ Also available as a modifier class `--3col`
 <div class="fd-tile-grid fd-tile-grid--4col">
     <div class="fd-tile">
         <div class="fd-tile__content">
-          <h2 class="fd-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-          <h2 class="fd-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-          <h2 class="fd-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-          <h2 class="fd-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-          <h2 class="fd-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-          <h2 class="fd-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-          <h2 class="fd-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-          <h2 class="fd-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
 </div>
@@ -157,52 +157,52 @@ Also available as a modifier class `--3col`
 <div class="fd-tile-grid fd-tile-grid--5col">
     <div class="fd-tile">
         <div class="fd-tile__content">
-            <h2 class="fd-tile__title">Lorem ipsum</h2>
+            <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-            <h2 class="fd-tile__title">Lorem ipsum</h2>
+            <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-            <h2 class="fd-tile__title">Lorem ipsum</h2>
+            <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-            <h2 class="fd-tile__title">Lorem ipsum</h2>
+            <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-            <h2 class="fd-tile__title">Lorem ipsum</h2>
+            <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-            <h2 class="fd-tile__title">Lorem ipsum</h2>
+            <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-            <h2 class="fd-tile__title">Lorem ipsum</h2>
+            <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-            <h2 class="fd-tile__title">Lorem ipsum</h2>
+            <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-            <h2 class="fd-tile__title">Lorem ipsum</h2>
+            <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-            <h2 class="fd-tile__title">Lorem ipsum</h2>
+            <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
 </div>
@@ -217,62 +217,62 @@ Also available as a modifier class `--3col`
 <div class="fd-tile-grid fd-tile-grid--6col">
     <div class="fd-tile">
         <div class="fd-tile__content">
-            <h2 class="fd-tile__title">Lorem ipsum</h2>
+            <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-            <h2 class="fd-tile__title">Lorem ipsum</h2>
+            <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-            <h2 class="fd-tile__title">Lorem ipsum</h2>
+            <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-            <h2 class="fd-tile__title">Lorem ipsum</h2>
+            <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-            <h2 class="fd-tile__title">Lorem ipsum</h2>
+            <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-            <h2 class="fd-tile__title">Lorem ipsum</h2>
+            <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-            <h2 class="fd-tile__title">Lorem ipsum</h2>
+            <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-            <h2 class="fd-tile__title">Lorem ipsum</h2>
+            <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-            <h2 class="fd-tile__title">Lorem ipsum</h2>
+            <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-            <h2 class="fd-tile__title">Lorem ipsum</h2>
+            <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-            <h2 class="fd-tile__title">Lorem ipsum</h2>
+            <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-            <h2 class="fd-tile__title">Lorem ipsum</h2>
+            <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
 </div>
@@ -288,49 +288,49 @@ Also available as a modifier class `--3col`
     <div class="fd-product-tile" role="button">
         <div class="fd-product-tile__media" style="background-image: url('https://techne.yaas.io/images/product-thumbnail-wide.png');"></div>
         <div class="fd-product-tile__content">
-          <h2 class="fd-product-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-product-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-product-tile" role="button">
         <div class="fd-product-tile__media" style="background-image: url('https://techne.yaas.io/images/product-thumbnail-wide.png');"></div>
         <div class="fd-product-tile__content">
-          <h2 class="fd-product-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-product-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-product-tile" role="button">
         <div class="fd-product-tile__media" style="background-image: url('https://techne.yaas.io/images/product-thumbnail-wide.png');"></div>
         <div class="fd-product-tile__content">
-          <h2 class="fd-product-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-product-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-product-tile" role="button">
         <div class="fd-product-tile__media" style="background-image: url('https://techne.yaas.io/images/product-thumbnail-wide.png');"></div>
         <div class="fd-product-tile__content">
-          <h2 class="fd-product-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-product-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-product-tile" role="button">
         <div class="fd-product-tile__media" style="background-image: url('https://techne.yaas.io/images/product-thumbnail-wide.png');"></div>
         <div class="fd-product-tile__content">
-          <h2 class="fd-product-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-product-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-product-tile" role="button">
         <div class="fd-product-tile__media" style="background-image: url('https://techne.yaas.io/images/product-thumbnail-wide.png');"></div>
         <div class="fd-product-tile__content">
-          <h2 class="fd-product-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-product-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-product-tile" role="button">
         <div class="fd-product-tile__media" style="background-image: url('https://techne.yaas.io/images/product-thumbnail-wide.png');"></div>
         <div class="fd-product-tile__content">
-          <h2 class="fd-product-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-product-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-product-tile" role="button">
         <div class="fd-product-tile__media" style="background-image: url('https://techne.yaas.io/images/product-thumbnail-wide.png');"></div>
         <div class="fd-product-tile__content">
-          <h2 class="fd-product-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-product-tile__title">Lorem ipsum</h3>
         </div>
     </div>
 </div>
@@ -346,52 +346,52 @@ Shows use of helper classes `.fd-has-grid-row-span-2` and `.fd-has-grid-column-s
 <div class="fd-tile-grid fd-tile-grid--6col">
     <div class="fd-tile fd-has-grid-row-span-2 fd-has-background-color-accent-7">
         <div class="fd-tile__content">
-          <h2 class="fd-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-          <h2 class="fd-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-          <h2 class="fd-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-          <h2 class="fd-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-          <h2 class="fd-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-          <h2 class="fd-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-          <h2 class="fd-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-          <h2 class="fd-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile">
         <div class="fd-tile__content">
-          <h2 class="fd-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
     <div class="fd-tile fd-has-grid-column-span-2 fd-has-background-color-accent-7">
         <div class="fd-tile__content">
-          <h2 class="fd-tile__title">Lorem ipsum</h2>
+          <h3 class="fd-tile__title">Lorem ipsum</h3>
         </div>
     </div>
 </div>

--- a/docs/pages/components/tile-grid.md
+++ b/docs/pages/components/tile-grid.md
@@ -14,7 +14,7 @@ A tile grid is layout component used to display [`tiles`](tile.html) on a grid l
 
 > This uses CSS grid which is [not supported by some older browsers](https://caniuse.com/#feat=css-grid). A flexbox fallback is included but it is recommended you test your page if you have a significant number of users on IE 11, for example.
 
-<br>
+> {{ site.data.strings.headerDisclaimer }}
 
 ## 3-col grid (default)
 

--- a/docs/pages/components/tile.md
+++ b/docs/pages/components/tile.md
@@ -14,7 +14,7 @@ A tile component can be used to display information in a simple container format
 {: .docs-intro}
 The component is ideal for displaying collection data when a grid or list layout is preferred. See [`tile-grid`](tile-grid.html).
 
-> Although the following examples use the `<h3>` tag for the title element, the styling provided by Fiori Fundamentals will remain consistent for any heading level used. `<h1>` should be reserved for the page title.
+> {{ site.data.strings.headerDisclaimer }}
 
 ## Simple Tile
 

--- a/docs/pages/components/tile.md
+++ b/docs/pages/components/tile.md
@@ -14,14 +14,14 @@ A tile component can be used to display information in a simple container format
 {: .docs-intro}
 The component is ideal for displaying collection data when a grid or list layout is preferred. See [`tile-grid`](tile-grid.html).
 
-<br>
+> Although the following examples use the `<h3>` tag for the title element, the styling provided by Fiori Fundamentals will remain consistent for any heading level used. `<h1>` should be reserved for the page title.
 
 ## Simple Tile
 
 {% capture tile %}
 <div class="fd-tile">
     <div class="fd-tile__content">
-        <h2 class="fd-tile__title">Tile Title</h2>
+        <h3 class="fd-tile__title">Tile Title</h3>
         <p>Tile Description</p>
     </div>
 </div>
@@ -38,7 +38,7 @@ The component is ideal for displaying collection data when a grid or list layout
         <span class=" fd-identifier--m fd-identifier--transparent sap-icon--home"></span>
     </div>
     <div class="fd-tile__content">
-        <h2 class="fd-tile__title">Tile Title</h2>
+        <h3 class="fd-tile__title">Tile Title</h3>
     </div>
 </div>
 
@@ -49,7 +49,7 @@ The component is ideal for displaying collection data when a grid or list layout
         <span class=" fd-identifier--m sap-icon--home fd-has-background-color-accent-3"></span>
     </div>
     <div class="fd-tile__content">
-        <h2 class="fd-tile__title">Tile Title</h2>
+        <h3 class="fd-tile__title">Tile Title</h3>
         <p>Tile Description</p>
     </div>
 </div>
@@ -61,7 +61,7 @@ The component is ideal for displaying collection data when a grid or list layout
         <span class=" fd-image--m" aria-label="TILE_MEDIA_ALT" style="background-image: url('http://api.adorable.io/avatars/50/rodney.artichoke@hybris.com.png');"></span>
     </div>
     <div class="fd-tile__content">
-        <h2 class="fd-tile__title">Tile Title</h2>
+        <h3 class="fd-tile__title">Tile Title</h3>
     </div>
 </div>
 
@@ -72,7 +72,7 @@ The component is ideal for displaying collection data when a grid or list layout
         <span class=" fd-image--m fd-image--circle" aria-label="TILE_MEDIA_ALT" style="background-image: url('http://api.adorable.io/avatars/50/rodney.artichoke@hybris.com.png');"></span>
     </div>
     <div class="fd-tile__content">
-        <h2 class="fd-tile__title">Tile Title</h2>
+        <h3 class="fd-tile__title">Tile Title</h3>
         <p>Tile Description</p>
     </div>
 </div>
@@ -84,7 +84,7 @@ The component is ideal for displaying collection data when a grid or list layout
 {% capture tile %}
 <div class="fd-tile">
     <div class="fd-tile__content">
-        <h2 class="fd-tile__title">Tile Title</h2>
+        <h3 class="fd-tile__title">Tile Title</h3>
     </div>
     <div class="fd-tile__actions">
         <div class="fd-popover fd-popover--right">
@@ -115,7 +115,7 @@ Add `role=button` to rendering a tile as a button
 {% capture tile %}
 <div class="fd-tile" role="button">
     <div class="fd-tile__content">
-        <h2 class="fd-tile__title">Tile Title</h2>
+        <h3 class="fd-tile__title">Tile Title</h3>
     </div>
 </div>
 {% endcapture %}
@@ -130,14 +130,14 @@ Add `role=button` to rendering a tile as a button
 <div class="fd-product-tile">
     <div class="fd-product-tile__media" style="background-image: url('https://techne.yaas.io/images/product-thumbnail-wide.png');"></div>
     <div class="fd-product-tile__content">
-        <h2 class="fd-product-tile__title">Default Product Tile</h2>
+        <h3 class="fd-product-tile__title">Default Product Tile</h3>
     </div>
 </div>
 
 <div class="fd-product-tile" role="button">
     <div class="fd-product-tile__media" style="background-image: url('https://techne.yaas.io/images/product-thumbnail-wide.png');"></div>
     <div class="fd-product-tile__content">
-        <h2 class="fd-product-tile__title">Product Tile Button</h2>
+        <h3 class="fd-product-tile__title">Product Tile Button</h3>
     </div>
 </div>
 
@@ -152,7 +152,7 @@ Add class `is-disabled` and/or `aria-disabled="true"` attribute
 {% capture tile %}
 <div class="fd-tile" aria-disabled="true">
     <div class="fd-tile__content">
-        <h2 class="fd-tile__title">Tile Title</h2>
+        <h3 class="fd-tile__title">Tile Title</h3>
     </div>
 </div>
 
@@ -163,7 +163,7 @@ Add class `is-disabled` and/or `aria-disabled="true"` attribute
         <span class=" fd-identifier--m fd-identifier--transparent sap-icon--home"></span>
     </div>
     <div class="fd-tile__content">
-        <h2 class="fd-tile__title">Tile Title</h2>
+        <h3 class="fd-tile__title">Tile Title</h3>
     </div>
 </div>
 
@@ -172,7 +172,7 @@ Add class `is-disabled` and/or `aria-disabled="true"` attribute
 <div class="fd-product-tile" aria-disabled="true">
     <div class="fd-product-tile__media" style="background-image: url('https://techne.yaas.io/images/product-thumbnail-wide.png');"></div>
     <div class="fd-product-tile__content">
-        <h2 class="fd-product-tile__title">Disabled Product Tile</h2>
+        <h3 class="fd-product-tile__title">Disabled Product Tile</h3>
     </div>
 </div>
 

--- a/docs/pages/layouts/global-navigation.md
+++ b/docs/pages/layouts/global-navigation.md
@@ -44,7 +44,7 @@ Elements and positioning in the global navigation are optional but included are:
             <a href="#" class="fd-mega-menu__header-link sap-icon--home">SAP Hybris Home</a>
          </div>
          <div class="fd-mega-menu__group">
-            <h1 class="fd-mega-menu__title">Group Name</h1>
+            <h3 class="fd-mega-menu__title">Group Name</h3>
             <ul class="fd-mega-menu__list">
                <li class="fd-mega-menu__item"><a class="fd-mega-menu__link" href="#">
                   item link
@@ -79,7 +79,7 @@ Elements and positioning in the global navigation are optional but included are:
             </ul>
          </div>
          <div class="fd-mega-menu__group">
-            <h1 class="fd-mega-menu__title">Group Name</h1>
+            <h3 class="fd-mega-menu__title">Group Name</h3>
             <ul class="fd-mega-menu__list">
                <li class="fd-mega-menu__item"><a class="fd-mega-menu__link" href="#">
                   item link

--- a/docs/pages/layouts/global-navigation.md
+++ b/docs/pages/layouts/global-navigation.md
@@ -24,7 +24,7 @@ Elements and positioning in the global navigation are optional but included are:
 * **Search icon**: on click, a search field is displayed.
 * **User icon**: on click, user options are displayed such as Sign Off and Preferences.
 
-<br>
+> {{ site.data.strings.headerDisclaimer }}
 
 {% capture app-layout %}
 <nav class="fd-global-nav">

--- a/docs/pages/layouts/panel.md
+++ b/docs/pages/layouts/panel.md
@@ -13,9 +13,6 @@ Panels are used to encapsulate part of the content, form elements, lists, collec
 
 Place patterns and interactions within panels on your pages to achieve focus and separation for the tasks at-hand with the information displayed inside the panel.
 
-<br>
-We use an H3 header here, however header sizes from H2 to H6 are also acceptable.
-<br>
 
 ## Elements
 
@@ -25,6 +22,8 @@ We use an H3 header here, however header sizes from H2 to H6 are also acceptable
 - `.fd-panel__filters`: Panel level filters that is specific to the data being displayed within the panel.
 - `.fd-panel__body`: Main content of the panel can that hold lists, table, tree, text, form or any other infomation.
 - `.fd-panel__footer`: Panel footer can be utilized for pagination, secondary actions, add more data, etc.
+
+> Although the following example uses the `<h3>` tag for the title element, the styling provided by Fiori Fundamentals will remain consistent for any heading level used. `<h1>` should be reserved for the page title.
 
 {% capture default %}
 <div class="fd-panel">

--- a/docs/pages/layouts/panel.md
+++ b/docs/pages/layouts/panel.md
@@ -14,6 +14,8 @@ Panels are used to encapsulate part of the content, form elements, lists, collec
 Place patterns and interactions within panels on your pages to achieve focus and separation for the tasks at-hand with the information displayed inside the panel.
 
 <br>
+We use an H3 header here, however header sizes from H2 to H6 are also acceptable.
+<br>
 
 ## Elements
 
@@ -28,9 +30,9 @@ Place patterns and interactions within panels on your pages to achieve focus and
 <div class="fd-panel">
     <div class="fd-panel__header">
         <div class="fd-panel__head">
-            <h1 class="fd-panel__title">
+            <h3 class="fd-panel__title">
                 .fd-panel__title
-            </h1>
+            </h3>
             <p class="fd-panel__description">
                 .fd-panel__description
             </p>

--- a/docs/pages/layouts/panel.md
+++ b/docs/pages/layouts/panel.md
@@ -13,6 +13,7 @@ Panels are used to encapsulate part of the content, form elements, lists, collec
 
 Place patterns and interactions within panels on your pages to achieve focus and separation for the tasks at-hand with the information displayed inside the panel.
 
+> {{ site.data.strings.headerDisclaimer }}
 
 ## Elements
 
@@ -22,8 +23,6 @@ Place patterns and interactions within panels on your pages to achieve focus and
 - `.fd-panel__filters`: Panel level filters that is specific to the data being displayed within the panel.
 - `.fd-panel__body`: Main content of the panel can that hold lists, table, tree, text, form or any other infomation.
 - `.fd-panel__footer`: Panel footer can be utilized for pagination, secondary actions, add more data, etc.
-
-> Although the following example uses the `<h3>` tag for the title element, the styling provided by Fiori Fundamentals will remain consistent for any heading level used. `<h1>` should be reserved for the page title.
 
 {% capture default %}
 <div class="fd-panel">

--- a/docs/pages/layouts/section.md
+++ b/docs/pages/layouts/section.md
@@ -95,10 +95,13 @@ Shows an alternate layout option using columns. This may be more appropriate dep
 ## Section with header
 {: .docs-header-h3}
 Header and title elements are available when necessary to label content groups.
+
+> Although the following example uses the `<h3>` tag for the title element, the styling provided by Fiori Fundamentals will remain consistent for any heading level used. `<h1>` should be reserved for the page title.
+
 {% capture section-layout-example %}
 <section class="fd-section">
     <div class="fd-section__header">
-      <h1 class="fd-section__title">Section title</h1>
+      <h3 class="fd-section__title">Section title</h3>
     </div>
     <div class="fd-panel">
         .fd-panel

--- a/docs/pages/layouts/section.md
+++ b/docs/pages/layouts/section.md
@@ -17,7 +17,8 @@ Can hold two child types:
 - `.fd-panel` (optionally with `.fd-panel-grid`) is the most common use.
 - `.fd-container` and `fd-col--[num]` can be used to organize panels or content when a grid layout is not desired.
 
-<br>
+> {{ site.data.strings.headerDisclaimer }}
+
 
 ## Section structure
 Shows an example of a background color applied with a helper class.
@@ -95,8 +96,6 @@ Shows an alternate layout option using columns. This may be more appropriate dep
 ## Section with header
 {: .docs-header-h3}
 Header and title elements are available when necessary to label content groups.
-
-> Although the following example uses the `<h3>` tag for the title element, the styling provided by Fiori Fundamentals will remain consistent for any heading level used. `<h1>` should be reserved for the page title.
 
 {% capture section-layout-example %}
 <section class="fd-section">

--- a/docs/pages/layouts/shell-layout.md
+++ b/docs/pages/layouts/shell-layout.md
@@ -148,7 +148,7 @@ The container visibility can be toggled with the `aria-hidden` attribute.
         <div class="fd-modal" role="dialog">
           <div class="fd-modal__content" role="document">
               <header class="fd-modal__header">
-                  <h1 class="fd-modal__title">fd-modal__header</h1>
+                  <h3 class="fd-modal__title">fd-modal__header</h3>
                   <button class="fd-button--light fd-modal__close"></button>
               </header>
               <div class="fd-modal__body">

--- a/test/templates/action-bar/component.njk
+++ b/test/templates/action-bar/component.njk
@@ -14,16 +14,8 @@ action_bar:
     {%- endif %}
 
     <div class="fd-action-bar__header">
-        {%- if properties.title_size %}
-        {%- set title_size = properties.title_size %}
-        <{{title_size}} class="fd-action-bar__title">
-            {{ properties.title }}
-        </ {{title_size}}>
-        {%- else %}
-        <h3 class="fd-action-bar__title">
-            {{ properties.title }}
-        </h3>
-        {%- endif %}
+        {% set title_size = properties.title_size if properties.title_size else "h3" %}
+        <{{title_size}} class="fd-action-bar__title">{{ properties.title }}</{{title_size}}>
         {%- if properties.description %}
         <p class="fd-action-bar__description">{{ properties.description }}</p>
         {%- endif %}

--- a/test/templates/action-bar/component.njk
+++ b/test/templates/action-bar/component.njk
@@ -12,10 +12,18 @@ action_bar:
         <button class="fd-button--light sap-icon--nav-back"></button>
     </div>
     {%- endif %}
+
     <div class="fd-action-bar__header">
-        <h1 class="fd-action-bar__title">
-        {{ properties.title }}
-        </h1>
+        {%- if properties.title_size %}
+        {%- set title_size = properties.title_size %}
+        <{{title_size}} class="fd-action-bar__title">
+            {{ properties.title }}
+        </ {{title_size}}>
+        {%- else %}
+        <h3 class="fd-action-bar__title">
+            {{ properties.title }}
+        </h3>
+        {%- endif %}
         {%- if properties.description %}
         <p class="fd-action-bar__description">{{ properties.description }}</p>
         {%- endif %}

--- a/test/templates/action-bar/index.njk
+++ b/test/templates/action-bar/index.njk
@@ -97,6 +97,82 @@
 
 {{  action_bar(
         properties={
+            title: "Action Bar with H2 header",
+            title_size: "h2",
+            actions: {
+                properties: {
+                    items: [secbtn,primarybtn]
+                }
+            },
+            back_button: true
+        },
+        modifier={
+            block: []
+        },
+        state={},
+        aria={}
+    )
+}}
+
+{{  action_bar(
+        properties={
+            title: "Action Bar with H4 header",
+            title_size: "h4",
+            actions: {
+                properties: {
+                    items: [secbtn,primarybtn]
+                }
+            },
+            back_button: true
+        },
+        modifier={
+            block: []
+        },
+        state={},
+        aria={}
+    )
+}}
+
+{{  action_bar(
+        properties={
+            title: "Action Bar with H5 header",
+            title_size: "h5",
+            actions: {
+                properties: {
+                    items: [secbtn,primarybtn]
+                }
+            },
+            back_button: true
+        },
+        modifier={
+            block: []
+        },
+        state={},
+        aria={}
+    )
+}}
+
+{{  action_bar(
+        properties={
+            title: "Action Bar with H6 header",
+            title_size: "h6",
+            actions: {
+                properties: {
+                    items: [secbtn,primarybtn]
+                }
+            },
+            back_button: true
+        },
+        modifier={
+            block: []
+        },
+        state={},
+        aria={}
+    )
+}}
+
+{{  action_bar(
+        properties={
             title: "Action Bar with no back button",
             actions: {
                 properties: {

--- a/test/templates/action-bar/index.njk
+++ b/test/templates/action-bar/index.njk
@@ -76,7 +76,10 @@
         aria={}
     )
 }}
+{% endset %}
+{{ format(example) }}
 
+{% set example %}
 {{  action_bar(
         properties={
             title: "Action Bar with no description",
@@ -94,7 +97,10 @@
         aria={}
     )
 }}
+{% endset %}
+{{ format(example) }}
 
+{% set example %}
 {{  action_bar(
         properties={
             title: "Action Bar with H2 header",
@@ -114,6 +120,10 @@
     )
 }}
 
+{% endset %}
+{{ format(example) }}
+
+{% set example %}
 {{  action_bar(
         properties={
             title: "Action Bar with H4 header",
@@ -133,6 +143,10 @@
     )
 }}
 
+{% endset %}
+{{ format(example) }}
+
+{% set example %}
 {{  action_bar(
         properties={
             title: "Action Bar with H5 header",
@@ -152,6 +166,10 @@
     )
 }}
 
+{% endset %}
+{{ format(example) }}
+
+{% set example %}
 {{  action_bar(
         properties={
             title: "Action Bar with H6 header",
@@ -171,6 +189,10 @@
     )
 }}
 
+{% endset %}
+{{ format(example) }}
+
+{% set example %}
 {{  action_bar(
         properties={
             title: "Action Bar with no back button",

--- a/test/templates/layout/component.njk
+++ b/test/templates/layout/component.njk
@@ -14,9 +14,12 @@ section:
 {%- macro section_header(properties={}, modifier=[], aria={}, classes=[]) %}
 <header class="fd-section__header{{ classes | classes }}{{ modifier | modifier("section__header") }}">
     {%- if properties.title %}
-    <h1 class="fd-section__title">
-        {{ properties.title }}
-    </h1>
+    {%- if properties.title_size %}
+        {%- set title_size = properties.title_size %}
+        <{{title_size}} class="fd-section__title">{{ properties.title }}</{{title_size}}>
+        {%- else %}
+           <h3 class="fd-section__title">{{ properties.title }}</h3>
+        {%- endif %}
     {%- endif %}
     {{- caller() | indent -}}
 </header>
@@ -74,9 +77,9 @@ panel:
 <div class="fd-panel__header{{ classes | classes }}{{ modifier | modifier("panel__header") }}">
     <div class="fd-panel_head">
         {%- if properties.title %}
-        <h1 class="fd-panel__title">
+        <h3 class="fd-panel__title">
             {{ properties.title }}
-        </h1>
+        </h3>
         {%- endif %}
         {%- if properties.description %}
         <p class="fd-panel__description">

--- a/test/templates/layout/component.njk
+++ b/test/templates/layout/component.njk
@@ -14,12 +14,8 @@ section:
 {%- macro section_header(properties={}, modifier=[], aria={}, classes=[]) %}
 <header class="fd-section__header{{ classes | classes }}{{ modifier | modifier("section__header") }}">
     {%- if properties.title %}
-    {%- if properties.title_size %}
-        {%- set title_size = properties.title_size %}
+        {% set title_size = properties.title_size  if properties.title_size  else "h3" %}
         <{{title_size}} class="fd-section__title">{{ properties.title }}</{{title_size}}>
-        {%- else %}
-           <h3 class="fd-section__title">{{ properties.title }}</h3>
-        {%- endif %}
     {%- endif %}
     {{- caller() | indent -}}
 </header>

--- a/test/templates/mega-menu/component.njk
+++ b/test/templates/mega-menu/component.njk
@@ -64,7 +64,12 @@ mega_menu:
 {%- macro navgroup(properties={}) -%}
 {%- for navgroup in properties -%}
 <div class="fd-mega-menu__group">
-    <h1 class="fd-mega-menu__title">{{ navgroup.title }}</h1>
+    {%- if navgroup.title_size %}
+    {%- set title_size = navgroup.title_size %}
+        <{{title_size}} class="fd-mega-menu__title">{{ navgroup.title }}</{{title_size}}>
+    {%- else %}
+    <h3 class="fd-mega-menu__title">{{ navgroup.title }}</h3>
+    {%- endif %}
     {{ navlist(navgroup.items) }}
 </div>
 {%- endfor -%}

--- a/test/templates/mega-menu/component.njk
+++ b/test/templates/mega-menu/component.njk
@@ -68,7 +68,7 @@ mega_menu:
     {%- set title_size = navgroup.title_size %}
         <{{title_size}} class="fd-mega-menu__title">{{ navgroup.title }}</{{title_size}}>
     {%- else %}
-    <h3 class="fd-mega-menu__title">{{ navgroup.title }}</h3>
+        <h3 class="fd-mega-menu__title">{{ navgroup.title }}</h3>
     {%- endif %}
     {{ navlist(navgroup.items) }}
 </div>

--- a/test/templates/mega-menu/component.njk
+++ b/test/templates/mega-menu/component.njk
@@ -64,12 +64,8 @@ mega_menu:
 {%- macro navgroup(properties={}) -%}
 {%- for navgroup in properties -%}
 <div class="fd-mega-menu__group">
-    {%- if navgroup.title_size %}
-    {%- set title_size = navgroup.title_size %}
-        <{{title_size}} class="fd-mega-menu__title">{{ navgroup.title }}</{{title_size}}>
-    {%- else %}
-        <h3 class="fd-mega-menu__title">{{ navgroup.title }}</h3>
-    {%- endif %}
+    {% set title_size = navgroup.title_size if navgroup.title_size else "h3" %}
+    <{{title_size}} class="fd-mega-menu__title">{{ navgroup.title }}</{{title_size}}>
     {{ navlist(navgroup.items) }}
 </div>
 {%- endfor -%}

--- a/test/templates/mega-menu/index.njk
+++ b/test/templates/mega-menu/index.njk
@@ -60,5 +60,153 @@
     {% endset %}
     {{ format(example) }}
 
+    <br><br><br>
+
+    {% set example %}
+    {{  mega_menu(
+        properties = {
+          "title": "Group with H2 Title",
+          "title_size": "h2",
+          "navgroups": [
+            {
+              "title": "Group Name with H2 Title",
+              "title_size": "h2",
+              "items": [
+                { "label": "item link" },
+                {
+                    "label": "item link",
+                    "haschild": true,
+                    "items": [
+                        { "label": "Link" },
+                        { "label": "Link" },
+                        { "label": "Link" }
+                    ]
+                 },
+                { "label": "item link" }
+              ]
+            }
+          ]
+        },
+            modifier={
+                block: []
+            },
+            state={},
+            aria={}
+        )
+    }}
+    {% endset %}
+    {{ format(example) }}
+
+    <br><br><br>
+
+    {% set example %}
+    {{  mega_menu(
+        properties = {
+          "title": "Group with H4 Title",
+          "title_size": "h4",
+          "navgroups": [
+            {
+              "title": "Group Name with H4 Title",
+              "title_size": "h4",
+              "items": [
+                { "label": "item link" },
+                {
+                    "label": "item link",
+                    "haschild": true,
+                    "items": [
+                        { "label": "Link" },
+                        { "label": "Link" },
+                        { "label": "Link" }
+                    ]
+                 },
+                { "label": "item link" }
+              ]
+            }
+          ]
+        },
+            modifier={
+                block: []
+            },
+            state={},
+            aria={}
+        )
+    }}
+    {% endset %}
+    {{ format(example) }}
+
+    <br><br><br>
+
+    {% set example %}
+    {{  mega_menu(
+        properties = {
+          "title": "Group with H5 Title",
+          "title_size": "h5",
+          "navgroups": [
+            {
+              "title": "Group Name with H5 Title",
+              "title_size": "h5",
+              "items": [
+                { "label": "item link" },
+                {
+                    "label": "item link",
+                    "haschild": true,
+                    "items": [
+                        { "label": "Link" },
+                        { "label": "Link" },
+                        { "label": "Link" }
+                    ]
+                 },
+                { "label": "item link" }
+              ]
+            }
+          ]
+        },
+            modifier={
+                block: []
+            },
+            state={},
+            aria={}
+        )
+    }}
+    {% endset %}
+    {{ format(example) }}
+
+    <br><br><br>
+
+    {% set example %}
+    {{  mega_menu(
+        properties = {
+          "title": "Group with H6 Title",
+          "title_size": "h6",
+          "navgroups": [
+            {
+              "title": "Group Name with H6 Title",
+              "title_size": "h6",
+              "items": [
+                { "label": "item link" },
+                {
+                    "label": "item link",
+                    "haschild": true,
+                    "items": [
+                        { "label": "Link" },
+                        { "label": "Link" },
+                        { "label": "Link" }
+                    ]
+                 },
+                { "label": "item link" }
+              ]
+            }
+          ]
+        },
+            modifier={
+                block: []
+            },
+            state={},
+            aria={}
+        )
+    }}
+    {% endset %}
+    {{ format(example) }}
+
 
 {% endblock %}

--- a/test/templates/menu/component.njk
+++ b/test/templates/menu/component.njk
@@ -45,7 +45,14 @@ menu:
 
 {% macro optgroup(properties={}, separated=false) -%}
     <div class="fd-menu__group">
-      <h1 class="fd-menu__title">{{ properties.label }}</h1>
+    {%- if properties.label %}
+    {%- if properties.header_size %}
+    {%- set header_size = properties.header_size %}
+      <{{header_size}} class="fd-menu__title">{{ properties.label }}</{{header_size}}>
+    {%- else %}
+      <h3 class="fd-menu__title">{{ properties.label }}</h3>
+    {%- endif %}
+    {%- endif %}
       <ul class="fd-menu__list{{ 'separated' | modifier('menu__list') if separated }}">
           {%- for item in properties.items %}
             {{ option(item) }}

--- a/test/templates/menu/component.njk
+++ b/test/templates/menu/component.njk
@@ -46,12 +46,8 @@ menu:
 {% macro optgroup(properties={}, separated=false) -%}
     <div class="fd-menu__group">
     {%- if properties.label %}
-      {%- if properties.header_size %}
-      {%- set header_size = properties.header_size %}
-        <{{header_size}} class="fd-menu__title">{{ properties.label }}</{{header_size}}>
-      {%- else %}
-        <h3 class="fd-menu__title">{{ properties.label }}</h3>
-      {%- endif %}
+      {% set title_size = properties.header_size if properties.header_size else "h3" %}
+      <{{title_size}} class="fd-menu__title">{{ properties.label }}</{{title_size}}>
     {%- endif %}
       <ul class="fd-menu__list{{ 'separated' | modifier('menu__list') if separated }}">
           {%- for item in properties.items %}

--- a/test/templates/menu/component.njk
+++ b/test/templates/menu/component.njk
@@ -46,12 +46,12 @@ menu:
 {% macro optgroup(properties={}, separated=false) -%}
     <div class="fd-menu__group">
     {%- if properties.label %}
-    {%- if properties.header_size %}
-    {%- set header_size = properties.header_size %}
-      <{{header_size}} class="fd-menu__title">{{ properties.label }}</{{header_size}}>
-    {%- else %}
-      <h3 class="fd-menu__title">{{ properties.label }}</h3>
-    {%- endif %}
+      {%- if properties.header_size %}
+      {%- set header_size = properties.header_size %}
+        <{{header_size}} class="fd-menu__title">{{ properties.label }}</{{header_size}}>
+      {%- else %}
+        <h3 class="fd-menu__title">{{ properties.label }}</h3>
+      {%- endif %}
     {%- endif %}
       <ul class="fd-menu__list{{ 'separated' | modifier('menu__list') if separated }}">
           {%- for item in properties.items %}

--- a/test/templates/menu/index.njk
+++ b/test/templates/menu/index.njk
@@ -66,6 +66,97 @@
 {% endset %}
 {{ format(example) }}
 
+<br><br><br>
+
+<h2>grouped with H2 headers</h2>
+{% set example %}
+{{ menu(properties={
+  items: [
+      { "label": "Option 1" },
+      { "label": "Option 2"},
+      { "label": "Option 3" },
+      {  "label": "Group Header",
+        "header_size": "h2",
+        "items": [
+            { "label": "Option 4" },
+            { "label": "Option 5" },
+            { "label": "Option 6" }
+        ]
+      }
+    ]
+  })
+}}
+{% endset %}
+{{ format(example) }}
+
+<br><br><br>
+
+<h2>grouped with H4 headers</h2>
+{% set example %}
+{{ menu(properties={
+  items: [
+      { "label": "Option 1" },
+      { "label": "Option 2"},
+      { "label": "Option 3" },
+      {  "label": "Group Header",
+        "header_size": "h4",
+        "items": [
+            { "label": "Option 4" },
+            { "label": "Option 5" },
+            { "label": "Option 6" }
+        ]
+      }
+    ]
+  })
+}}
+{% endset %}
+{{ format(example) }}
+
+<br><br><br>
+
+<h2>grouped with H5 headers</h2>
+{% set example %}
+{{ menu(properties={
+  items: [
+      { "label": "Option 1" },
+      { "label": "Option 2"},
+      { "label": "Option 3" },
+      {  "label": "Group Header",
+        "header_size": "h5",
+        "items": [
+            { "label": "Option 4" },
+            { "label": "Option 5" },
+            { "label": "Option 6" }
+        ]
+      }
+    ]
+  })
+}}
+{% endset %}
+{{ format(example) }}
+
+<br><br><br>
+
+<h2>grouped with H6 headers</h2>
+{% set example %}
+{{ menu(properties={
+  items: [
+      { "label": "Option 1" },
+      { "label": "Option 2"},
+      { "label": "Option 3" },
+      {  "label": "Group Header",
+        "header_size": "h6",
+        "items": [
+            { "label": "Option 4" },
+            { "label": "Option 5" },
+            { "label": "Option 6" }
+        ]
+      }
+    ]
+  })
+}}
+{% endset %}
+{{ format(example) }}
 
 <br><br><br>
 

--- a/test/templates/modal/component.njk
+++ b/test/templates/modal/component.njk
@@ -9,12 +9,8 @@ modal:
 <div class="fd-modal" role="dialog">
   <div class="fd-modal__content" role="document">
       <header class="fd-modal__header">
-      {%- if properties.header_size %}
-      {%- set header_size = properties.header_size %}
-          <{{header_size}} class="fd-modal__title">{{ properties.header }}</{{header_size}}>
-      {%- else %}   
-          <h3 class="fd-modal__title">{{properties.header}}</h3>
-      {%- endif %}
+      {% set title_size = properties.header_size  if properties.header_size  else "h3" %}
+      <{{title_size}} class="fd-modal__title">{{ properties.header }}</{{title_size}}>
           {{  button(
                   {
                       label: item.label

--- a/test/templates/modal/component.njk
+++ b/test/templates/modal/component.njk
@@ -9,7 +9,12 @@ modal:
 <div class="fd-modal" role="dialog">
   <div class="fd-modal__content" role="document">
       <header class="fd-modal__header">
-          <h1 class="fd-modal__title">{{properties.header}}</h1>
+      {%- if properties.header_size %}
+      {%- set header_size = properties.header_size %}
+          <{{header_size}} class="fd-modal__title">{{ properties.header }}</{{header_size}}>
+      {%- else %}   
+          <h3 class="fd-modal__title">{{properties.header}}</h3>
+      {%- endif %}
           {{  button(
                   {
                       label: item.label

--- a/test/templates/modal/index.njk
+++ b/test/templates/modal/index.njk
@@ -28,6 +28,87 @@ NOTE: The <code>modal</code> itself does not provide the outer container. Use th
 
 {% endset %}
 {{ format(example) }}
+
+<br><br>
+
+{% set example %}
+
+
+  {{  modal(
+        properties={
+            header: "Modal with H2 Header",
+            header_size: "h2",
+            body: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+            actions: [
+              { label: 'Confirm'},
+              {type: 'light', label: 'Cancel'}
+            ]
+          }
+      )
+  }}
+
+{% endset %}
+{{ format(example) }}
+<br><br>
+
+{% set example %}
+
+
+  {{  modal(
+        properties={
+            header: "Modal with H4 Header",
+            header_size: "h4",
+            body: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+            actions: [
+              { label: 'Confirm'},
+              {type: 'light', label: 'Cancel'}
+            ]
+          }
+      )
+  }}
+
+{% endset %}
+{{ format(example) }}
+<br><br>
+
+{% set example %}
+
+
+  {{  modal(
+        properties={
+            header: "Modal with H5 Header",
+            header_size: "h5",
+            body: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+            actions: [
+              { label: 'Confirm'},
+              {type: 'light', label: 'Cancel'}
+            ]
+          }
+      )
+  }}
+
+{% endset %}
+{{ format(example) }}
+<br><br>
+
+{% set example %}
+
+
+  {{  modal(
+        properties={
+            header: "Modal with H6 Header",
+            header_size: "h6",
+            body: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+            actions: [
+              { label: 'Confirm'},
+              {type: 'light', label: 'Cancel'}
+            ]
+          }
+      )
+  }}
+
+{% endset %}
+{{ format(example) }}
 <br><br>
 
 {% endblock %}

--- a/test/templates/pages/all.njk
+++ b/test/templates/pages/all.njk
@@ -202,7 +202,7 @@
     </div>
 
     <div class="fd-panel__header">
-        <h1 class="fd-panel__title">Lorem ipsum</h1>
+        <h3 class="fd-panel__title">Lorem ipsum</h3>
     </div>
     <!-- Loaded content goes here -->
     <div class="fd-panel__footer">

--- a/test/templates/pages/section.njk
+++ b/test/templates/pages/section.njk
@@ -1,6 +1,7 @@
 {% extends "./layouts/page.njk" %}
 {# {% import "../layout/layout.section_njk" as section %} #}
 {% import "../layout/component.njk" as layout %}
+{% from "./../format.njk" import format %}
 
 {% from "../tree/component.njk" import tree %}
 {% from "../table/component.njk" import table %}
@@ -9,7 +10,7 @@
 {% set hide_page_header = true %}
 {% block page_content %}
 
-<div class="fd-has-background-color-neutral-2">
+{% set example %}
 {% call layout.section() -%}
     {% call layout.section_header({ title: ".fd-section__title" }) -%}
         {% call layout.section_actions() -%}
@@ -24,7 +25,13 @@
 .fd-section__footer
     {%- endcall %}
 {%- endcall %}
-</div>
+
+{% endset %}
+{{ format(example) }}
+
+<br><br>
+
+{% set example %}
 <div class="fd-has-background-color-status-1">
 {% call layout.section(modifier="full-bleed") -%}
     {% call layout.section_header({ title: ".fd-section__title" }) -%}
@@ -41,69 +48,63 @@
     {%- endcall %}
 {%- endcall %}
 </div>
+{% endset %}
+{{ format(example) }}
 
-
-
+<br><br>
 
 {% set badgetitle %}
 Vivamus sagittis <span class="fd-badge fd-badge--success">Active</span>
 {% endset %}
 
+{% set example %}
     {% call layout.section(classes="") -%}
         {% call layout.section_header({ title: badgetitle }) -%}
 
         {%- endcall %}
 
-<div class="fd-container">
-
-    <div class="fd-col--6">
-
-        <div class="fd-form__group">
-            <div class="fd-form__item">
-                <label class="fd-form__label" for="input-1">Field Label</label>
-                <input class="fd-form__control" type="text" id="input-1" name="" value="" placeholder="Field placeholder text">
-            </div>
-        </div>
-        <fieldset class="fd-form__group">
-            <legend class="fd-form__legend">Select an option</legend>
-            <div class="fd-form__item fd-form__item--inline fd-form__item--check">
-                <input class="fd-form__control" type="radio" id="radio-13" name="radio-name-5" value="" checked>
-                <label class="fd-form__label" for="radio-13">Option One</label>
-            </div>
-            <div class="fd-form__item fd-form__item--inline fd-form__item--check">
-                <input class="fd-form__control" type="radio" id="radio-14" name="radio-name-5" value="">
-                <label class="fd-form__label" for="radio-14">Option Two</label>
-            </div>
-            <div class="fd-form__item fd-form__item--inline fd-form__item--check">
-                <input class="fd-form__control" type="radio" id="radio-15" name="radio-name-5" value="">
-                <label class="fd-form__label" for="radio-15">Option Three</label>
-            </div>
-        </fieldset>
-
-    </div>
+    <div class="fd-container">
         <div class="fd-col--6">
-
-            <fieldset class="fd-form__group">
+            <div class="fd-form__group">
                 <div class="fd-form__item">
-                    <label class="fd-form__label" for="textarea-1">Field Label</label>
-                    <textarea class="fd-form__control" id="textarea-1" name="" >Pellentesque metus lacus commodo eget justo ut rutrum varius nunc. Sed non rhoncus risus. Morbi sodales gravida pulvinar. Duis malesuada odio volutpat elementum vulputate massa magna scelerisque ante et accumsan tellus nunc in sem.</textarea>
+                    <label class="fd-form__label" for="input-1">Field Label</label>
+                    <input class="fd-form__control" type="text" id="input-1" name="" value="" placeholder="Field placeholder text">
+                </div>
+            </div>
+            <fieldset class="fd-form__group">
+                <legend class="fd-form__legend">Select an option</legend>
+                <div class="fd-form__item fd-form__item--inline fd-form__item--check">
+                    <input class="fd-form__control" type="radio" id="radio-13" name="radio-name-5" value="" checked>
+                    <label class="fd-form__label" for="radio-13">Option One</label>
+                </div>
+                <div class="fd-form__item fd-form__item--inline fd-form__item--check">
+                    <input class="fd-form__control" type="radio" id="radio-14" name="radio-name-5" value="">
+                    <label class="fd-form__label" for="radio-14">Option Two</label>
+                </div>
+                <div class="fd-form__item fd-form__item--inline fd-form__item--check">
+                    <input class="fd-form__control" type="radio" id="radio-15" name="radio-name-5" value="">
+                    <label class="fd-form__label" for="radio-15">Option Three</label>
                 </div>
             </fieldset>
-
+            </div>
+            <div class="fd-col--6">
+                <fieldset class="fd-form__group">
+                    <div class="fd-form__item">
+                        <label class="fd-form__label" for="textarea-1">Field Label</label>
+                        <textarea class="fd-form__control" id="textarea-1" name="" >Pellentesque metus lacus commodo eget justo ut rutrum varius nunc. Sed non rhoncus risus. Morbi sodales gravida pulvinar. Duis malesuada odio volutpat elementum vulputate massa magna scelerisque ante et accumsan tellus nunc in sem.</textarea>
+                    </div>
+                </fieldset>
+            </div>
         </div>
-
-</div>
-
-
-
         {% call layout.section_footer() -%}
         <em>Vivamus sagittis diam in vehicula lobortis sapien arcu mattis erat vel aliquet.</em>
         {%- endcall %}
     {%- endcall %}
 
+{% endset %}
+{{ format(example) }}
 
-
-
+{% set example %}
     {% call layout.section(modifier="full-bleed", classes="") -%}
 
         {% call layout.section_header({ title: "Table" }) -%}
@@ -122,62 +123,53 @@ Vivamus sagittis <span class="fd-badge fd-badge--success">Active</span>
         {%- endcall %}
     {%- endcall %}
 
+{% endset %}
+{{ format(example) }}
 
-
-
-
-
-
-
-    <hr>
-
-    <section class="fd-section">
-        <div class="fd-section__header">
-            <h1 class="fd-section__title">
-                Code
-            </h1>
-        </div>
-
-{%- set code_example %}
-{% call layout.section() -%}
-    {% call layout.section_header({ title: "//title (optional)" }) -%}
-        {% call layout.section_actions() -%}
-//buttons (optional)
+<h2> Example with H2 </h2>
+{% set example %}
+    {% call layout.section() -%}
+        {% call layout.section_header({ title: ".fd-section__title", title_size: "h2" }) -%}
         {%- endcall %}
     {%- endcall %}
-
-//content (.fd-container, .fd-card-group)
-    {% call layout.section_footer() -%}
-//link or info (optional)
-    {%- endcall %}
-{%- endcall %}
-
-{% call layout.section(modifier="full-bleed") -%}
-    {% call layout.section_header({ title: "//title (optional)" }) -%}
-        {% call layout.section_actions() -%}
-//buttons (optional)
-        {%- endcall %}
-    {%- endcall %}
-
-//content (.fd-table, .fd-tree)
-    {% call layout.section_footer() -%}
-//link or info (optional)
-    {%- endcall %}
-{%- endcall %}
 {% endset %}
 
-<pre>
-{{code_example | e | trim }}
-</pre>
+{{ format(example) }}
 
+<br><br>
 
+<h2> Example with H4 </h2>
+{% set example %}
+    {% call layout.section() -%}
+        {% call layout.section_header({ title: ".fd-section__title", title_size: "h4" }) -%}
+        {%- endcall %}
+    {%- endcall %}
+{% endset %}
 
+{{ format(example) }}
 
+<br><br>
 
+<h2> Example with H5 </h2>
+{% set example %}
+    {% call layout.section() -%}
+        {% call layout.section_header({ title: ".fd-section__title", title_size: "h5" }) -%}
+        {%- endcall %}
+    {%- endcall %}
+{% endset %}
 
+{{ format(example) }}
 
+<br><br>
 
+<h2> Example with H6 </h2>
+{% set example %}
+    {% call layout.section() -%}
+        {% call layout.section_header({ title: ".fd-section__title", title_size: "h6" }) -%}
+        {%- endcall %}
+    {%- endcall %}
+{% endset %}
 
-
+{{ format(example) }}
 
 {% endblock %}

--- a/test/templates/panel/component.njk
+++ b/test/templates/panel/component.njk
@@ -15,10 +15,17 @@ panel:
 <div class="fd-panel__header{{ classes | classes }}{{ modifier | modifier("panel__header") }}">
     {%- if properties.title %}
     <div class="fd-panel__head">
-        <h3 class="fd-panel__title">
+        {%- if properties.title_size %}
+        {%- set title_size = properties.title_size %}
+        <{{title_size}} class="fd-panel__title">
+            {{ properties.title }}
+        </{{title_size}}>
+        {%- else %}
+         <h3 class="fd-panel__title">
             {{ properties.title }}
         </h3>
         {%- endif %}
+    {%- endif %}
         {%- if properties.description %}
         <p class="fd-panel__description">
             {{ properties.description }}

--- a/test/templates/panel/component.njk
+++ b/test/templates/panel/component.njk
@@ -15,9 +15,9 @@ panel:
 <div class="fd-panel__header{{ classes | classes }}{{ modifier | modifier("panel__header") }}">
     {%- if properties.title %}
     <div class="fd-panel__head">
-        <h1 class="fd-panel__title">
+        <h3 class="fd-panel__title">
             {{ properties.title }}
-        </h1>
+        </h3>
         {%- endif %}
         {%- if properties.description %}
         <p class="fd-panel__description">

--- a/test/templates/panel/component.njk
+++ b/test/templates/panel/component.njk
@@ -15,16 +15,8 @@ panel:
 <div class="fd-panel__header{{ classes | classes }}{{ modifier | modifier("panel__header") }}">
     {%- if properties.title %}
     <div class="fd-panel__head">
-        {%- if properties.title_size %}
-        {%- set title_size = properties.title_size %}
-        <{{title_size}} class="fd-panel__title">
-            {{ properties.title }}
-        </{{title_size}}>
-        {%- else %}
-         <h3 class="fd-panel__title">
-            {{ properties.title }}
-        </h3>
-        {%- endif %}
+        {% set title_size = properties.title_size  if properties.title_size  else "h3" %}
+        <{{title_size}} class="fd-panel__title">{{ properties.title }}</{{title_size}}>
     {%- endif %}
         {%- if properties.description %}
         <p class="fd-panel__description">

--- a/test/templates/panel/index.njk
+++ b/test/templates/panel/index.njk
@@ -28,8 +28,9 @@
 {% endset %}
 
 
-
 {% block content %}
+
+<h2> Default Example </h2>
 
 <p class="fd-has-type-2">NOTE: This is a <code>layout</code> component</p>
     <!-- output the component example and the code snippet -->
@@ -39,5 +40,52 @@
 
     {{ format(example) }}
 
+<br/><br/>
+
+<h2> Example with H2 </h2>
+{% set example %}
+    {% call panel() -%}
+        {% call panel_header({ title: ".fd-panel__title", description: ".fd-panel__description", title_size: "h2" }) -%}
+        {%- endcall %}
+    {%- endcall %}
+{% endset %}
+
+{{ format(example) }}
+
+<br/><br/>
+
+<h2> Example with H4 </h2>
+{% set example %}
+    {% call panel() -%}
+        {% call panel_header({ title: ".fd-panel__title", description: ".fd-panel__description", title_size: "h4" }) -%}
+        {%- endcall %}
+    {%- endcall %}
+{% endset %}
+
+{{ format(example) }}
+
+<br/><br/>
+
+<h2> Example with H5 </h2>
+{% set example %}
+    {% call panel() -%}
+        {% call panel_header({ title: ".fd-panel__title", description: ".fd-panel__description", title_size: "h5" }) -%}
+        {%- endcall %}
+    {%- endcall %}
+{% endset %}
+
+{{ format(example) }}
+
+<br/><br/>
+
+<h2> Example with H6 </h2>
+{% set example %}
+    {% call panel() -%}
+        {% call panel_header({ title: ".fd-panel__title", description: ".fd-panel__description", title_size: "h6" }) -%}
+        {%- endcall %}
+    {%- endcall %}
+{% endset %}
+
+{{ format(example) }}
 
 {% endblock %}

--- a/test/templates/product-tile/component.njk
+++ b/test/templates/product-tile/component.njk
@@ -13,7 +13,13 @@ product_tile:
 
 {%- macro product_tile_content(properties={}, modifier=[], aria={}, classes=[]) %}
 <div class="fd-product-tile__content">
-  <h2 class="fd-product-tile__title">{{ properties.title }}</h2>
+  {%- if properties.title_size %}
+    {%- set title_size = properties.title_size %}
+    <{{title_size}} class="fd-product-tile__title">{{ properties.title }}
+    </{{title_size}}>
+  {%- else %}
+    <h3 class="fd-product-tile__title">{{ properties.title }}</h3>
+  {%- endif %}
   {%- if properties.description %}
   <p>{{ properties.description }}</p>
   {%- endif %}

--- a/test/templates/product-tile/component.njk
+++ b/test/templates/product-tile/component.njk
@@ -13,13 +13,8 @@ product_tile:
 
 {%- macro product_tile_content(properties={}, modifier=[], aria={}, classes=[]) %}
 <div class="fd-product-tile__content">
-  {%- if properties.title_size %}
-    {%- set title_size = properties.title_size %}
-    <{{title_size}} class="fd-product-tile__title">{{ properties.title }}
-    </{{title_size}}>
-  {%- else %}
-    <h3 class="fd-product-tile__title">{{ properties.title }}</h3>
-  {%- endif %}
+    {% set title_size = properties.title_size  if properties.title_size  else "h3" %}
+    <{{title_size}} class="fd-product-tile__title">{{ properties.title }}</{{title_size}}>
   {%- if properties.description %}
   <p>{{ properties.description }}</p>
   {%- endif %}

--- a/test/templates/product-tile/index.njk
+++ b/test/templates/product-tile/index.njk
@@ -72,6 +72,64 @@
       {% endset %}
         {{ format(example) }}
 
+<br><br>
 
+<h2> Example with H2 </h2>
+
+{%- set example %}
+  {%- call product_tile() -%}
+    {% call product_tile_media(data.properties.image) -%}
+    {%- endcall %}
+    {%- call product_tile_content({ title: data.properties.title, title_size: "h2" }) -%}
+    {%- endcall %}
+  {%- endcall %}
+{% endset %}
+
+{{ format(example) }}
+
+<br><br>
+
+<h2> Example with H4 </h2>
+
+{%- set example %}
+  {%- call product_tile() -%}
+    {% call product_tile_media(data.properties.image) -%}
+    {%- endcall %}
+    {%- call product_tile_content({ title: data.properties.title, title_size: "h4" }) -%}
+    {%- endcall %}
+  {%- endcall %}
+{% endset %}
+
+{{ format(example) }}
+
+<br><br>
+
+<h2> Example with H5 </h2>
+
+{%- set example %}
+  {%- call product_tile() -%}
+    {% call product_tile_media(data.properties.image) -%}
+    {%- endcall %}
+    {%- call product_tile_content({ title: data.properties.title, title_size: "h5" }) -%}
+    {%- endcall %}
+  {%- endcall %}
+{% endset %}
+
+<br><br>
+
+<h2> Example with H6 </h2>
+
+{%- set example %}
+  {%- call product_tile() -%}
+    {% call product_tile_media(data.properties.image) -%}
+    {%- endcall %}
+    {%- call product_tile_content({ title: data.properties.title, title_size: "h6" }) -%}
+    {%- endcall %}
+  {%- endcall %}
+{% endset %}
+
+{{ format(example) }}
+
+{{ format(example) }}
 
 {% endblock %}

--- a/test/templates/product-tile/index.njk
+++ b/test/templates/product-tile/index.njk
@@ -115,6 +115,8 @@
   {%- endcall %}
 {% endset %}
 
+{{ format(example) }}
+
 <br><br>
 
 <h2> Example with H6 </h2>

--- a/test/templates/side-nav/component.njk
+++ b/test/templates/side-nav/component.njk
@@ -75,12 +75,8 @@ nav.fd-side-nav
 {%- for navgroup in properties -%}
 <div class="fd-side-nav__group">
   {%- if navgroup.title %}
-    {%- if navgroup.title_size %}
-    {%- set title_size = navgroup.title_size %}
-        <{{title_size}} class="fd-side-nav__title"> {{ navgroup.title }} </{{title_size}}>
-    {%- else %}
-        <h3 class="fd-side-nav__title">{{ navgroup.title }}</h3>
-    {%- endif %}
+  {% set title_size = navgroup.title_size  if navgroup.title_size  else "h3" %}
+    <{{title_size}} class="fd-side-nav__title">{{ navgroup.title }}</{{title_size}}>
   {%- endif %}
     {{ navlist(navgroup.items) }}
 </div>

--- a/test/templates/side-nav/component.njk
+++ b/test/templates/side-nav/component.njk
@@ -75,12 +75,12 @@ nav.fd-side-nav
 {%- for navgroup in properties -%}
 <div class="fd-side-nav__group">
   {%- if navgroup.title %}
-  {%- if navgroup.title_size %}
-  {%- set title_size = navgroup.title_size %}
-    <{{title_size}} class="fd-side-nav__title"> {{ navgroup.title }} </{{title_size}}>
-  {%- else %}
-    <h3 class="fd-side-nav__title">{{ navgroup.title }}</h3>
-  {%- endif %}
+    {%- if navgroup.title_size %}
+    {%- set title_size = navgroup.title_size %}
+        <{{title_size}} class="fd-side-nav__title"> {{ navgroup.title }} </{{title_size}}>
+    {%- else %}
+        <h3 class="fd-side-nav__title">{{ navgroup.title }}</h3>
+    {%- endif %}
   {%- endif %}
     {{ navlist(navgroup.items) }}
 </div>

--- a/test/templates/side-nav/component.njk
+++ b/test/templates/side-nav/component.njk
@@ -75,7 +75,12 @@ nav.fd-side-nav
 {%- for navgroup in properties -%}
 <div class="fd-side-nav__group">
   {%- if navgroup.title %}
-  <h1 class="fd-side-nav__title">{{ navgroup.title }}</h1>
+  {%- if navgroup.title_size %}
+  {%- set title_size = navgroup.title_size %}
+    <{{title_size}} class="fd-side-nav__title"> {{ navgroup.title }} </{{title_size}}>
+  {%- else %}
+    <h3 class="fd-side-nav__title">{{ navgroup.title }}</h3>
+  {%- endif %}
   {%- endif %}
     {{ navlist(navgroup.items) }}
 </div>

--- a/test/templates/side-nav/index.njk
+++ b/test/templates/side-nav/index.njk
@@ -77,6 +77,173 @@
     {% endset %}
     {{ format(example) }}
 
+     <br><br><br>
+<h2>w/ H2 group headings</h2>
+    {% set example %}
+    {{ side_nav(
+        properties = {
+          "title": "Group Title",
+          "navgroups": [
+            {
+              "title": "Group Name",
+              "title_size": "h2",
+              "items": [
+                { "label": "icon link"},
+                {
+                    "label": "item link",
+                    "haschild": true
+                 },
+                { "label": "icon link"},
+                { "label": "item link" },
+                { "label": "item link" }
+              ]
+            },
+            {
+                "title": "Group Name",
+                "title_size": "h2",
+                "items": [
+                  { "label": "item link" },
+                  {
+                      "label": "item link",
+                      "haschild": true
+                   },
+                  { "label": "item link" },
+                  { "label": "item link" },
+                  { "label": "item link" }
+              ]
+            }
+          ]
+        }
+    )}}
+    {% endset %}
+    {{ format(example) }}
+
+    <br><br><br>
+
+<h2>w/ H4 group headings</h2>
+    {% set example %}
+    {{ side_nav(
+        properties = {
+          "title": "Group Title",
+          "navgroups": [
+            {
+              "title": "Group Name",
+              "title_size": "h4",
+              "items": [
+                { "label": "icon link"},
+                {
+                    "label": "item link",
+                    "haschild": true
+                 },
+                { "label": "icon link"},
+                { "label": "item link" },
+                { "label": "item link" }
+              ]
+            },
+            {
+                "title": "Group Name",
+                "title_size": "h4",
+                "items": [
+                  { "label": "item link" },
+                  {
+                      "label": "item link",
+                      "haschild": true
+                   },
+                  { "label": "item link" },
+                  { "label": "item link" },
+                  { "label": "item link" }
+              ]
+            }
+          ]
+        }
+    )}}
+    {% endset %}
+    {{ format(example) }}
+
+    <br><br><br>
+
+<h2>w/ H5 group headings</h2>
+    {% set example %}
+    {{ side_nav(
+        properties = {
+          "title": "Group Title",
+          "navgroups": [
+            {
+              "title": "Group Name",
+              "title_size": "h5",
+              "items": [
+                { "label": "icon link"},
+                {
+                    "label": "item link",
+                    "haschild": true
+                 },
+                { "label": "icon link"},
+                { "label": "item link" },
+                { "label": "item link" }
+              ]
+            },
+            {
+                "title": "Group Name",
+                "title_size": "h5",
+                "items": [
+                  { "label": "item link" },
+                  {
+                      "label": "item link",
+                      "haschild": true
+                   },
+                  { "label": "item link" },
+                  { "label": "item link" },
+                  { "label": "item link" }
+              ]
+            }
+          ]
+        }
+    )}}
+    {% endset %}
+    {{ format(example) }}
+
+        <br><br><br>
+
+<h2>w/ H6 group headings</h2>
+    {% set example %}
+    {{ side_nav(
+        properties = {
+          "title": "Group Title",
+          "navgroups": [
+            {
+              "title": "Group Name",
+              "title_size": "h6",
+              "items": [
+                { "label": "icon link"},
+                {
+                    "label": "item link",
+                    "haschild": true
+                 },
+                { "label": "icon link"},
+                { "label": "item link" },
+                { "label": "item link" }
+              ]
+            },
+            {
+                "title": "Group Name",
+                "title_size": "h6",
+                "items": [
+                  { "label": "item link" },
+                  {
+                      "label": "item link",
+                      "haschild": true
+                   },
+                  { "label": "item link" },
+                  { "label": "item link" },
+                  { "label": "item link" }
+              ]
+            }
+          ]
+        }
+    )}}
+    {% endset %}
+    {{ format(example) }}
+
     <br><br><br>
 
     <h2>w/ sublink</h2>

--- a/test/templates/spinner/index.njk
+++ b/test/templates/spinner/index.njk
@@ -36,7 +36,7 @@
         ) | indent(4)
     }}
     <div class="fd-panel__header">
-        <h1 class="fd-panel__title">Lorem ipsum</h1>
+        <h3 class="fd-panel__title">Lorem ipsum</h3>
     </div>
     <!-- Loaded content goes here -->
     <div class="fd-panel__footer">

--- a/test/templates/table/index.njk
+++ b/test/templates/table/index.njk
@@ -200,7 +200,7 @@
 
 <br><br><br>
 
-<h3>Asc Sort Colum Example</h3>
+<h3>Asc Sort Column Example</h3>
 
 {% set example %}
 {{  table({

--- a/test/templates/tile/component.njk
+++ b/test/templates/tile/component.njk
@@ -14,8 +14,15 @@ tile:
 {%- macro tile_content(properties={}, modifier=[], aria={}, classes=[]) %}
 <div class="fd-tile__content">
   {%- if properties.title %}
-  <h2 class="fd-tile__title">{{ properties.title }}</h2>    
+    {%- if properties.title_size %}
+        {%- set title_size = properties.title_size %}
+        <{{title_size}} class="fd-tile__title">{{ properties.title }}
+        </{{title_size}}>
+    {%- else %}
+        <h3 class="fd-tile__title">{{ properties.title }}</h3>
+    {%- endif %}
   {%- endif %}
+
   {%- if properties.description %}
   <p>{{ properties.description }}</p>
   {%- endif %}

--- a/test/templates/tile/component.njk
+++ b/test/templates/tile/component.njk
@@ -14,13 +14,8 @@ tile:
 {%- macro tile_content(properties={}, modifier=[], aria={}, classes=[]) %}
 <div class="fd-tile__content">
   {%- if properties.title %}
-    {%- if properties.title_size %}
-        {%- set title_size = properties.title_size %}
-        <{{title_size}} class="fd-tile__title">{{ properties.title }}
-        </{{title_size}}>
-    {%- else %}
-        <h3 class="fd-tile__title">{{ properties.title }}</h3>
-    {%- endif %}
+    {% set title_size = properties.title_size  if properties.title_size  else "h3" %}
+    <{{title_size}} class="fd-tile__title">{{ properties.title }}</{{title_size}}>
   {%- endif %}
 
   {%- if properties.description %}

--- a/test/templates/tile/index.njk
+++ b/test/templates/tile/index.njk
@@ -172,10 +172,56 @@
 {% endset %}
     {{ format(example) }}
 
-    <br><br>
+<br><br>
 
+<h2> Example with H2 </h2>
 
+{%- set example %}
+  {% call tile() -%}
+    {% call tile_content({ title: data.properties.title, title_size: "h2" }) -%}
+    {%- endcall %}
+  {%- endcall %}
+{% endset %}
 
+{{ format(example) }}
 
+<br><br>
+
+<h2> Example with H4 </h2>
+
+{%- set example %}
+  {% call tile() -%}
+    {% call tile_content({ title: data.properties.title, title_size: "h4" }) -%}
+    {%- endcall %}
+  {%- endcall %}
+{% endset %}
+
+{{ format(example) }}
+
+<br><br>
+
+<h2> Example with H5 </h2>
+
+{%- set example %}
+  {% call tile() -%}
+    {% call tile_content({ title: data.properties.title, title_size: "h5" }) -%}
+    {%- endcall %}
+  {%- endcall %}
+{% endset %}
+
+{{ format(example) }}
+
+<br><br>
+
+<h2> Example with H6 </h2>
+
+{%- set example %}
+  {% call tile() -%}
+    {% call tile_content({ title: data.properties.title, title_size: "h6" }) -%}
+    {%- endcall %}
+  {%- endcall %}
+{% endset %}
+
+{{ format(example) }}
 
 {% endblock %}


### PR DESCRIPTION
Closes sap/fundamental#1178

Formerly, these components were using an `<h1>`  tag which is not accessible as there should not be more than one `<h1>` tag on the page. The default has been changed so that these components use an `<h3>` tag instead.

#### Test

<img width="1322" alt="Screen Shot 2019-04-01 at 3 14 54 PM" src="https://user-images.githubusercontent.com/31866543/55363145-fc835500-5490-11e9-8f78-ec3546026241.png">

#### Changelog

**Changed**

* `<h3>` is now default. `<h2>` - `<h6>` is supported.
