### PR TITLE
fix: search.json not being loaded in prod

### DIFF
--- a/docs/_includes/search-box.html
+++ b/docs/_includes/search-box.html
@@ -5,6 +5,7 @@
 </div>
 
 <script src="https://unpkg.com/simple-jekyll-search@1.7.2/dest/simple-jekyll-search.min.js"></script>
+<script src="{{site.baseurl}}/js/search.json"></script>
 <script type="text/javascript">
     SimpleJekyllSearch({
         searchInput: document.getElementById('search-input'),


### PR DESCRIPTION
Search box not working in prod on documentation site. `search.json` was not being loaded.
