### PR TITLE
fix: Small refactor for TimePicker using popper

### DIFF
--- a/scss/components/time-picker.scss
+++ b/scss/components/time-picker.scss
@@ -11,8 +11,15 @@ $block: #{$fd-namespace}-time-picker;
 
 .#{$block} {
     .#{$fd-namespace}-popover {
-        &__body,
-        &__popper {
+        &__body {
+            padding: fd-space(s);
+        }
+    }
+}
+
+.#{$fd-namespace}-popover {
+    &__popper {
+        .#{$fd-namespace}-time {
             padding: fd-space(s);
         }
     }


### PR DESCRIPTION
The styling for the `TimePicker` overlay was missing padding because popper.js places the markup in a different DOM node so the styles needed to be adjusted.

#### Changelog

**Changed**

* Altered the selector for adding padding in the popover for `TimePicker`