### PR TITLE
fix: Bumped standard-version to 4.4.0 to fix issue with the tag prefix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2541,6 +2541,67 @@
         "is-obj": "^1.0.0"
       }
     },
+    "dotgitignore": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dotgitignore/-/dotgitignore-1.0.3.tgz",
+      "integrity": "sha512-eu5XjSstm0WXQsARgo6kPjkINYZlOUW+z/KtAAIBjHa5mUpMPrxJytbPIndWz6GubBuuuH5ljtVcXKnVnH5q8w==",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.1.0",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
+      }
+    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -8693,14 +8754,15 @@
       }
     },
     "standard-version": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-4.2.0.tgz",
-      "integrity": "sha1-MBfoxc7SqS23UBeQJVw7qFFXN10=",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-4.4.0.tgz",
+      "integrity": "sha512-jJ8FZhnmh9xJRQLnaXiGRLaAUNItIH29lOQZGpL5fd4+jUHto9Ij6SPCYN86h6ZNNXkYq2TYiIVVF7gVyC+pcQ==",
       "dev": true,
       "requires": {
         "chalk": "^1.1.3",
         "conventional-changelog": "^1.1.0",
         "conventional-recommended-bump": "^1.0.0",
+        "dotgitignore": "^1.0.3",
         "figures": "^1.5.0",
         "fs-access": "^1.0.0",
         "semver": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "postcss-cli": "^6.1.2",
     "pre-commit": "^1.2.2",
     "signale": "^1.3.0",
-    "standard-version": "4.2.0",
+    "standard-version": "^4.4.0",
     "start-server-and-test": "^1.7.13",
     "stylelint": "^9.10.1",
     "stylelint-scss": "^3.5.4",


### PR DESCRIPTION
The `fundamental` repo has been failing when `github-assistant` is attempting to gather the release notes, whereas other repos are working correctly.  The issue is that tag that the script parses from `standard-version`'s output was missing the tag prefix.  The line highlighted in the screenshot should say "tagging release v1.5.8" -- it was missing the "v" prefix so the `github-assistant` code was actually creating a new tag for the version without the "v" prefix and tying the release to that.

![Screen Shot 2019-05-24 at 1 18 31 PM](https://user-images.githubusercontent.com/11407353/58348685-ef4a6d00-7e26-11e9-86fa-69b55a2b4949.png)

Looking through the change log for `standard-version`, this appears to have been fixed in version 4.4.0 (see https://github.com/conventional-changelog/standard-version/commit/b4ed4f9).