### PR TITLE
fix: update readme so that docs site works out of the box

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ npm install fiori-fundamentals --save
 
 1. **Install NPM Dependencies**: `npm install`
 
-1. **Install Ruby Gems** - These gems are needed to be installed for the documentation site: `gem install ruby bundle jekyll`
+1. **Install Ruby Gems** - These gems are needed to be installed for the documentation site. Navigate to the `docs` folder and `gem install ruby bundle jekyll`
 
 1. **Serve the documentation website locally** - `npm start`
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "release:create": "create-release",
     "release": "./scripts/publish-release.sh",
     "start:playground": "npm run build && node test/app.js",
-    "start": "npx gulp default",
+    "start": "npm run docs && npx gulp default",
     "std-version": "standard-version -m \"chore(release): version %s build ${TRAVIS_BUILD_NUMBER} [ci skip]\"",
     "test:update": "npx gulp test:reference && npx gulp test:approve",
     "test": "npx gulp test:visual"


### PR DESCRIPTION


Update to readme and start script to allow new users to start the docs site without further steps needed.
