### PR TITLE
fix: readme links now point to updated wiki pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This gives you incredible flexibility to use individual components and enable [a
 npm install fiori-fundamentals --save
 ````
 
-> NOTE: We only distribute the [fonts, icons and CSS](https://github.com/SAP/fundamental/tree/master/dist) and [the SASS source](https://github.com/SAP/fundamental/tree/master/scss), not the full project or HTML for specific components. If your project uses LESS, see [LESS compatible Fiori Fundamentals](https://github.com/SAP/fundamental/wiki/LESS-compatible-Fiori-Fundamentals).
+> NOTE: We only distribute the fonts, icons and compiled CSS and [the SASS source](https://github.com/SAP/fundamental/tree/master/scss), not the full project or HTML for specific components. If your project uses LESS, see [LESS compatible Fiori Fundamentals](https://github.com/SAP/fundamental/wiki/LESS-compatible-Fiori-Fundamentals).
 
 
 ## Working with the Project
@@ -79,7 +79,7 @@ If you encounter an issue, you can create a [ticket](https://github.com/SAP/fund
 
 ## Contributing
 
-If you want to contribute, please check the [Contribution Guidelines](https://github.com/SAP/fundamental/wiki/Contribution-Guidelines). Also check the [SCSS Style Guide](https://github.com/SAP/fundamental/wiki/SCSS-Style-Guide), [Visual Testing Guide](https://github.com/SAP/fundamental/wiki/Visual-Testing-(Simple-and-Automated)) and [Icon Overview](https://github.com/SAP/fundamental/wiki/Generating-Icons).
+If you want to contribute, please check the [Contribution Guidelines](https://github.com/SAP/fundamental/wiki/Contribution-Guidelines). Also check the [Development Guidelines](https://github.com/SAP/fundamental/wiki/Development-Guidelines) and [Visual Testing Guide](https://github.com/SAP/fundamental/wiki/Visual-Testing).
 
 
 ## Versioning


### PR DESCRIPTION
Wiki pages were condensed/updated and the links in the readme were not updated.

The icon workflow wiki page has been removed from the readme link, but is still in the wiki. This page needs to be updated with the current workflow, but I'm not sure what that is.