### PR TITLE
chore: update standard version and commit message

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "start:playground:scs": "PORT=3031 SELF_CONTAINED=true npm run start:playground:default",
     "start:browser-sync": "browser-sync start --proxy 'localhost:4000' --files 'docs/_site/**/*' --reloadDelay '2000'",
     "start": "npm run docs:compile && cd docs && bundle install && bundle exec jekyll serve --incremental --config _config.yml,_config-library.yml",
-    "std-version": "standard-version -m \"chore(release): version %s build ${TRAVIS_BUILD_NUMBER} [ci skip]\"",
+    "std-version": "standard-version --releaseCommitMessageFormat \"chore(release): version {{currentTag}} build ${TRAVIS_BUILD_NUMBER} [ci skip]\"",
     "style:assets": "./scripts/copy-assets.sh",
     "style:compile": "node-sass -q --output-style expanded --precision 5 scss/ --output dist/",
     "style:less": " mv dist/fundamentals-ie11.less.css less/fiori-fundamentals-ie11.less && mv dist/fundamentals.less.css less/fiori-fundamentals.less && ./scripts/less.js",


### PR DESCRIPTION
update standard version and commit message

### Description
`-m` or `--message` is deprecated https://github.com/conventional-changelog/standard-version/blob/master/command.js#L33

Instead of using `%s` we can use `{{currentTag}}` -- https://github.com/conventional-changelog/standard-version/blob/ae032bfa9268a0a14351b0d78b6deedee7891e3a/test.js#L1244