### PR TITLE
fix: update token to latest design 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="1.5.6-rc.0"></a>
+## [1.5.6-rc.0](https://github.com/SAP/fundamental/compare/v1.5.5...v1.5.6-rc.0) (2019-04-19)
+
+
+
 <a name="1.5.5"></a>
 ## [1.5.5](https://github.com/SAP/fundamental/compare/v1.5.5-rc.1...v1.5.5) (2019-04-18)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fiori-fundamentals",
-  "version": "1.5.5",
+  "version": "1.5.6-rc.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fiori-fundamentals",
-  "version": "1.5.5",
+  "version": "1.5.6-rc.0",
   "description": "Fiori Fundamentals is a Design System and HTML/CSS Component Library used to build modern Product User Experiences with the SAP look and feel. Learn more about this project at - http://sap.github.io/fundamental/",
   "main": "index.js",
   "scripts": {

--- a/scss/core/_forms.scss
+++ b/scss/core/_forms.scss
@@ -211,7 +211,7 @@ input[type="radio"],
 .#{$fd-namespace}-radio {
     border-radius: 50%;
     &::after {
-        $check-size_: fd-space(2);
+        $check-size_: 10px;
         content: "";
         border-radius: 50%;
         width: $check-size_;


### PR DESCRIPTION
Closes sap/fundamental#952

Updated token component to match the latest designs 

before:
![Screen Shot 2019-04-19 at 9 54 33 AM](https://user-images.githubusercontent.com/15215400/56429614-2f975800-6289-11e9-9a5b-a07a2dcdb588.png)

after: 
![Screen Shot 2019-04-19 at 9 53 22 AM](https://user-images.githubusercontent.com/15215400/56429587-142c4d00-6289-11e9-95bc-578c0c51551a.png)



#### Test
* http://localhost:3030/token
* http://localhost:4000/components/token.html


#### Changelog

**New**

nothing

**Changed**

* updated bg color to `neutral 1`
* updated border color from `transparent` to `neutral 3`
* change close icon from `sys-cancel` to `decline`

**Removed**

nothing
