### PR TITLE
docs: use ie11 compiled css version for docs site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ test/visual-regression-tests/backstop_data
 # Generated CSS files
 /docs/_site
 /docs/.*
-docs/css/fiori-fundamentals.css
+docs/css/fiori-fundamentals-ie11.css
 test/visual-regression-tests/config/backstopConfigCI.json
 docs/_config-library.yml
 /less/fiori-fundamentals-ie11.less

--- a/docs/css/docs-all.scss
+++ b/docs/css/docs-all.scss
@@ -2,7 +2,7 @@
 # Front matter comment to ensure Jekyll properly reads file.
 ---
 //base component styles - do not import SCSS as the underlying jekyll sass engine does not use LibSass
-@import "./fiori-fundamentals.css";
+@import "./fiori-fundamentals-ie11.css";
 //needed for color variables in docs site
 @import "../../scss/functions/_color.scss";
 @import "../../scss/_settings.scss";

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "npm run style:remove && npm run style:compile && npm run style:rename && npm run style:postCSS && npm run style:assets",
     "build:prod": "npm run build && npm run style:minify && npm run style:less",
     "deploy": "gh-pages -d docs/_site",
-    "docs:compile": "npm run build && npm run docs:config && cp scss/icons/SAP-icons.woff docs/css/; cp dist/fiori-fundamentals.css docs/css",
+    "docs:compile": "npm run build && npm run docs:config && cp scss/icons/SAP-icons.woff docs/css/; cp dist/fiori-fundamentals-ie11.css docs/css",
     "docs:config": "./scripts/create-library-config.js",
     "docs:prod": "npm run docs:compile && cd docs && bundle install && bundle exec jekyll build --config _config.yml,_config-library.yml,_config-prod.yml && cd ..",
     "docs": "npm run docs:compile && cd docs && bundle install && bundle exec jekyll build --config _config.yml,_config-library.yml && cd ..",


### PR DESCRIPTION
Switch the docs site to use `fiori-fundamentals-ie11.css` as it's base. 

This provides some basic capabilities to see the docs site in ie11. More work will need to be done to be fully compatible, see [wiki spike](https://github.com/SAP/fundamental/wiki/SPIKE:-IE11-handling), but this is a good first step.