### PR TITLE
fix: remove anchor modifier

### DIFF
--- a/scss/components/button.scss
+++ b/scss/components/button.scss
@@ -18,7 +18,7 @@ a.#{$block} {
   //BASE
   //set all reset and baseline block styles
   @at-root {
-    .#{$block}, [class*="#{$block}--"], a.#{$block}, a[class*="#{$block}--"] {
+    .#{$block}, [class*="#{$block}--"], a[class*="#{$block}--"] {
       $fd-button-color: fd-color("action", 1);
       $fd-button-border-color: fd-color("action", 1);
       $fd-button-background-color: fd-color("background", 2);


### PR DESCRIPTION
Reverts a small change from https://github.com/SAP/fundamental/pull/1383

The `a.#{$block},` modifier was disallowing consumer overrides for styling on the button component when used as an anchor.
BEFORE:
<img width="1380" alt="screen_shot_2019-04-12_at_10 02 04_am" src="https://user-images.githubusercontent.com/29607818/56062588-bbf1ca00-5d21-11e9-9a57-aaa8b59887ee.png">

AFTER:
<img width="1451" alt="Screen Shot 2019-04-12 at 12 52 33 PM" src="https://user-images.githubusercontent.com/29607818/56062629-e0e63d00-5d21-11e9-9ae9-37f1f6c7c40a.png">


I know this changed stemmed from https://github.com/SAP/fundamental/issues/1252, but the playground page for this still looks correct to me as long as we keep `a[class*="#{$block}--"]` : 
<img width="1458" alt="Screen Shot 2019-04-12 at 12 54 15 PM" src="https://user-images.githubusercontent.com/29607818/56062707-2a368c80-5d22-11e9-8436-011c2d78266a.png">

