### PR TITLE
chore: remove summary from search json template

### DIFF
--- a/docs/_includes/search-box.html
+++ b/docs/_includes/search-box.html
@@ -16,3 +16,4 @@
         fuzzy: true,
     });
 </script>
+

--- a/docs/js/search.json
+++ b/docs/js/search.json
@@ -12,7 +12,6 @@ layout:
 "tags": "{{ page.tags }}",
 "keywords": "{{page.keywords}}",
 "url": "{{ page.url}}",
-"summary": "{{page.summary | strip }}",
 "folder": "{{page.folder | strip }}"
 }
 {% unless forloop.last and site.posts.size < 1 %},{% endunless %}
@@ -25,8 +24,7 @@ layout:
 "title": "{{ post.title | escape }}",
 "tags": "{{ post.tags }}",
 "keywords": "{{post.keywords}}",
-"url": "{{ post.url | remove: "/" }}",
-"summary": "{{post.summary | strip }}"
+"url": "{{ post.url | remove: "/" }}"
 }
 {% unless forloop.last %},{% endunless %}
 {% endfor %}

--- a/docs/js/search.json
+++ b/docs/js/search.json
@@ -4,29 +4,19 @@ search: exclude
 layout: 
 ---
 
-[
-{% for page in site.pages %}
-{% unless page.search == "exclude" %}
-{
-"title": "{{ page.title | escape }}",
-"tags": "{{ page.tags }}",
-"keywords": "{{page.keywords}}",
-"url": "{{ page.url}}",
-"folder": "{{page.folder | strip }}"
-}
-{% unless forloop.last and site.posts.size < 1 %},{% endunless %}
-{% endunless %}
-{% endfor %}
-
+[{% for page in site.pages %}{% unless page.search == "exclude" %}
+    {
+        "title": "{{ page.title | escape }}",
+        "tags": "{{ page.tags }}",
+        "keywords": "{{page.keywords}}",
+        "url": "{{ page.url}}",
+        "folder": "{{page.folder | strip }}"
+    }{% unless forloop.last and site.posts.size < 1 %},{% endunless %}{% endunless %}{% endfor %}
 {% for post in site.posts %}
-
-{
-"title": "{{ post.title | escape }}",
-"tags": "{{ post.tags }}",
-"keywords": "{{post.keywords}}",
-"url": "{{ post.url | remove: "/" }}"
-}
-{% unless forloop.last %},{% endunless %}
-{% endfor %}
-
-]
+    {
+        "title": "{{ post.title | escape }}",
+        "tags": "{{ post.tags }}",
+        "keywords": "{{post.keywords}}",
+        "url": "{{ post.url | remove: "/" }}"
+    }
+{% unless forloop.last %},{% endunless %}{% endfor %}]


### PR DESCRIPTION
Closes sap/fundamental#1476


Removing the `summary` parameter from `search.json` template. it was rendering invalid JSON on the live documentation. oddly enough, the template works fine locally. There is no way to test and see if this fix will work, unless the PR is merged. 

