### PR TITLE
table cells should break-word

### DIFF
--- a/scss/components/table.scss
+++ b/scss/components/table.scss
@@ -90,6 +90,9 @@ $block: #{$fd-namespace}-table;
             border-left: none;
             border-right: none;
         }
+        td {
+            word-break: break-word;
+        }
     }
     td,
     th {


### PR DESCRIPTION
Closes sap/fundamental#1445

Long strings in table cells should break-word so they wrap

