### PR TITLE
Fix: Increased focus ring for chevron button on tree component

### DIFF
--- a/scss/components/tree.scss
+++ b/scss/components/tree.scss
@@ -26,6 +26,7 @@ $block: #{$fd-namespace}-tree;
     $fd-tree-row-background-color--hover: fd-color-state("hover") !default;
 
     $fd-tree-control-width: 18px !default;
+    $fd-tree-control-button-width-height: 34px !default;
     $fd-tree-control-margin-right: fd-space(2) !default;
     $fd-tree-transition-params: $fd-animation--speed ease-in !default;
 
@@ -149,9 +150,9 @@ $block: #{$fd-namespace}-tree;
         @include fd-button-reset();
         position: absolute;
         top: calc(50% - #{$fd-tree-control-width}/2);
-        margin-left: -#{$_row_padding};
-        margin-right: fd-space(3);
-        width: $fd-tree-control-width;
+        margin: -8px fd-space(3) 0 -36px;
+        width: $fd-tree-control-button-width-height;
+        height: $fd-tree-control-button-width-height;
         transform: rotate(180deg);
         vertical-align: middle;
         transition: transform $fd-animation--speed linear;


### PR DESCRIPTION
Closes sap/fundamental#1277

Increases focus area by changing margin, width, and height for chevron button.

*Of note: The size of focus area now matches the dimensions of the ellipsis button on the right.

*Before:*
![image](https://user-images.githubusercontent.com/34703079/55765280-d5de9480-5a23-11e9-97b6-93875d7c66d5.png)

*After:*
![image](https://user-images.githubusercontent.com/34703079/55765334-06263300-5a24-11e9-9497-7cf932878f43.png)


