### PR TITLE
fix: remove typo from shellbar

### DIFF
--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -4,7 +4,7 @@
 plugins: stylelint-scss
 rules:
   # Possible errors
-
+  property-no-unknown: true
   ## Color
   color-no-invalid-hex: true
   

--- a/scss/components/shellbar.scss
+++ b/scss/components/shellbar.scss
@@ -158,7 +158,7 @@ $block: #{$fd-namespace}-shellbar;
         display: inline-block;
         vertical-align: middle;
         width: $fd-shellbar-copilot-width;
-        «»height: $fd-shellbar-copilot-height;
+        height: $fd-shellbar-copilot-height;
         > img {
             display: block;
             max-width: 100%;

--- a/scss/mixins/_mixins.scss
+++ b/scss/mixins/_mixins.scss
@@ -140,7 +140,7 @@
   display: inline-block;
   margin: 0;
   padding: 0;
-  font-smoothing: antialiased;
+  font-smoothing: antialiased; /* stylelint-disable-line property-no-unknown */
   appearance: none;
   outline: 0;
   border: 0;


### PR DESCRIPTION
`shellbar.scss` had a small typo on line 161. Visually verified that everything looks fine on the shellbar playground pages. 
