### PR TITLE
fix: update broken links in alert and modal

### DIFF
--- a/docs/pages/components/alert.md
+++ b/docs/pages/components/alert.md
@@ -11,7 +11,7 @@ summary:
 
 Alerts provide messages within the application that are color-coded to emphasize the level of urgency.
 {: .docs-intro}
-For Alert placement guidelines within the application, see [Application Layout page]({{site.baseurl}}/layouts/application-layout.html#application-with-ui-overlay) and [Application Alerts overlay Demo Page]({{site.baseurl}}/demo-pages/alert-overlay-demo-page.html)
+For Alert placement guidelines within the application, see [Application Layout page]({{site.baseurl}}/layouts/shell-layout.html#application-with-ui-overlay) and [Application Alerts overlay Demo Page]({{site.baseurl}}/demo-pages/alert-overlay-demo-page.html)
 
 <br>
 

--- a/docs/pages/components/modal.md
+++ b/docs/pages/components/modal.md
@@ -11,7 +11,7 @@ summary:
 
 The modal is a container generally displayed in response to an action.
 {: .docs-intro}
-It is used for short forms, confirmation messages or to display contextual information that does not require a page. The modal should always be used in conjunction with the [Application Layout Containers]({{site.baseurl}}/layouts/application-layout.html#application-with-ui-overlay). See an example [App layout page with Modal]({{site.baseurl}}/demo-pages/modal-overlay-demo-page.html)
+It is used for short forms, confirmation messages or to display contextual information that does not require a page. The modal should always be used in conjunction with the [Application Layout Containers]({{site.baseurl}}/layouts/shell-layout.html#application-with-ui-overlay). See an example [App layout page with Modal]({{site.baseurl}}/demo-pages/modal-overlay-demo-page.html)
 
 > {{ site.data.strings.headerDisclaimer }}
 

--- a/docs/pages/components/modal.md
+++ b/docs/pages/components/modal.md
@@ -11,7 +11,7 @@ summary:
 
 The modal is a container generally displayed in response to an action.
 {: .docs-intro}
-It is used for short forms, confirmation messages or to display contextual information that does not require a page. The modal should always be used in conjunction with the [Application Layout Containers](/layouts/application-layout.html#application-with-ui-overlay). See an example [App layout page with Modal](/demo-pages/modal-overlay-demo-page.html)
+It is used for short forms, confirmation messages or to display contextual information that does not require a page. The modal should always be used in conjunction with the [Application Layout Containers]({{site.baseurl}}/layouts/application-layout.html#application-with-ui-overlay). See an example [App layout page with Modal]({{site.baseurl}}/demo-pages/modal-overlay-demo-page.html)
 
 > {{ site.data.strings.headerDisclaimer }}
 


### PR DESCRIPTION
Closes sap/fundamental#1425

Updates links in Alert and Modal to correct link, adds `site.baseUrl` where missing.