### PR TITLE
chore: Release notes

### DIFF
--- a/ci-scripts/publish.sh
+++ b/ci-scripts/publish.sh
@@ -15,12 +15,13 @@ echo "$std_ver"
 
 git push --follow-tags "https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG" master > /dev/null 2>&1;
 
-npm run release:create -- --repo $TRAVIS_REPO_SLUG --tag $release_tag --branch master
-
-#build dist folder
+# build dist folder
 npm run build:prod
 
 npm publish
+
+# run this after publish to make sure GitHub finishes updating from the push
+npm run release:create -- --repo $TRAVIS_REPO_SLUG --tag $release_tag --branch master
 
 npm run docs:prod
 npm run deploy -- --repo "https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6033,9 +6033,9 @@
       }
     },
     "github-assistant": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/github-assistant/-/github-assistant-0.2.0.tgz",
-      "integrity": "sha512-h33eREnaFNxdeLwQQA9zQH82UaPzPQqJsrGhGdMH4Z5FeSWpqXhp7o74saf6flt69ScFWcXAqzPuoQmbG0Jq3A==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/github-assistant/-/github-assistant-0.3.0.tgz",
+      "integrity": "sha512-xvt3aRVBYIsu37cUA/xNBHZJWka84e74jG601M3b5Ws2lvj3ddtoep73QqLafMNHElmY6MyxnEOj8WAKJcASTg==",
       "dev": true,
       "requires": {
         "github-api": "^3.0.0",
@@ -6050,9 +6050,9 @@
           "dev": true
         },
         "camelcase": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
-          "integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
           "dev": true
         },
         "cliui": {
@@ -6173,9 +6173,9 @@
           }
         },
         "p-try": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
           "dev": true
         },
         "path-exists": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "del": "^3.0.0",
     "express": "^4.16.4",
     "gh-pages": "^2.0.1",
-    "github-assistant": "^0.2.0",
+    "github-assistant": "^0.3.0",
     "glob": "^7.1.3",
     "gulp-autoprefixer": "^6.0.0",
     "gulp-clean-css": "^3.10.0",


### PR DESCRIPTION
It was found that the calls to GitHub API to build the release notes _could_ happen prior to the commits being pushed (or updated within GitHub).  To help ensure this works, I have moved the create release call below publish.

Also, updated to a new version of `github-assistant` that will include a "Documentation" section in the release notes.

#### Example
![Screen Shot 2019-04-05 at 2 08 57 PM](https://user-images.githubusercontent.com/11407353/55651177-619abb80-57ad-11e9-9fc4-170024b16ccd.png)
