### PR TITLE
fix: Compilation typo error 

### DIFF
--- a/scss/layout/_mixins.scss
+++ b/scss/layout/_mixins.scss
@@ -12,7 +12,7 @@
 	[aria-hidden=true] {
 		display: none;
 	}
-	@if $direction = horizontal {
+	@if $direction == horizontal {
 	    @include fd-clearfix();
 		margin: 0;
 		li {


### PR DESCRIPTION
There was syntax error causing `dart-sass` fail