### PR TITLE
fix: Update token component to match GD v1.05

### DIFF
--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -179,7 +179,7 @@ $fd-colors-background-states: map-merge((
   "positive": map-get($fd-colors-background, 3),
   "negative": map-get($fd-colors-background, 5),
   "alert": map-get($fd-colors-background, 4),
-  "information": map-get($fd-colors-background, 6),
+  "information": map-get($fd-colors-neutral, 1),
 ), $fd-colors-background-states);
 
 //————————^ FIORI FUNDAMENTALS FOUNDATION ————————^

--- a/scss/components/token.scss
+++ b/scss/components/token.scss
@@ -13,12 +13,12 @@ $block: #{$fd-namespace}-token;
 
 .#{$block} {
     //LOCAL VARS (set all themeable properties, always include !default)
-    $fd-token-border-color: transparent !default;
+    $fd-token-border-color: fd-color("neutral", 3) !default;
     $fd-token-color: fd-color("text", 2) !default;
     $fd-token-background-color: fd-color-state("information") !default;
     --fd-token-color: var(--fd-color-text-2);
     --fd-token-background-color: var(--fd-color-background-information);
-    --fd-token-border-color: transparent;
+    --fd-token-border-color: var(--fd-color-neutral-3);
 
     @include fd-reset();
     @include fd-type("-1");
@@ -34,16 +34,16 @@ $block: #{$fd-namespace}-token;
     border-style: solid;
     @include fd-var-color("border-color", $fd-token-border-color, --fd-token-border-color);
     cursor: pointer;
-    @include fd-icon("sys-cancel", "s", "after") {
+    @include fd-icon("decline", "s", "after") {
         @include fd-var-color("color", fd-color("action", 1), --fd-color-action-1);
-        margin-left: fd-space(base);
+        margin-left: fd-space(tiny);
         vertical-align: bottom;
         line-height: fd-space(6);
     }
     @include fd-rtl() {
-        @include fd-icon("sys-cancel", "s", "before") {
+        @include fd-icon("decline", "s", "before") {
             @include fd-var-color("color", fd-color("action", 1), --fd-color-action-1);
-            margin-left: fd-space(base);
+            margin-left: fd-space(tiny);
             vertical-align: bottom;
             line-height: fd-space(6);
         }
@@ -51,7 +51,7 @@ $block: #{$fd-namespace}-token;
         &::before {
             display: inline;
             margin-left: 0;
-            margin-right: fd-space(base);
+            margin-right: fd-space(tiny);
         }
         &::after {
             content: none;

--- a/test/templates/token/data.json
+++ b/test/templates/token/data.json
@@ -3,7 +3,7 @@
     "name": "Token",
     "css_vars": true,
     "rtl": true,
-    "version": "1.0.0",
+    "version": "1.0.5",
     "properties": {
         "label": "Filter"
     },


### PR DESCRIPTION
Closes sap/fundamental#952

Updated token component to match GD v1.05

before:
![Screen Shot 2019-04-19 at 9 54 33 AM](https://user-images.githubusercontent.com/15215400/56429614-2f975800-6289-11e9-9a5b-a07a2dcdb588.png)

after: 
![Screen Shot 2019-04-19 at 9 53 22 AM](https://user-images.githubusercontent.com/15215400/56429587-142c4d00-6289-11e9-95bc-578c0c51551a.png)



#### Test
* http://localhost:3030/token
* http://localhost:4000/components/token.html


#### Changelog

**New**

nothing

**Changed**

* updated bg color to `neutral 1`
* updated border color from `transparent` to `neutral 3`
* change close icon from `sys-cancel` to `decline`

**Removed**

nothing
