### PR TITLE
fix: Changed popper attributes to match default popper.js

### DIFF
--- a/scss/components/popover.scss
+++ b/scss/components/popover.scss
@@ -179,11 +179,11 @@ $block: #{$fd-namespace}-popover;
             }
         }
 
-        &[data-x-out-of-boundaries] {
+        &[x-out-of-boundaries] {
             display: none;
         }
 
-        &[data-placement^="top"] {
+        &[x-placement^="top"] {
             margin-bottom: $fd-popover-arrow-height;
 
             .fd-popover__arrow {
@@ -201,7 +201,7 @@ $block: #{$fd-namespace}-popover;
             }
         }
 
-        &[data-placement^="bottom"] {
+        &[x-placement^="bottom"] {
             margin-top: $fd-popover-arrow-height;
 
             .fd-popover__arrow {
@@ -219,7 +219,7 @@ $block: #{$fd-namespace}-popover;
             }
         }
 
-        &[data-placement^="left"] {
+        &[x-placement^="left"] {
             margin-right: $fd-popover-arrow-height;
 
             .fd-popover__arrow {
@@ -237,7 +237,7 @@ $block: #{$fd-namespace}-popover;
             }
         }
 
-        &[data-placement^="right"] {
+        &[x-placement^="right"] {
             margin-left: $fd-popover-arrow-height;
 
             .fd-popover__arrow {

--- a/test/templates/popover/component.njk
+++ b/test/templates/popover/component.njk
@@ -32,7 +32,7 @@ popover:
 {%- endmacro -%}
 
 {%- macro popover_popper(properties={}, modifier={}, state={}, aria={ hidden: true }) -%}
-<div class="fd-popover__popper{{ modifier.block | modifier('popover__popper') }}" {{ aria | aria }} id="{{ properties.id }}" data-placement="bottom">
+<div class="fd-popover__popper{{ modifier.block | modifier('popover__popper') }}" {{ aria | aria }} id="{{ properties.id }}" x-placement="bottom">
   {{properties.body}}
   <div class="fd-popover__arrow"></div>
 </div>


### PR DESCRIPTION
If using the default popper.js library, the attributes that get output are `x-placement` and `x-out-of-boundaries` so we are changing the styles to match that.  The react and vue libraries will need to make small changes, but this change needs to occur first.

Although this is _technically_ a breaking change, the only consumers of these styles are the three functional libraries (ngx, react and vue). `fundamental-ngx` hasn't implemented yet so there is no change needed.  `fundamental-react` and `fundamental-vue` have agreed to make their small changes once this is released.

#### Changelog

**Changed**

* Changed popover popper attributes